### PR TITLE
fix: add support for `limit` param in list_users tool

### DIFF
--- a/pagerduty_mcp/tools/users.py
+++ b/pagerduty_mcp/tools/users.py
@@ -12,20 +12,15 @@ def get_user_data() -> User:
     return User.model_validate(response)
 
 
-def list_users(
-    query: str | None = None, teams_ids: list[str] | None = None, limit: int | None = None
-) -> ListResponseModel[User]:
+def list_users(query_model: UserQuery) -> ListResponseModel[User]:
     """List users, optionally filtering by name (query) and team IDs.
 
     Args:
-        query (str, optional): Filter users by name.
-        teams_ids (list[str], optional): Filter users by team IDs.
-        limit (int, optional): Pagination limit.
+        query_model: Optional filtering parameters
 
     Returns:
-        List[User]: List of users matching the criteria.
+        List of users matching the criteria.
     """
-    user_query = UserQuery(query=query, teams_ids=teams_ids, limit=limit)
-    response = get_client().rget("/users", params=user_query.to_params())
+    response = get_client().rget("/users", params=query_model.to_params())
     users = [User(**user) for user in response]
     return ListResponseModel[User](response=users)


### PR DESCRIPTION
### Description

Add support for `limit` parameter in `list_users` tool

Closes #38 

## After the change - tested with GPT 4.1, 5 & Sonnet 4

<img width="783" height="454" alt="Screenshot 2025-09-17 at 5 28 18 PM" src="https://github.com/user-attachments/assets/9f1bae9d-92e6-43a4-85a9-c10a0796a01b" />

<img width="1510" height="759" alt="Screenshot 2025-09-17 at 5 34 14 PM" src="https://github.com/user-attachments/assets/5a02df13-16c3-4369-91c3-bbbbd08ac82d" />


### Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only

