### PR TITLE
fix: Let the list_incidents endpoint work with an account-level token

### DIFF
--- a/pagerduty_mcp/tools/incidents.py
+++ b/pagerduty_mcp/tools/incidents.py
@@ -42,13 +42,15 @@ def list_incidents(query_model: IncidentQuery) -> ListResponseModel[Incident]:
         >>> result = list_incidents(IncidentQuery(status=["triggered", "acknowledged"], limit=10))
     """
     params = query_model.to_params()
-    user_data = get_user_data()
 
-    if query_model.request_scope == "assigned":
-        params["user_ids[]"] = [user_data.id]
-    elif query_model.request_scope == "teams":
-        user_team_ids = [team.id for team in user_data.teams]
-        params["teams_ids[]"] = user_team_ids
+    if query_model.request_scope in ["assigned", "teams"]:
+        user_data = get_user_data()
+
+        if query_model.request_scope == "assigned":
+            params["user_ids[]"] = [user_data.id]
+        elif query_model.request_scope == "teams":
+            user_team_ids = [team.id for team in user_data.teams]
+            params["teams_ids[]"] = user_team_ids
 
     response = paginate(
         client=get_client(), entity="incidents", params=params, maximum_records=query_model.limit or 100

--- a/tests/test_incidents.py
+++ b/tests/test_incidents.py
@@ -93,6 +93,23 @@ class TestIncidentTools(unittest.TestCase):
     @patch("pagerduty_mcp.tools.incidents.get_client")
     @patch("pagerduty_mcp.tools.incidents.get_user_data")
     @patch("pagerduty_mcp.tools.incidents.paginate")
+    def test_list_incidents_all(self, mock_paginate, mock_get_user_data, mock_get_client):
+        """Fetching all incidents shouldn't require user context."""
+
+        # Setup mocks
+        mock_paginate.return_value = [self.sample_incident_data]
+
+        # Test with account level query
+        query = IncidentQuery(request_scope="all")
+        _ = list_incidents(query)
+
+        # Verify paginate was called without user context
+        mock_paginate.assert_called_once()
+        mock_get_user_data.assert_not_called()
+
+    @patch("pagerduty_mcp.tools.incidents.get_client")
+    @patch("pagerduty_mcp.tools.incidents.get_user_data")
+    @patch("pagerduty_mcp.tools.incidents.paginate")
     def test_list_incidents_assigned_scope(self, mock_paginate, mock_get_user_data, mock_get_client):
         """Test listing incidents with assigned scope."""
         # Setup mocks

--- a/tests/test_incidents.py
+++ b/tests/test_incidents.py
@@ -94,7 +94,7 @@ class TestIncidentTools(unittest.TestCase):
     @patch("pagerduty_mcp.tools.incidents.get_user_data")
     @patch("pagerduty_mcp.tools.incidents.paginate")
     def test_list_incidents_all(self, mock_paginate, mock_get_user_data, mock_get_client):
-        """Fetching all incidents shouldn't require user context."""
+        """Fetching all incidents shouldn't call sub-tools it doesn't need."""
 
         # Setup mocks
         mock_paginate.return_value = [self.sample_incident_data]
@@ -142,6 +142,20 @@ class TestIncidentTools(unittest.TestCase):
         call_args = mock_paginate.call_args
         self.assertIn("teams_ids[]", call_args[1]["params"])
         self.assertEqual(call_args[1]["params"]["teams_ids[]"], ["PTEAM123"])
+
+    @patch("pagerduty_mcp.tools.incidents.get_user_data")
+    def test_list_incidents_user_required_error(self, mock_get_user):
+        """If the request_scope requires user context but none is available, an error should be raised."""
+        # Setup mocks
+        mock_get_user.side_effect = Exception("users/me does not work for account-level tokens")
+
+        # Test with user required query
+        query = IncidentQuery(request_scope="assigned")
+
+        with self.assertRaises(Exception) as context:
+            list_incidents(query)
+
+        self.assertIn("users/me does not work for account-level tokens", str(context.exception))
 
     @patch("pagerduty_mcp.tools.incidents.get_client")
     @patch("pagerduty_mcp.tools.incidents.get_user_data")


### PR DESCRIPTION
### Description

Unless we actually need a user to get assigned or team incidents, an account-level token should be able to fetch the list of incidents.

### Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only

### Checklist

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes are documented
- [x] Changes generate *no new warnings*
- [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

If this is a breaking change 👇

- [ ] I have documented the migration process
- [ ] I have implemented necessary warnings (if it can live side by side)

**Disclaimer:** We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.