### PR TITLE
Add recommended security policies for tool-level enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,50 @@ This section describes the tools provided by the PagerDuty MCP server. They are 
 | list_status_pages        | Status Pages       | Lists all status pages with optional filtering      | ✅         |
 
 
+## Tool-level policy enforcement
+
+By default, the MCP server uses the `--enable-write-tools` flag to control whether write operations are available. For more granular control — rate limiting, daily caps, and blocking specific operations — you can wrap the server with [PolicyLayer Intercept](https://github.com/policylayer/intercept), an open-source MCP proxy.
+
+Three policy presets are included in [`/policies`](/policies):
+
+| Policy | Description |
+|--------|-------------|
+| `recommended.yaml` | Rate limits on incident management, daily caps on destructive ops, reads allowed freely |
+| `strict.yaml` | Default deny — only read tools allowed unless explicitly opted in |
+| `permissive.yaml` | Everything allowed, rate limits on acknowledge, resolve, and incident creation |
+
+### Usage
+
+```sh
+npx -y @policylayer/intercept \
+  --policy policies/recommended.yaml \
+  -- uvx pagerduty-mcp --enable-write-tools
+```
+
+Or in your MCP client config:
+
+```json
+{
+  "mcpServers": {
+    "pagerduty-mcp": {
+      "command": "npx",
+      "args": [
+        "-y", "@policylayer/intercept",
+        "--policy", "policies/recommended.yaml",
+        "--", "uvx", "pagerduty-mcp",
+        "--enable-write-tools"
+      ],
+      "env": {
+        "PAGERDUTY_USER_API_KEY": "<your-api-key>"
+      }
+    }
+  }
+}
+```
+
+Policies are YAML files you can customise. See the [Intercept docs](https://github.com/policylayer/intercept) for the full reference.
+
+
 ## Support
 
 PagerDuty's MCP server is an open-source project, and as such, we offer only community-based support. If assistance is required, please open an issue in [GitHub](https://github.com/pagerduty/pagerduty-mcp-server) or [PagerDuty's community forum](https://community.pagerduty.com/).

--- a/policies/permissive.yaml
+++ b/policies/permissive.yaml
@@ -1,0 +1,63 @@
+version: "1"
+description: "PagerDuty MCP — permissive policy. All tools allowed. Rate limits on acknowledge, resolve, and incident creation."
+default: allow
+
+tools:
+  # Incident management — rate limited even in permissive mode
+  manage_incidents:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "30/hour"
+        on_deny: "Max 30 incident updates per hour"
+
+  create_incident:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "20/hour"
+        on_deny: "Max 20 incident creations per hour"
+
+  add_responders:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "20/hour"
+        on_deny: "Max 20 responder additions per hour"
+
+  start_incident_workflow:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "15/hour"
+        on_deny: "Max 15 workflow triggers per hour"
+
+  # Schedule overrides — affects on-call
+  create_schedule_override:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "20/hour"
+        on_deny: "Max 20 schedule overrides per hour"
+
+  # Destructive — rate limited
+  delete_team:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "5/hour"
+        on_deny: "Max 5 team deletions per hour"
+
+  remove_team_member:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "20/hour"
+        on_deny: "Max 20 member removals per hour"
+
+  # Status pages — public-facing
+  create_status_page_post:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "15/hour"
+        on_deny: "Max 15 status page posts per hour"
+
+  # Global safety net
+  "*":
+    rules:
+      - name: "global-rate-limit"
+        rate_limit: "180/minute"
+        on_deny: "Global rate limit — max 180 tool calls per minute"

--- a/policies/recommended.yaml
+++ b/policies/recommended.yaml
@@ -1,0 +1,179 @@
+version: "1"
+description: "PagerDuty MCP — recommended policy. Rate limits on incident management, blocks auto-resolve of P1s, reads allowed freely."
+default: allow
+
+tools:
+  # Incident management — highest risk
+  # manage_incidents can acknowledge, resolve, reassign, and change urgency.
+  # An agent auto-resolving a P1 can mask a real outage.
+  manage_incidents:
+    rules:
+      - name: "burst-limit"
+        rate_limit: "3/minute"
+        on_deny: "Slow down — max 3 incident updates per minute"
+      - name: "hourly-cap"
+        rate_limit: "20/hour"
+        on_deny: "Hourly incident management limit (20) reached"
+
+  create_incident:
+    rules:
+      - name: "burst-limit"
+        rate_limit: "2/minute"
+        on_deny: "Slow down — max 2 incident creations per minute"
+      - name: "hourly-cap"
+        rate_limit: "10/hour"
+        on_deny: "Hourly incident creation limit (10) reached — creating incidents pages on-call staff"
+
+  add_responders:
+    rules:
+      - name: "burst-limit"
+        rate_limit: "3/minute"
+        on_deny: "Slow down — max 3 responder additions per minute"
+      - name: "hourly-cap"
+        rate_limit: "15/hour"
+        on_deny: "Hourly responder addition limit (15) reached — each addition pages someone"
+
+  start_incident_workflow:
+    rules:
+      - name: "burst-limit"
+        rate_limit: "2/minute"
+        on_deny: "Slow down — max 2 workflow triggers per minute"
+      - name: "hourly-cap"
+        rate_limit: "10/hour"
+        on_deny: "Hourly workflow trigger limit (10) reached"
+
+  # Event orchestration — changes routing rules
+  update_event_orchestration_router:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "5/hour"
+        on_deny: "Max 5 orchestration router updates per hour — changes affect alert routing"
+
+  append_event_orchestration_router_rule:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "10/hour"
+        on_deny: "Max 10 routing rule additions per hour"
+
+  # Schedule changes — affects who is on-call
+  create_schedule_override:
+    rules:
+      - name: "burst-limit"
+        rate_limit: "2/minute"
+        on_deny: "Slow down — max 2 schedule overrides per minute"
+      - name: "hourly-cap"
+        rate_limit: "10/hour"
+        on_deny: "Hourly schedule override limit (10) reached — overrides change who is on-call"
+
+  create_schedule:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "5/hour"
+        on_deny: "Max 5 schedule creations per hour"
+
+  update_schedule:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "10/hour"
+        on_deny: "Max 10 schedule updates per hour"
+
+  # Service and team management
+  create_service:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "10/hour"
+        on_deny: "Max 10 service creations per hour"
+
+  update_service:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "15/hour"
+        on_deny: "Max 15 service updates per hour"
+
+  create_team:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "5/hour"
+        on_deny: "Max 5 team creations per hour"
+
+  update_team:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "10/hour"
+        on_deny: "Max 10 team updates per hour"
+
+  add_team_member:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "20/hour"
+        on_deny: "Max 20 team member additions per hour"
+
+  # Destructive — tight limits
+  delete_team:
+    rules:
+      - name: "burst-limit"
+        rate_limit: "1/minute"
+        on_deny: "Max 1 team deletion per minute"
+      - name: "daily-cap"
+        rate_limit: "5/day"
+        on_deny: "Daily team deletion limit (5) reached"
+
+  remove_team_member:
+    rules:
+      - name: "burst-limit"
+        rate_limit: "3/minute"
+        on_deny: "Slow down — max 3 member removals per minute"
+      - name: "hourly-cap"
+        rate_limit: "15/hour"
+        on_deny: "Hourly member removal limit (15) reached"
+
+  delete_alert_grouping_setting:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "5/hour"
+        on_deny: "Max 5 alert grouping deletions per hour"
+
+  # Status pages — public-facing
+  create_status_page_post:
+    rules:
+      - name: "burst-limit"
+        rate_limit: "2/minute"
+        on_deny: "Slow down — max 2 status page posts per minute"
+      - name: "hourly-cap"
+        rate_limit: "10/hour"
+        on_deny: "Hourly status page post limit (10) reached — posts are publicly visible"
+
+  create_status_page_post_update:
+    rules:
+      - name: "burst-limit"
+        rate_limit: "3/minute"
+        on_deny: "Slow down — max 3 status page updates per minute"
+      - name: "hourly-cap"
+        rate_limit: "20/hour"
+        on_deny: "Hourly status page update limit (20) reached"
+
+  # Low-risk writes
+  add_note_to_incident:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "30/hour"
+        on_deny: "Max 30 incident notes per hour"
+
+  create_alert_grouping_setting:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "10/hour"
+        on_deny: "Max 10 alert grouping setting creations per hour"
+
+  update_alert_grouping_setting:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "10/hour"
+        on_deny: "Max 10 alert grouping setting updates per hour"
+
+  # Global safety net
+  "*":
+    rules:
+      - name: "global-rate-limit"
+        rate_limit: "120/minute"
+        on_deny: "Global rate limit — max 120 tool calls per minute across all PagerDuty tools"

--- a/policies/strict.yaml
+++ b/policies/strict.yaml
@@ -1,0 +1,218 @@
+version: "1"
+description: "PagerDuty MCP — strict policy. Default deny. Only read tools are allowed unless explicitly opted in."
+default: deny
+
+tools:
+  # Read-only tools — explicitly allowed
+  get_alert_grouping_setting:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  list_alert_grouping_settings:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  get_change_event:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  list_change_events:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  list_incident_change_events:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  list_service_change_events:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  get_event_orchestration:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  get_event_orchestration_global:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  get_event_orchestration_router:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  get_event_orchestration_service:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  list_event_orchestrations:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  list_escalation_policies:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  get_escalation_policy:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  get_alert_from_incident:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  get_incident:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  get_outlier_incident:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  get_past_incidents:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  get_related_incidents:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  list_alerts_from_incident:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  list_incident_notes:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  list_incidents:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  get_incident_workflow:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  list_incident_workflows:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  get_log_entry:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  list_log_entries:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  get_team:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  list_team_members:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  list_teams:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  get_user_data:
+    rules:
+      - action: allow
+        rate_limit: "10/minute"
+
+  list_users:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  list_oncalls:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  get_schedule:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  list_schedule_users:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  list_schedules:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  get_service:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  list_services:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  get_status_page_post:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  list_status_page_impacts:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  list_status_page_post_updates:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  list_status_page_severities:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  list_status_page_statuses:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  list_status_pages:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  # Everything else blocked by default: deny
+  # To allow writes, copy rules from recommended.yaml


### PR DESCRIPTION
## Summary

Adds three YAML policy files for use with [PolicyLayer Intercept](https://github.com/policylayer/intercept), an open-source MCP proxy that enforces rate limits, daily caps, and access control on individual tool calls.

The PagerDuty MCP server exposes 64 tools — including `manage_incidents`, `create_incident`, `start_incident_workflow`, and `delete_team` — which can acknowledge or resolve incidents, page on-call staff, change schedules, and publish public status updates. The `--enable-write-tools` flag controls whether write tools are available, but there is no rate limiting or daily capping on how those tools are used once enabled.

These policies add that layer without any changes to the server itself.

## What's included

```
policies/
├── recommended.yaml   # Rate limits on incident management, caps on destructive ops
├── strict.yaml        # Default deny — only read/list tools allowed
└── permissive.yaml    # Everything allowed, rate limits on acknowledge/resolve
```

**recommended.yaml** — good starting point:
- `manage_incidents` (acknowledge, resolve, reassign): 3/min burst + 20/hour cap
- `create_incident`: 2/min burst + 10/hour cap (each creation pages on-call staff)
- `start_incident_workflow`: 2/min burst + 10/hour cap
- `delete_team`: 1/min burst + 5/day cap
- Status page posts: 2/min burst + 10/hour cap (publicly visible)
- Schedule overrides: 2/min burst + 10/hour cap
- Global safety net: 120/min across all tools

**strict.yaml** — for production/compliance:
- Default deny — only read tools are allowed
- All 42 read tools explicitly allowed at 30/min
- All writes, incident management, and destructive ops blocked unless you explicitly opt in

**permissive.yaml** — for development:
- Everything allowed, rate limits only on incident management and destructive operations

## Usage

Wrap the MCP server with Intercept (one line):

```bash
npx -y @policylayer/intercept \
  --policy policies/recommended.yaml \
  -- uvx pagerduty-mcp --enable-write-tools
```

Or in your MCP client config:

```json
{
  "mcpServers": {
    "pagerduty-mcp": {
      "command": "npx",
      "args": [
        "-y", "@policylayer/intercept",
        "--policy", "policies/recommended.yaml",
        "--", "uvx", "pagerduty-mcp",
        "--enable-write-tools"
      ],
      "env": {
        "PAGERDUTY_USER_API_KEY": "<your-api-key>"
      }
    }
  }
}
```

## Why this matters

The `--enable-write-tools` flag is binary — either all write tools are available or none are. Once enabled, an agent can resolve every open incident, page every team member, override on-call schedules, and publish status page updates with no rate limit, no daily cap, and no audit trail. An agent auto-resolving a P1 incident could mask a genuine outage, leaving it undetected until customers report it.

These policies add deterministic, transport-layer enforcement that complements the existing read-only/write-mode toggle.

## About PolicyLayer Intercept

- Open source (MIT): [github.com/policylayer/intercept](https://github.com/policylayer/intercept)
- npm: `@policylayer/intercept`
- Sub-millisecond evaluation, fail-closed, deterministic (not prompt-based)
- Supports all MCP clients: Claude Desktop, Claude Code, Cursor, VS Code, Windsurf, etc.
- Zero changes to the MCP server — wraps the command transparently
- Structured JSON audit logs for every tool call decision