### Checklist

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes are documented
- [x] Changes generate *no new warnings*
- [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

If this is a breaking change 👇

- [ ] I have documented the migration process
- [ ] I have implemented necessary warnings (if it can live side by side)

**Disclaimer:** We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.

```bash
make check
Running linting checks...
uv run python -m ruff check .
All checks passed!
Running tests with coverage...
uv run python -m coverage run -m pytest tests/
==================================================== test session starts ====================================================
platform darwin -- Python 3.12.9, pytest-8.4.1, pluggy-1.6.0
rootdir: /Users/jruiz/Workspace/pagerduty/local-mcp-server/pagerduty-mcp-server-issue-38-patch
configfile: pyproject.toml
plugins: anyio-4.9.0
collected 140 items

tests/test_escalation_policies.py ................                                                                    [ 11%]
tests/test_incidents.py ......................                                                                        [ 27%]
tests/test_oncalls.py ................                                                                                [ 38%]
tests/test_schedules.py ......................                                                                        [ 54%]
tests/test_services.py ....................                                                                           [ 68%]
tests/test_teams.py ............................                                                                      [ 88%]
tests/test_users.py ................                                                                                  [100%]

===================================================== warnings summary ======================================================
tests/test_schedules.py::TestScheduleTools::test_create_schedule_override_client_error
tests/test_schedules.py::TestScheduleTools::test_create_schedule_override_success
  /Users/jruiz/Workspace/pagerduty/local-mcp-server/pagerduty-mcp-server-issue-38-patch/.venv/lib/python3.12/site-packages/pydantic/main.py:463: UserWarning: Pydantic serializer warnings:
    PydanticSerializationUnexpectedValue(Expected `datetime` - serialized value may not be as expected [input_value='2024-12-25T00:00:00', input_type=str])
    PydanticSerializationUnexpectedValue(Expected `datetime` - serialized value may not be as expected [input_value='2024-12-26T00:00:00', input_type=str])
    return self.__pydantic_serializer__.to_python(

tests/test_schedules.py::TestScheduleTools::test_create_schedule_override_multiple_overrides
  /Users/jruiz/Workspace/pagerduty/local-mcp-server/pagerduty-mcp-server-issue-38-patch/.venv/lib/python3.12/site-packages/pydantic/main.py:463: UserWarning: Pydantic serializer warnings:
    PydanticSerializationUnexpectedValue(Expected `datetime` - serialized value may not be as expected [input_value='2024-12-25T00:00:00', input_type=str])
    PydanticSerializationUnexpectedValue(Expected `datetime` - serialized value may not be as expected [input_value='2024-12-26T00:00:00', input_type=str])
    PydanticSerializationUnexpectedValue(Expected `datetime` - serialized value may not be as expected [input_value='2024-12-30T00:00:00', input_type=str])
    PydanticSerializationUnexpectedValue(Expected `datetime` - serialized value may not be as expected [input_value='2024-12-31T00:00:00', input_type=str])
    return self.__pydantic_serializer__.to_python(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================== 140 passed, 3 warnings in 1.21s ==============================================

Coverage Report:
uv run python -m coverage report --include="pagerduty_mcp/tools/*" --show-missing
Name                                         Stmts   Miss  Cover   Missing
--------------------------------------------------------------------------
pagerduty_mcp/tools/__init__.py                 10      0   100%
pagerduty_mcp/tools/escalation_policies.py      10      0   100%
pagerduty_mcp/tools/incidents.py                77      0   100%
pagerduty_mcp/tools/oncalls.py                   7      0   100%
pagerduty_mcp/tools/schedules.py                19      0   100%
pagerduty_mcp/tools/services.py                 20      0   100%
pagerduty_mcp/tools/teams.py                    39      0   100%
pagerduty_mcp/tools/users.py                     9      0   100%
--------------------------------------------------------------------------
TOTAL                                          191      0   100%

Detailed Coverage by Module:
================================
uv run python -m coverage report --include="pagerduty_mcp/tools/incidents.py" --show-missing
Name                               Stmts   Miss  Cover   Missing
----------------------------------------------------------------
pagerduty_mcp/tools/incidents.py      77      0   100%
----------------------------------------------------------------
TOTAL                                 77      0   100%
uv run python -m coverage report --include="pagerduty_mcp/tools/users.py" --show-missing
Name                           Stmts   Miss  Cover   Missing
------------------------------------------------------------
pagerduty_mcp/tools/users.py       9      0   100%
------------------------------------------------------------
TOTAL                              9      0   100%
uv run python -m coverage report --include="pagerduty_mcp/tools/services.py" --show-missing
Name                              Stmts   Miss  Cover   Missing
---------------------------------------------------------------
pagerduty_mcp/tools/services.py      20      0   100%
---------------------------------------------------------------
TOTAL                                20      0   100%
uv run python -m coverage report --include="pagerduty_mcp/tools/teams.py" --show-missing
Name                           Stmts   Miss  Cover   Missing
------------------------------------------------------------
pagerduty_mcp/tools/teams.py      39      0   100%
------------------------------------------------------------
TOTAL                             39      0   100%
uv run python -m coverage report --include="pagerduty_mcp/tools/schedules.py" --show-missing
Name                               Stmts   Miss  Cover   Missing
----------------------------------------------------------------
pagerduty_mcp/tools/schedules.py      19      0   100%
----------------------------------------------------------------
TOTAL                                 19      0   100%
uv run python -m coverage report --include="pagerduty_mcp/tools/escalation_policies.py" --show-missing
Name                                         Stmts   Miss  Cover   Missing
--------------------------------------------------------------------------
pagerduty_mcp/tools/escalation_policies.py      10      0   100%
--------------------------------------------------------------------------
TOTAL                                           10      0   100%
uv run python -m coverage report --include="pagerduty_mcp/tools/oncalls.py" --show-missing
Name                             Stmts   Miss  Cover   Missing
--------------------------------------------------------------
pagerduty_mcp/tools/oncalls.py       7      0   100%
--------------------------------------------------------------
TOTAL                                7      0   100%
All checks completed!
```