### PR TITLE
feat: allow escalation policies as responder request targets

### DIFF
--- a/pagerduty_mcp/models/__init__.py
+++ b/pagerduty_mcp/models/__init__.py
@@ -10,6 +10,8 @@ from .incidents import (
     IncidentQuery,
     IncidentResponderRequest,
     IncidentResponderRequestResponse,
+    ResponderRequest,
+    ResponderRequestTarget,
 )
 from .oncalls import Oncall, OncallQuery
 from .references import IncidentReference, ScheduleReference, ServiceReference, TeamReference, UserReference
@@ -41,6 +43,8 @@ __all__ = [
     "MCPContext",
     "Oncall",
     "OncallQuery",
+    "ResponderRequest",
+    "ResponderRequestTarget",
     "Schedule",
     "ScheduleLayer",
     "ScheduleLayerUser",

--- a/pagerduty_mcp/models/incidents.py
+++ b/pagerduty_mcp/models/incidents.py
@@ -178,17 +178,15 @@ class IncidentManageRequest(BaseModel):
 
 
 class ResponderRequest(BaseModel):
-    id: str = Field(description="The ID of the user to request as a responder")
-
-    @computed_field
-    @property
-    def type(self) -> Literal["user_reference"]:
-        return "user_reference"
+    id: str = Field(description="The ID of the user or escalation policy to request as a responder")
+    type: Literal["user_reference", "escalation_policy_reference"] = Field(
+        description="The type of target (either a user or an escalation policy)"
+    )
 
 
 class ResponderRequestTarget(BaseModel):
     responder_request_target: ResponderRequest = Field(
-        description="Array of user IDs to request as responders",
+        description="Array of user or escalation policy IDs to request as responders",
     )
 
 
@@ -198,7 +196,7 @@ class IncidentResponderRequest(BaseModel):
         description="Optional message to include with the responder request",
     )
     responder_request_targets: list[ResponderRequestTarget] = Field(
-        description="Array of user IDs to request as responders",
+        description="Array of user or escalation policy IDs to request as responders",
     )
 
 


### PR DESCRIPTION
### Description

Add capacity to allow escalation policies as responder request targets

Closes #31 

## After the change - tested with GPT 4.1, 5 & Sonnet 4
<img width="542" height="466" alt="Screenshot 2025-09-17 at 6 57 36 PM" src="https://github.com/user-attachments/assets/0f6ef81b-e0ac-4240-8493-5ed56680cdb8" />


### Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only

