### PR TITLE
Implement custom PagerdutyMCPClient with user agent including DIST_NA…

### DIFF
--- a/pagerduty_mcp/__init__.py
+++ b/pagerduty_mcp/__init__.py
@@ -1,0 +1,1 @@
+DIST_NAME = "pagerduty-mcp"

--- a/pagerduty_mcp/client.py
+++ b/pagerduty_mcp/client.py
@@ -2,10 +2,13 @@ import logging
 import os
 from contextvars import ContextVar
 from functools import lru_cache
+from importlib import metadata
 
 import pagerduty
 from dotenv import load_dotenv
 from pydantic import BaseModel
+
+from pagerduty_mcp import DIST_NAME
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -14,6 +17,12 @@ load_dotenv()
 
 API_KEY = os.getenv("PAGERDUTY_USER_API_KEY")
 API_HOST = os.getenv("PAGERDUTY_API_HOST", "https://api.pagerduty.com")
+
+
+class PagerdutyMCPClient(pagerduty.RestApiV2Client):
+    @property
+    def user_agent(self) -> str:
+        return f"{DIST_NAME}/{metadata.version(DIST_NAME)} {super().user_agent}"
 
 
 class ClientConfig(BaseModel):
@@ -32,7 +41,7 @@ def _get_cached_client(api_key: str, api_host: str) -> pagerduty.RestApiV2Client
 
 def create_pd_client(api_key: str, api_host: str | None = None) -> pagerduty.RestApiV2Client:
     """Get the PagerDuty client."""
-    pd_client = pagerduty.RestApiV2Client(api_key)
+    pd_client = PagerdutyMCPClient(api_key)
     if api_host:
         pd_client.url = api_host
 


### PR DESCRIPTION
This pull request introduces a new `PagerdutyMCPClient` class to extend the functionality of the PagerDuty client and updates the `create_pd_client` function to use this new class. It also adds a `DIST_NAME` constant for package metadata and imports the `metadata` module to retrieve the package version dynamically.

### Enhancements to the PagerDuty client:

* Added a new `PagerdutyMCPClient` class in `pagerduty_mcp/client.py` that extends `pagerduty.RestApiV2Client` to customize the `user_agent` property. The `user_agent` now includes the package name and version using the `DIST_NAME` constant and `metadata.version`.

* Updated the `create_pd_client` function in `pagerduty_mcp/client.py` to instantiate the new `PagerdutyMCPClient` class instead of the base `pagerduty.RestApiV2Client`.

### Package metadata:

* Added a `DIST_NAME` constant in `pagerduty_mcp/__init__.py` to store the package name (`"pagerduty-mcp"`).

* Imported the `metadata` module in `pagerduty_mcp/client.py` to retrieve the package version dynamically.…ME version