### PR TITLE
fix: update DIST_NAME in __init__.py to reflect the correct package name

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -17,6 +17,7 @@
 - [ ] Changes have been tested
 - [ ] Changes are documented
 - [ ] Changes generate *no new warnings*
+- [ ] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)
 
 If this is a breaking change 👇
 

--- a/pagerduty_mcp/__init__.py
+++ b/pagerduty_mcp/__init__.py
@@ -1,1 +1,1 @@
-DIST_NAME = "pagerduty-mcp"
+DIST_NAME = "pagerduty-mcp-server"


### PR DESCRIPTION


### Description

This pull request introduces a small change to the `pagerduty_mcp` package's distribution name to fix an issue reported in #15.

**Issue number:** #15 

### Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only

### Checklist

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [ ] Changes are documented
- [x] Changes generate *no new warnings*

If this is a breaking change 👇

- [ ] I have documented the migration process
- [ ] I have implemented necessary warnings (if it can live side by side)

**Disclaimer:** We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.