### Checklist

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes are documented
- [x] Changes generate *no new warnings*
- [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

If this is a breaking change 👇

- [ ] I have documented the migration process
- [ ] I have implemented necessary warnings (if it can live side by side)

**Disclaimer:** We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.

```bash
make check
Running linting checks...
uv run python -m ruff check .
All checks passed!
Running tests with coverage...
uv run python -m coverage run -m pytest tests/
==================================================== test session starts ====================================================
platform darwin -- Python 3.12.9, pytest-8.4.1, pluggy-1.6.0
rootdir: /Users/jruiz/Workspace/pagerduty/local-mcp-server/pagerduty-mcp-server-issue-31-patch
configfile: pyproject.toml
plugins: anyio-4.9.0
collected 142 items

tests/test_escalation_policies.py ................                                                                    [ 11%]
tests/test_incidents.py ........................                                                                      [ 28%]
tests/test_oncalls.py ................                                                                                [ 39%]
tests/test_schedules.py ......................                                                                        [ 54%]
tests/test_services.py ....................                                                                           [ 69%]
tests/test_teams.py ............................                                                                      [ 88%]
tests/test_users.py ................                                                                                  [100%]

===================================================== warnings summary ======================================================
tests/test_schedules.py::TestScheduleTools::test_create_schedule_override_client_error
tests/test_schedules.py::TestScheduleTools::test_create_schedule_override_success
  /Users/jruiz/Workspace/pagerduty/local-mcp-server/pagerduty-mcp-server-issue-31-patch/.venv/lib/python3.12/site-packages/pydantic/main.py:463: UserWarning: Pydantic serializer warnings:
    PydanticSerializationUnexpectedValue(Expected `datetime` - serialized value may not be as expected [input_value='2024-12-25T00:00:00', input_type=str])
    PydanticSerializationUnexpectedValue(Expected `datetime` - serialized value may not be as expected [input_value='2024-12-26T00:00:00', input_type=str])
    return self.__pydantic_serializer__.to_python(

tests/test_schedules.py::TestScheduleTools::test_create_schedule_override_multiple_overrides
  /Users/jruiz/Workspace/pagerduty/local-mcp-server/pagerduty-mcp-server-issue-31-patch/.venv/lib/python3.12/site-packages/pydantic/main.py:463: UserWarning: Pydantic serializer warnings:
    PydanticSerializationUnexpectedValue(Expected `datetime` - serialized value may not be as expected [input_value='2024-12-25T00:00:00', input_type=str])
    PydanticSerializationUnexpectedValue(Expected `datetime` - serialized value may not be as expected [input_value='2024-12-26T00:00:00', input_type=str])
    PydanticSerializationUnexpectedValue(Expected `datetime` - serialized value may not be as expected [input_value='2024-12-30T00:00:00', input_type=str])
    PydanticSerializationUnexpectedValue(Expected `datetime` - serialized value may not be as expected [input_value='2024-12-31T00:00:00', input_type=str])
    return self.__pydantic_serializer__.to_python(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================== 142 passed, 3 warnings in 1.27s ==============================================

Coverage Report:
uv run python -m coverage report --include="pagerduty_mcp/tools/*" --show-missing
Name                                         Stmts   Miss  Cover   Missing
--------------------------------------------------------------------------
pagerduty_mcp/tools/__init__.py                 10      0   100%
pagerduty_mcp/tools/escalation_policies.py      10      0   100%
pagerduty_mcp/tools/incidents.py                77      0   100%
pagerduty_mcp/tools/oncalls.py                   7      0   100%
pagerduty_mcp/tools/schedules.py                19      0   100%
pagerduty_mcp/tools/services.py                 20      0   100%
pagerduty_mcp/tools/teams.py                    39      0   100%
pagerduty_mcp/tools/users.py                     9      0   100%
--------------------------------------------------------------------------
TOTAL                                          191      0   100%

Detailed Coverage by Module:
================================
uv run python -m coverage report --include="pagerduty_mcp/tools/incidents.py" --show-missing
Name                               Stmts   Miss  Cover   Missing
----------------------------------------------------------------
pagerduty_mcp/tools/incidents.py      77      0   100%
----------------------------------------------------------------
TOTAL                                 77      0   100%
uv run python -m coverage report --include="pagerduty_mcp/tools/users.py" --show-missing
Name                           Stmts   Miss  Cover   Missing
------------------------------------------------------------
pagerduty_mcp/tools/users.py       9      0   100%
------------------------------------------------------------
TOTAL                              9      0   100%
uv run python -m coverage report --include="pagerduty_mcp/tools/services.py" --show-missing
Name                              Stmts   Miss  Cover   Missing
---------------------------------------------------------------
pagerduty_mcp/tools/services.py      20      0   100%
---------------------------------------------------------------
TOTAL                                20      0   100%
uv run python -m coverage report --include="pagerduty_mcp/tools/teams.py" --show-missing
Name                           Stmts   Miss  Cover   Missing
------------------------------------------------------------
pagerduty_mcp/tools/teams.py      39      0   100%
------------------------------------------------------------
TOTAL                             39      0   100%
uv run python -m coverage report --include="pagerduty_mcp/tools/schedules.py" --show-missing
Name                               Stmts   Miss  Cover   Missing
----------------------------------------------------------------
pagerduty_mcp/tools/schedules.py      19      0   100%
----------------------------------------------------------------
TOTAL                                 19      0   100%
uv run python -m coverage report --include="pagerduty_mcp/tools/escalation_policies.py" --show-missing
Name                                         Stmts   Miss  Cover   Missing
--------------------------------------------------------------------------
pagerduty_mcp/tools/escalation_policies.py      10      0   100%
--------------------------------------------------------------------------
TOTAL                                           10      0   100%
uv run python -m coverage report --include="pagerduty_mcp/tools/oncalls.py" --show-missing
Name                             Stmts   Miss  Cover   Missing
--------------------------------------------------------------
pagerduty_mcp/tools/oncalls.py       7      0   100%
--------------------------------------------------------------
TOTAL                                7      0   100%
All checks completed!
```