### PR TITLE
feat: add service dependency tools for business and technical services

### DIFF
--- a/pagerduty_mcp/models/__init__.py
+++ b/pagerduty_mcp/models/__init__.py
@@ -10,7 +10,8 @@ from .alert_grouping_settings import (
     TimeGroupingConfig,
 )
 from .alerts import Alert, AlertQuery
-from .base import MAX_RESULTS, ListResponseModel
+from .base import MAX_RESULTS, DependencyList, ListResponseModel, Relationship
+from .business_services import BusinessService, BusinessServiceDependencyList, BusinessServiceQuery
 from .change_events import ChangeEvent, ChangeEventQuery
 from .escalation_policies import EscalationPolicy, EscalationPolicyQuery
 from .event_orchestrations import (
@@ -114,6 +115,11 @@ from .users import User, UserQuery
 
 __all__ = [
     "MAX_RESULTS",
+    "BusinessService",
+    "BusinessServiceDependencyList",
+    "BusinessServiceQuery",
+    "DependencyList",
+    "Relationship",
     "ActionConfiguration",
     "ActionInput",
     "ActionOutput",

--- a/pagerduty_mcp/models/base.py
+++ b/pagerduty_mcp/models/base.py
@@ -37,3 +37,14 @@ class ListResponseModel[T: BaseModel](BaseModel):
                 " records not included in this response."
             )
         return "\n".join(summary)
+
+
+class Relationship(BaseModel):
+    id: str | None = None
+    supporting_service: dict | None = None
+    dependent_service: dict | None = None
+    type: str | None = None
+
+
+class DependencyList(BaseModel):
+    relationships: list[Relationship]

--- a/pagerduty_mcp/models/business_services.py
+++ b/pagerduty_mcp/models/business_services.py
@@ -1,0 +1,38 @@
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field, computed_field
+
+from pagerduty_mcp.models.base import DEFAULT_PAGINATION_LIMIT, MAXIMUM_PAGINATION_LIMIT, Relationship
+from pagerduty_mcp.models.references import TeamReference
+
+
+class BusinessService(BaseModel):
+    id: str | None = Field(description="The ID of the business service", default=None)
+    name: str | None = Field(default=None, description="The name of the business service")
+    description: str | None = Field(default=None, description="The description of the business service")
+    point_of_contact: str | None = Field(default=None, description="The point of contact for the business service")
+    team: TeamReference | None = Field(default=None, description="The team associated with the business service")
+
+    @computed_field
+    @property
+    def type(self) -> Literal["business_service"]:
+        return "business_service"
+
+
+class BusinessServiceQuery(BaseModel):
+    limit: int | None = Field(
+        ge=1,
+        le=MAXIMUM_PAGINATION_LIMIT,
+        default=DEFAULT_PAGINATION_LIMIT,
+        description="Pagination limit",
+    )
+
+    def to_params(self) -> dict[str, Any]:
+        params = {}
+        if self.limit:
+            params["limit"] = self.limit
+        return params
+
+
+class BusinessServiceDependencyList(BaseModel):
+    relationships: list[Relationship]

--- a/pagerduty_mcp/tools/__init__.py
+++ b/pagerduty_mcp/tools/__init__.py
@@ -9,6 +9,10 @@ from .alerts import (
     get_alert_from_incident,
     list_alerts_from_incident,
 )
+from .business_services import (
+    get_business_service_dependencies,
+    list_business_services,
+)
 from .change_events import (
     get_change_event,
     list_change_events,
@@ -66,6 +70,7 @@ from .schedules import (
 from .services import (
     create_service,
     get_service,
+    get_technical_service_dependencies,
     list_services,
     update_service,
 )
@@ -114,9 +119,13 @@ read_tools = [
     # Incident Workflows
     list_incident_workflows,
     get_incident_workflow,
+    # Business Services
+    list_business_services,
+    get_business_service_dependencies,
     # Services
     list_services,
     get_service,
+    get_technical_service_dependencies,
     # Teams
     list_teams,
     get_team,

--- a/pagerduty_mcp/tools/business_services.py
+++ b/pagerduty_mcp/tools/business_services.py
@@ -1,0 +1,42 @@
+from pagerduty_mcp.client import get_client
+from pagerduty_mcp.models import ListResponseModel
+from pagerduty_mcp.models.base import Relationship
+from pagerduty_mcp.models.business_services import (
+    BusinessService,
+    BusinessServiceDependencyList,
+    BusinessServiceQuery,
+)
+from pagerduty_mcp.utils import paginate
+
+
+def list_business_services(query_model: BusinessServiceQuery) -> ListResponseModel[BusinessService]:
+    """List business services.
+
+    Args:
+        query_model: Optional filtering parameters
+
+    Returns:
+        ListResponseModel containing BusinessService objects
+    """
+    response = paginate(client=get_client(), entity="business_services", params=query_model.to_params())
+    services = [BusinessService(**service) for service in response]
+    return ListResponseModel[BusinessService](response=services)
+
+
+def get_business_service_dependencies(business_service_id: str) -> BusinessServiceDependencyList:
+    """Get dependencies for a business service.
+
+    Uses GET /service_dependencies/business_services/{id} to return all service
+    relationships where this business service is either the dependent or supporting service.
+
+    Args:
+        business_service_id: The ID of the business service
+
+    Returns:
+        BusinessServiceDependencyList containing the service relationships
+    """
+    client = get_client()
+    resp = client.get(f"/service_dependencies/business_services/{business_service_id}")
+    rels = resp.json().get("relationships", [])
+    relationships = [Relationship(**rel) for rel in rels]
+    return BusinessServiceDependencyList(relationships=relationships)

--- a/pagerduty_mcp/tools/services.py
+++ b/pagerduty_mcp/tools/services.py
@@ -1,5 +1,6 @@
 from pagerduty_mcp.client import get_client
 from pagerduty_mcp.models import ListResponseModel, Service, ServiceCreate, ServiceQuery
+from pagerduty_mcp.models.base import DependencyList, Relationship
 from pagerduty_mcp.utils import paginate
 
 
@@ -66,3 +67,22 @@ def update_service(service_id: str, service_data: ServiceCreate) -> Service:
         return Service.model_validate(response["service"])
 
     return Service.model_validate(response)
+
+
+def get_technical_service_dependencies(service_id: str) -> DependencyList:
+    """Get dependencies for a technical service.
+
+    Uses GET /service_dependencies/technical_services/{id} to return all service
+    relationships where this technical service is either the dependent or supporting service.
+
+    Args:
+        service_id: The ID of the technical service
+
+    Returns:
+        DependencyList containing the service relationships
+    """
+    client = get_client()
+    resp = client.get(f"/service_dependencies/technical_services/{service_id}")
+    rels = resp.json().get("relationships", [])
+    relationships = [Relationship(**rel) for rel in rels]
+    return DependencyList(relationships=relationships)

--- a/tests/evals/run_tests.py
+++ b/tests/evals/run_tests.py
@@ -25,6 +25,7 @@ from tests.evals.test_incident_workflows import INCIDENT_WORKFLOW_COMPETENCY_TES
 from tests.evals.test_incidents import INCIDENT_COMPETENCY_TESTS
 from tests.evals.test_log_entries import LOG_ENTRY_COMPETENCY_TESTS
 from tests.evals.test_status_pages import STATUS_PAGES_COMPETENCY_TESTS
+from tests.evals.test_services import SERVICES_COMPETENCY_TESTS
 from tests.evals.test_teams import TEAMS_COMPETENCY_TESTS
 
 test_mapping = {
@@ -33,6 +34,7 @@ test_mapping = {
     "incidents": INCIDENT_COMPETENCY_TESTS,
     "incident-workflows": INCIDENT_WORKFLOW_COMPETENCY_TESTS,
     "log-entries": LOG_ENTRY_COMPETENCY_TESTS,
+    "services": SERVICES_COMPETENCY_TESTS,
     "teams": TEAMS_COMPETENCY_TESTS,
     "event-orchestrations": EVENT_ORCHESTRATIONS_COMPETENCY_TESTS,
     "status-pages": STATUS_PAGES_COMPETENCY_TESTS,
@@ -45,6 +47,7 @@ test_mapping = {
         + STATUS_PAGES_COMPETENCY_TESTS
         + CHANGE_EVENTS_COMPETENCY_TESTS
         + LOG_ENTRY_COMPETENCY_TESTS
+        + SERVICES_COMPETENCY_TESTS
     ),
 }
 

--- a/tests/evals/test_services.py
+++ b/tests/evals/test_services.py
@@ -1,0 +1,173 @@
+"""Tests for service dependency competency questions."""
+
+from .competency_test import CompetencyTest, MockedMCPServer
+
+
+class ServiceDependencyCompetencyTest(CompetencyTest):
+    """Competency tests for business and technical service dependency tools."""
+
+    def register_mock_responses(self, mcp: MockedMCPServer) -> None:
+        """Register minimal realistic responses to support multi-turn conversations."""
+        mcp.register_mock_response(
+            "list_business_services",
+            lambda params: True,
+            {
+                "response": [
+                    {"id": "BS123", "name": "Payment Processing", "type": "business_service"},
+                    {"id": "BS456", "name": "Customer Portal", "type": "business_service"},
+                    {"id": "BS789", "name": "Order Management", "type": "business_service"},
+                ]
+            },
+        )
+        mcp.register_mock_response(
+            "get_business_service_dependencies",
+            lambda params: True,
+            {
+                "relationships": [
+                    {
+                        "id": "DEP001",
+                        "type": "service_dependency",
+                        "supporting_service": {"id": "BS123", "type": "business_service_reference"},
+                        "dependent_service": {"id": "BS789", "type": "business_service_reference"},
+                    },
+                    {
+                        "id": "DEP002",
+                        "type": "service_dependency",
+                        "supporting_service": {"id": "SVC001", "type": "technical_service_reference"},
+                        "dependent_service": {"id": "BS123", "type": "business_service_reference"},
+                    },
+                ]
+            },
+        )
+        mcp.register_mock_response(
+            "list_services",
+            lambda params: True,
+            {
+                "response": [
+                    {"id": "SVC001", "name": "Payments API", "status": "active"},
+                    {"id": "SVC002", "name": "Auth Service", "status": "active"},
+                    {"id": "SVC003", "name": "Database Service", "status": "active"},
+                ]
+            },
+        )
+        mcp.register_mock_response(
+            "get_technical_service_dependencies",
+            lambda params: True,
+            {
+                "relationships": [
+                    {
+                        "id": "DEP003",
+                        "type": "service_dependency",
+                        "supporting_service": {"id": "SVC001", "type": "technical_service_reference"},
+                        "dependent_service": {"id": "BS123", "type": "business_service_reference"},
+                    },
+                    {
+                        "id": "DEP004",
+                        "type": "service_dependency",
+                        "supporting_service": {"id": "SVC002", "type": "technical_service_reference"},
+                        "dependent_service": {"id": "SVC001", "type": "technical_service_reference"},
+                    },
+                ]
+            },
+        )
+
+
+SERVICES_COMPETENCY_TESTS = [
+    # -------------------------------------------------------------------------
+    # list_business_services
+    # -------------------------------------------------------------------------
+    ServiceDependencyCompetencyTest(
+        query="Show me all business services",
+        expected_tools=[{"tool_name": "list_business_services", "parameters": {}}],
+        description="List all business services",
+    ),
+    ServiceDependencyCompetencyTest(
+        query="List business services",
+        expected_tools=[{"tool_name": "list_business_services", "parameters": {}}],
+        description="List business services with simple query",
+    ),
+    ServiceDependencyCompetencyTest(
+        query="What business services do we have configured in PagerDuty?",
+        expected_tools=[{"tool_name": "list_business_services", "parameters": {}}],
+        description="List business services using natural language",
+    ),
+    # -------------------------------------------------------------------------
+    # get_business_service_dependencies
+    # -------------------------------------------------------------------------
+    ServiceDependencyCompetencyTest(
+        query="Show me the dependencies for business service BS123",
+        expected_tools=[
+            {"tool_name": "get_business_service_dependencies", "parameters": {"business_service_id": "BS123"}}
+        ],
+        description="Get business service dependencies by ID",
+    ),
+    ServiceDependencyCompetencyTest(
+        query="What services does business service BS456 depend on?",
+        expected_tools=[
+            {"tool_name": "get_business_service_dependencies", "parameters": {"business_service_id": "BS456"}}
+        ],
+        description="Get business service dependencies using natural language",
+    ),
+    ServiceDependencyCompetencyTest(
+        query="Show me all service relationships for business service BS789",
+        expected_tools=[
+            {"tool_name": "get_business_service_dependencies", "parameters": {"business_service_id": "BS789"}}
+        ],
+        description="Get business service relationships",
+    ),
+    ServiceDependencyCompetencyTest(
+        query="What is the blast radius if business service BS123 goes down?",
+        expected_tools=[
+            {"tool_name": "get_business_service_dependencies", "parameters": {"business_service_id": "BS123"}}
+        ],
+        allowed_helper_tools=["list_business_services"],
+        description="Understand impact of business service outage using dependency lookup",
+    ),
+    ServiceDependencyCompetencyTest(
+        query="What supports the Payment Processing business service?",
+        expected_tools=[
+            {"tool_name": "get_business_service_dependencies", "parameters": {}}
+        ],
+        allowed_helper_tools=["list_business_services"],
+        description="Find supporting services for a named business service (requires lookup)",
+    ),
+    # -------------------------------------------------------------------------
+    # get_technical_service_dependencies
+    # -------------------------------------------------------------------------
+    ServiceDependencyCompetencyTest(
+        query="Show me the dependencies for technical service SVC001",
+        expected_tools=[
+            {"tool_name": "get_technical_service_dependencies", "parameters": {"service_id": "SVC001"}}
+        ],
+        description="Get technical service dependencies by ID",
+    ),
+    ServiceDependencyCompetencyTest(
+        query="What does technical service SVC002 depend on?",
+        expected_tools=[
+            {"tool_name": "get_technical_service_dependencies", "parameters": {"service_id": "SVC002"}}
+        ],
+        description="Get technical service dependencies using natural language",
+    ),
+    ServiceDependencyCompetencyTest(
+        query="Show me all service relationships for technical service SVC003",
+        expected_tools=[
+            {"tool_name": "get_technical_service_dependencies", "parameters": {"service_id": "SVC003"}}
+        ],
+        description="Get technical service relationships",
+    ),
+    ServiceDependencyCompetencyTest(
+        query="Which services depend on technical service SVC001?",
+        expected_tools=[
+            {"tool_name": "get_technical_service_dependencies", "parameters": {"service_id": "SVC001"}}
+        ],
+        description="Find dependents of a technical service",
+    ),
+    ServiceDependencyCompetencyTest(
+        query="What is the impact if the Payments API goes down?",
+        expected_tools=[
+            {"tool_name": "get_technical_service_dependencies", "parameters": {}}
+        ],
+        allowed_helper_tools=["list_services"],
+        description="Understand impact of technical service outage (requires service lookup)",
+    ),
+]

--- a/tests/test_business_services.py
+++ b/tests/test_business_services.py
@@ -1,0 +1,265 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from pagerduty_mcp.models.base import DEFAULT_PAGINATION_LIMIT, MAXIMUM_PAGINATION_LIMIT, Relationship
+from pagerduty_mcp.models.business_services import (
+    BusinessService,
+    BusinessServiceDependencyList,
+    BusinessServiceQuery,
+)
+from pagerduty_mcp.tools.business_services import (
+    get_business_service_dependencies,
+    list_business_services,
+)
+
+
+class TestBusinessServiceTools(unittest.TestCase):
+    """Test cases for business service tools."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up test data reused across all test methods."""
+        cls.sample_business_service = {
+            "id": "BS123",
+            "name": "Payment Processing",
+            "description": "Handles all payment transactions",
+            "point_of_contact": "payments-team@example.com",
+            "team": {"id": "TEAM1", "summary": "Payments Team", "type": "team_reference"},
+            "type": "business_service",
+        }
+
+        cls.sample_business_services_list = [
+            {
+                "id": "BS123",
+                "name": "Payment Processing",
+                "description": "Handles all payment transactions",
+                "point_of_contact": None,
+                "team": {"id": "TEAM1", "summary": "Payments Team", "type": "team_reference"},
+                "type": "business_service",
+            },
+            {
+                "id": "BS456",
+                "name": "Customer Portal",
+                "description": "Customer-facing web portal",
+                "point_of_contact": None,
+                "team": None,
+                "type": "business_service",
+            },
+        ]
+
+        cls.sample_relationships_response = {
+            "relationships": [
+                {
+                    "id": "DEP001",
+                    "type": "service_dependency",
+                    "supporting_service": {
+                        "id": "BS123",
+                        "type": "business_service_reference",
+                    },
+                    "dependent_service": {
+                        "id": "BS789",
+                        "type": "business_service_reference",
+                    },
+                },
+                {
+                    "id": "DEP002",
+                    "type": "service_dependency",
+                    "supporting_service": {
+                        "id": "SVC001",
+                        "type": "technical_service_reference",
+                    },
+                    "dependent_service": {
+                        "id": "BS123",
+                        "type": "business_service_reference",
+                    },
+                },
+            ]
+        }
+
+        cls.mock_client = MagicMock()
+
+    def setUp(self):
+        """Reset mock before each test."""
+        self.mock_client.reset_mock()
+        self.mock_client.get.side_effect = None
+
+    # -------------------------------------------------------------------------
+    # list_business_services
+    # -------------------------------------------------------------------------
+
+    @patch("pagerduty_mcp.tools.business_services.paginate")
+    @patch("pagerduty_mcp.tools.business_services.get_client")
+    def test_list_business_services_default(self, mock_get_client, mock_paginate):
+        """Test listing business services with default parameters."""
+        mock_get_client.return_value = self.mock_client
+        mock_paginate.return_value = self.sample_business_services_list
+
+        query = BusinessServiceQuery()
+        result = list_business_services(query)
+
+        mock_paginate.assert_called_once_with(
+            client=self.mock_client, entity="business_services", params=query.to_params()
+        )
+        self.assertEqual(len(result.response), 2)
+        self.assertIsInstance(result.response[0], BusinessService)
+        self.assertEqual(result.response[0].id, "BS123")
+        self.assertEqual(result.response[0].name, "Payment Processing")
+        self.assertEqual(result.response[1].id, "BS456")
+
+    @patch("pagerduty_mcp.tools.business_services.paginate")
+    @patch("pagerduty_mcp.tools.business_services.get_client")
+    def test_list_business_services_custom_limit(self, mock_get_client, mock_paginate):
+        """Test listing business services with a custom limit."""
+        mock_get_client.return_value = self.mock_client
+        mock_paginate.return_value = self.sample_business_services_list
+
+        query = BusinessServiceQuery(limit=50)
+        list_business_services(query)
+
+        mock_paginate.assert_called_once_with(
+            client=self.mock_client, entity="business_services", params={"limit": 50}
+        )
+
+    @patch("pagerduty_mcp.tools.business_services.paginate")
+    @patch("pagerduty_mcp.tools.business_services.get_client")
+    def test_list_business_services_empty_response(self, mock_get_client, mock_paginate):
+        """Test listing business services when no services exist."""
+        mock_get_client.return_value = self.mock_client
+        mock_paginate.return_value = []
+
+        result = list_business_services(BusinessServiceQuery())
+
+        self.assertEqual(len(result.response), 0)
+
+    @patch("pagerduty_mcp.tools.business_services.paginate")
+    @patch("pagerduty_mcp.tools.business_services.get_client")
+    def test_list_business_services_paginate_error(self, mock_get_client, mock_paginate):
+        """Test list_business_services propagates paginate exceptions."""
+        mock_get_client.return_value = self.mock_client
+        mock_paginate.side_effect = Exception("API Error")
+
+        with self.assertRaises(Exception) as ctx:
+            list_business_services(BusinessServiceQuery())
+
+        self.assertEqual(str(ctx.exception), "API Error")
+
+    # -------------------------------------------------------------------------
+    # get_business_service_dependencies
+    # -------------------------------------------------------------------------
+
+    @patch("pagerduty_mcp.tools.business_services.get_client")
+    def test_get_dependencies_returns_relationships(self, mock_get_client):
+        """Test fetching dependencies returns all relationships."""
+        mock_get_client.return_value = self.mock_client
+        mock_response = MagicMock()
+        mock_response.json.return_value = self.sample_relationships_response
+        self.mock_client.get.return_value = mock_response
+
+        result = get_business_service_dependencies("BS123")
+
+        self.mock_client.get.assert_called_once_with(
+            "/service_dependencies/business_services/BS123"
+        )
+        self.assertIsInstance(result, BusinessServiceDependencyList)
+        self.assertEqual(len(result.relationships), 2)
+        self.assertIsInstance(result.relationships[0], Relationship)
+        self.assertEqual(result.relationships[0].id, "DEP001")
+        self.assertIsNotNone(result.relationships[0].supporting_service)
+        self.assertEqual(result.relationships[0].supporting_service.get("id"), "BS123")  # type: ignore[union-attr]
+        self.assertIsNotNone(result.relationships[1].dependent_service)
+        self.assertEqual(result.relationships[1].dependent_service.get("id"), "BS123")  # type: ignore[union-attr]
+
+    @patch("pagerduty_mcp.tools.business_services.get_client")
+    def test_get_dependencies_empty(self, mock_get_client):
+        """Test fetching dependencies for a service with no relationships."""
+        mock_get_client.return_value = self.mock_client
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"relationships": []}
+        self.mock_client.get.return_value = mock_response
+
+        result = get_business_service_dependencies("BS999")
+
+        self.assertIsInstance(result, BusinessServiceDependencyList)
+        self.assertEqual(len(result.relationships), 0)
+
+    @patch("pagerduty_mcp.tools.business_services.get_client")
+    def test_get_dependencies_uses_correct_endpoint(self, mock_get_client):
+        """Test that the correct API endpoint is called."""
+        mock_get_client.return_value = self.mock_client
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"relationships": []}
+        self.mock_client.get.return_value = mock_response
+
+        get_business_service_dependencies("BSABC")
+
+        self.mock_client.get.assert_called_once_with(
+            "/service_dependencies/business_services/BSABC"
+        )
+
+    @patch("pagerduty_mcp.tools.business_services.get_client")
+    def test_get_dependencies_client_error(self, mock_get_client):
+        """Test get_business_service_dependencies propagates client exceptions."""
+        mock_get_client.return_value = self.mock_client
+        self.mock_client.get.side_effect = Exception("Network Error")
+
+        with self.assertRaises(Exception) as ctx:
+            get_business_service_dependencies("BS123")
+
+        self.assertEqual(str(ctx.exception), "Network Error")
+
+    # -------------------------------------------------------------------------
+    # Model validation
+    # -------------------------------------------------------------------------
+
+    def test_business_service_computed_type(self):
+        """Test BusinessService computed type property always returns 'business_service'."""
+        service = BusinessService(id="BS1", name="My Service")
+        self.assertEqual(service.type, "business_service")
+
+    def test_business_service_optional_fields(self):
+        """Test BusinessService with only required fields."""
+        service = BusinessService()
+        self.assertIsNone(service.id)
+        self.assertIsNone(service.name)
+        self.assertIsNone(service.team)
+        self.assertEqual(service.type, "business_service")
+
+    def test_business_service_query_default_params(self):
+        """Test BusinessServiceQuery.to_params() with defaults."""
+        query = BusinessServiceQuery()
+        self.assertEqual(query.to_params(), {"limit": DEFAULT_PAGINATION_LIMIT})
+
+    def test_business_service_query_custom_limit(self):
+        """Test BusinessServiceQuery.to_params() with a custom limit."""
+        query = BusinessServiceQuery(limit=50)
+        self.assertEqual(query.to_params(), {"limit": 50})
+
+    def test_business_service_query_limit_bounds(self):
+        """Test BusinessServiceQuery validates limit within allowed bounds."""
+        self.assertEqual(BusinessServiceQuery(limit=1).limit, 1)
+        self.assertEqual(BusinessServiceQuery(limit=MAXIMUM_PAGINATION_LIMIT).limit, MAXIMUM_PAGINATION_LIMIT)
+
+    def test_relationship_model_fields(self):
+        """Test Relationship model accepts all expected fields."""
+        rel = Relationship(
+            id="DEP001",
+            type="service_dependency",
+            supporting_service={"id": "SVC1", "type": "technical_service_reference"},
+            dependent_service={"id": "BS1", "type": "business_service_reference"},
+        )
+        self.assertEqual(rel.id, "DEP001")
+        self.assertIsNotNone(rel.supporting_service)
+        self.assertIsNotNone(rel.dependent_service)
+        self.assertEqual(rel.supporting_service.get("id"), "SVC1")  # type: ignore[union-attr]
+        self.assertEqual(rel.dependent_service.get("id"), "BS1")  # type: ignore[union-attr]
+
+    def test_relationship_model_optional_fields(self):
+        """Test Relationship model with no fields set."""
+        rel = Relationship()
+        self.assertIsNone(rel.id)
+        self.assertIsNone(rel.supporting_service)
+        self.assertIsNone(rel.dependent_service)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,13 +1,14 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
-from pagerduty_mcp.models.base import DEFAULT_PAGINATION_LIMIT, MAXIMUM_PAGINATION_LIMIT
+from pagerduty_mcp.models.base import DEFAULT_PAGINATION_LIMIT, MAXIMUM_PAGINATION_LIMIT, DependencyList, Relationship
 from pagerduty_mcp.models.escalation_policies import EscalationPolicyReference
 from pagerduty_mcp.models.references import TeamReference
 from pagerduty_mcp.models.services import Service, ServiceCreate, ServiceQuery
 from pagerduty_mcp.tools.services import (
     create_service,
     get_service,
+    get_technical_service_dependencies,
     list_services,
     update_service,
 )
@@ -68,6 +69,7 @@ class TestServiceTools(unittest.TestCase):
         """Reset mock before each test."""
         self.mock_client.reset_mock()
         # Clear any side effects
+        self.mock_client.get.side_effect = None
         self.mock_client.rget.side_effect = None
         self.mock_client.rpost.side_effect = None
         self.mock_client.rput.side_effect = None
@@ -438,6 +440,77 @@ class TestServiceTools(unittest.TestCase):
         )
 
         self.assertEqual(service.type, "service")
+
+    # -------------------------------------------------------------------------
+    # get_technical_service_dependencies
+    # -------------------------------------------------------------------------
+
+    @patch("pagerduty_mcp.tools.services.get_client")
+    def test_get_technical_service_dependencies_returns_relationships(self, mock_get_client):
+        """Test fetching technical service dependencies returns all relationships."""
+        mock_get_client.return_value = self.mock_client
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "relationships": [
+                {
+                    "id": "DEP001",
+                    "type": "service_dependency",
+                    "supporting_service": {"id": "SVC123", "type": "technical_service_reference"},
+                    "dependent_service": {"id": "BS789", "type": "business_service_reference"},
+                },
+                {
+                    "id": "DEP002",
+                    "type": "service_dependency",
+                    "supporting_service": {"id": "SVC456", "type": "technical_service_reference"},
+                    "dependent_service": {"id": "SVC123", "type": "technical_service_reference"},
+                },
+            ]
+        }
+        self.mock_client.get.return_value = mock_response
+
+        result = get_technical_service_dependencies("SVC123")
+
+        self.mock_client.get.assert_called_once_with("/service_dependencies/technical_services/SVC123")
+        self.assertIsInstance(result, DependencyList)
+        self.assertEqual(len(result.relationships), 2)
+        self.assertIsInstance(result.relationships[0], Relationship)
+        self.assertEqual(result.relationships[0].id, "DEP001")
+
+    @patch("pagerduty_mcp.tools.services.get_client")
+    def test_get_technical_service_dependencies_empty(self, mock_get_client):
+        """Test fetching technical service dependencies for a service with none."""
+        mock_get_client.return_value = self.mock_client
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"relationships": []}
+        self.mock_client.get.return_value = mock_response
+
+        result = get_technical_service_dependencies("SVC999")
+
+        self.assertIsInstance(result, DependencyList)
+        self.assertEqual(len(result.relationships), 0)
+
+    @patch("pagerduty_mcp.tools.services.get_client")
+    def test_get_technical_service_dependencies_uses_correct_endpoint(self, mock_get_client):
+        """Test that the correct API endpoint is called for technical service dependencies."""
+        mock_get_client.return_value = self.mock_client
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"relationships": []}
+        self.mock_client.get.return_value = mock_response
+
+        get_technical_service_dependencies("SVCABC")
+
+        self.mock_client.get.assert_called_once_with("/service_dependencies/technical_services/SVCABC")
+
+    @patch("pagerduty_mcp.tools.services.get_client")
+    def test_get_technical_service_dependencies_client_error(self, mock_get_client):
+        """Test get_technical_service_dependencies propagates client exceptions."""
+        mock_get_client.return_value = self.mock_client
+        self.mock_client.get.side_effect = Exception("Network Error")
+
+        with self.assertRaises(Exception) as ctx:
+            get_technical_service_dependencies("SVC123")
+
+        self.assertEqual(str(ctx.exception), "Network Error")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Add `list_business_services` tool to list all PagerDuty business services
- Add `get_business_service_dependencies` tool using the correct endpoint `GET /service_dependencies/business_services/{id}`
- Add `get_technical_service_dependencies` tool using the correct endpoint `GET /service_dependencies/technical_services/{id}`
- Add `BusinessService`, `BusinessServiceQuery`, `BusinessServiceDependencyList` models
- Add `Relationship` and `DependencyList` base models shared by both dependency tools

## Motivation

The PagerDuty service dependency graph is a key operational tool for understanding blast radius during incidents. Without these tools, an LLM cannot answer questions like:
- "What business services are impacted by this technical service being down?"
- "What does this business service depend on?"

## Implementation notes

Both dependency tools use `client.get()` (raw HTTP) rather than `client.rget()`. The `rget` helper from `pdpyras` expects the response body to be wrapped under a key matching the resource name (e.g. `{"service": {...}}`). The service dependencies endpoint returns `{"relationships": [...]}` which `rget` does not recognise, causing a silent error and an empty result. Using `client.get().json()` reads the response directly.

## Test plan

- [ ] `list_business_services` returns business services with correct fields
- [ ] `get_business_service_dependencies` returns relationships with `supporting_service` and `dependent_service` references for a service that has known dependencies
- [ ] `get_technical_service_dependencies` returns relationships for a technical service with known dependencies
- [ ] Services with no dependencies return an empty `relationships` list (not an error)