### PR TITLE
feat: service status field + PAGERDUTY_AUTH_TYPE env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,16 @@ To integrate the Docker container with MCP clients, you can use Docker as the co
     }
     ```
 
+## Configuration
+
+The MCP server is configured via environment variables:
+
+| Environment Variable | Required | Default | Description |
+|---|---|---|---|
+| `PAGERDUTY_USER_API_KEY` | Yes | — | Your PagerDuty User API Token (or OAuth2 access token when `PAGERDUTY_AUTH_TYPE=oauth2`). |
+| `PAGERDUTY_API_HOST` | No | `https://api.pagerduty.com` | PagerDuty API base URL. Use `https://api.eu.pagerduty.com` for EU accounts. |
+| `PAGERDUTY_AUTH_TYPE` | No | `token` | Controls the Authorization header format. `token` sends `Token token=<key>` (for User API keys). `oauth2` sends `Bearer <key>` (for OAuth2 access tokens). |
+
 ## Available Tools and Resources
 
 This section describes the tools provided by the PagerDuty MCP server. They are categorized based on whether they only read data or can modify data in your PagerDuty account.

--- a/pagerduty_mcp/client.py
+++ b/pagerduty_mcp/client.py
@@ -1,5 +1,5 @@
-
 from pagerduty_mcp.context import ContextResolver
+
 
 def get_client():
     """Backwards-compatible helper to get the PagerDuty client from the current context."""

--- a/pagerduty_mcp/context/application_context_strategy.py
+++ b/pagerduty_mcp/context/application_context_strategy.py
@@ -15,15 +15,24 @@ class PagerdutyMCPClient(RestApiV2Client):
         return f"{DIST_NAME}/{metadata.version(DIST_NAME)} {super().user_agent}"
 
 
+_VALID_AUTH_TYPES = ("token", "oauth2")
+
+
 def create_pd_client() -> RestApiV2Client:
     """Create a PagerDuty client."""
     api_key = os.getenv("PAGERDUTY_USER_API_KEY")
     api_host = os.getenv("PAGERDUTY_API_HOST", "https://api.pagerduty.com")
+    auth_type = os.getenv("PAGERDUTY_AUTH_TYPE", "token")
 
     if not api_key:
         raise RuntimeError("An API key is required to call the PagerDuty API.")
 
-    pd_client = PagerdutyMCPClient(api_key)
+    if auth_type not in _VALID_AUTH_TYPES:
+        raise ValueError(
+            f"Invalid PAGERDUTY_AUTH_TYPE value. Allowed values are: {', '.join(_VALID_AUTH_TYPES)}."
+        )
+
+    pd_client = PagerdutyMCPClient(api_key, auth_type=auth_type)
     if api_host:
         pd_client.url = api_host
     return pd_client

--- a/pagerduty_mcp/context/context_strategy.py
+++ b/pagerduty_mcp/context/context_strategy.py
@@ -1,12 +1,13 @@
-from typing import Protocol, ContextManager
+from contextlib import AbstractContextManager
+from typing import Protocol
+
 from pagerduty_mcp.context.mcp_context import MCPContext
+
 
 class ContextStrategy(Protocol):
     """Protocol for context management strategies."""
 
     @property
-    def context(self) -> MCPContext:
-        ...
+    def context(self) -> MCPContext: ...
 
-    def use_context(self, context: MCPContext) -> ContextManager:
-        ...
+    def use_context(self, context: MCPContext) -> AbstractContextManager: ...

--- a/pagerduty_mcp/context/mcp_context.py
+++ b/pagerduty_mcp/context/mcp_context.py
@@ -1,21 +1,21 @@
 import logging
 
-from typing_extensions import Optional
-
 from pagerduty.rest_api_v2_client import RestApiV2Client
+
 from pagerduty_mcp.models.users import User
+
 
 class MCPContext:
     """Container for request-scoped context data."""
 
     client: RestApiV2Client
-    user: Optional[User] = None
+    user: User | None = None
 
     def __init__(self, client: RestApiV2Client):
         self.client = client
         self.user = self._init_user()
 
-    def _init_user(self) -> Optional[User]:
+    def _init_user(self) -> User | None:
         """Set the user associated with the client credentials."""
         try:
             response = self.client.rget("/users/me")
@@ -28,7 +28,7 @@ class MCPContext:
 
             return user
 
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             logging.warning(f"Failed to initialize user: {e}")
 
         return None

--- a/pagerduty_mcp/models/services.py
+++ b/pagerduty_mcp/models/services.py
@@ -13,6 +13,7 @@ class Service(BaseModel):
     description: str | None = Field(default=None, description="The description of the service")
     escalation_policy: EscalationPolicyReference
     teams: list[TeamReference] | None = Field(default=None, description="List of teams associated with the service")
+    status: str | None = Field(default=None, description="The current state of the service")
 
     @computed_field
     @property

--- a/tests/context/test_application_context_strategy.py
+++ b/tests/context/test_application_context_strategy.py
@@ -24,7 +24,7 @@ def mock_client(monkeypatch):
     mock_client.headers = {}
 
     # mock the method used to create the client
-    monkeypatch.setattr(application_context_strategy, "PagerdutyMCPClient", lambda _: mock_client)
+    monkeypatch.setattr(application_context_strategy, "PagerdutyMCPClient", lambda *args, **kwargs: mock_client)
     return mock_client
 
 

--- a/tests/context/test_request_context_strategy.py
+++ b/tests/context/test_request_context_strategy.py
@@ -1,12 +1,13 @@
-import pytest
-
 from unittest.mock import MagicMock
 
+import pytest
 from pagerduty.rest_api_v2_client import RestApiV2Client
+
 from pagerduty_mcp.context import ContextResolver, application_context_strategy
 from pagerduty_mcp.context.mcp_context import MCPContext
 from pagerduty_mcp.context.request_context_strategy import RequestContextStrategy
 from pagerduty_mcp.models.users import User
+
 
 @pytest.fixture
 def prepare_env(monkeypatch):
@@ -14,22 +15,27 @@ def prepare_env(monkeypatch):
     yield
     ContextResolver._context_strategy = None
 
+
 @pytest.fixture
 def mock_client(monkeypatch):
+    """Fixture that provides a mock RestApiV2Client with patched PagerdutyMCPClient."""
     mock_client = MagicMock(RestApiV2Client)
     mock_client.headers = {}
 
     monkeypatch.setattr(application_context_strategy, "PagerdutyMCPClient", lambda _: mock_client)
     return mock_client
 
+
 @pytest.fixture
 def mock_user(mock_client):
+    """Fixture that configures mock_client to return a test user from rget."""
     user_fields = {"email": "test@example.com", "name": "blah", "role": "admin", "teams": []}
     mock_user = User(**user_fields)
 
     mock_client.rget.return_value = user_fields
 
     return mock_user
+
 
 class TestRequestContextStrategy:
     """Test cases for the RequestContextStrategy and its integration with MCPContext."""
@@ -40,16 +46,16 @@ class TestRequestContextStrategy:
         ContextResolver.set_strategy(strategy)
 
         with strategy.use_context(context):
-             assert ContextResolver.get_user() == mock_user
+            assert ContextResolver.get_user() == mock_user
 
         # also works from manager class
         with ContextResolver.use_context(context):
-             assert ContextResolver.get_user() == mock_user
+            assert ContextResolver.get_user() == mock_user
 
         # indulge my light paranoia
         context = MCPContext(MagicMock(RestApiV2Client))
         with strategy.use_context(context):
-             assert ContextResolver.get_user() == None
+            assert ContextResolver.get_user() is None
 
     def test_get_client(self, prepare_env, mock_client):
         mock_context = MCPContext(mock_client)
@@ -78,7 +84,7 @@ class TestRequestContextStrategy:
         ContextResolver.set_strategy(strategy)
 
         with strategy.use_context(mock_context):
-            assert ContextResolver.get_user() == None
+            assert ContextResolver.get_user() is None
 
     def test_raises_when_no_context(self, prepare_env):
         ContextResolver.set_strategy(RequestContextStrategy())

--- a/tests/mock_context_strategy.py
+++ b/tests/mock_context_strategy.py
@@ -1,15 +1,15 @@
-
-
 from contextlib import contextmanager
 from unittest.mock import MagicMock
 
 from pagerduty.rest_api_v2_client import RestApiV2Client
+
 from pagerduty_mcp.context.context_strategy import ContextStrategy
 from pagerduty_mcp.context.mcp_context import MCPContext
 
 
 class MockContextStrategy(ContextStrategy):
     """A mock context strategy for testing purposes."""
+
     def __init__(self):
         self._context = MagicMock(MCPContext)
         self._client = MagicMock(RestApiV2Client)

--- a/tests/test_application_context.py
+++ b/tests/test_application_context.py
@@ -1,0 +1,42 @@
+import os
+import unittest
+from unittest.mock import patch
+
+import pagerduty_mcp.context.application_context_strategy as m
+
+
+class TestApplicationContextStrategy(unittest.TestCase):
+
+    @patch.dict(os.environ, {"PAGERDUTY_USER_API_KEY": "test-key"}, clear=True)
+    @patch("pagerduty_mcp.context.application_context_strategy.PagerdutyMCPClient")
+    def test_default_auth_type_is_token(self, mock_cls):
+        m.create_pd_client()
+        mock_cls.assert_called_once()
+        _, kwargs = mock_cls.call_args
+        self.assertEqual(kwargs.get("auth_type", "token"), "token")
+
+    @patch.dict(os.environ, {"PAGERDUTY_USER_API_KEY": "test-key", "PAGERDUTY_AUTH_TYPE": "token"}, clear=True)
+    @patch("pagerduty_mcp.context.application_context_strategy.PagerdutyMCPClient")
+    def test_explicit_token_auth_type(self, mock_cls):
+        m.create_pd_client()
+        mock_cls.assert_called_once()
+        _, kwargs = mock_cls.call_args
+        self.assertEqual(kwargs.get("auth_type"), "token")
+
+    @patch.dict(os.environ, {"PAGERDUTY_USER_API_KEY": "test-key", "PAGERDUTY_AUTH_TYPE": "oauth2"}, clear=True)
+    @patch("pagerduty_mcp.context.application_context_strategy.PagerdutyMCPClient")
+    def test_oauth2_auth_type(self, mock_cls):
+        m.create_pd_client()
+        mock_cls.assert_called_once()
+        _, kwargs = mock_cls.call_args
+        self.assertEqual(kwargs.get("auth_type"), "oauth2")
+
+    @patch.dict(os.environ, {"PAGERDUTY_USER_API_KEY": "test-key", "PAGERDUTY_AUTH_TYPE": "invalid"}, clear=True)
+    def test_invalid_auth_type_raises_value_error(self):
+        with self.assertRaises(ValueError) as ctx:
+            m.create_pd_client()
+        self.assertIn("PAGERDUTY_AUTH_TYPE", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -451,6 +451,37 @@ class TestServiceTools(unittest.TestCase):
 
         self.assertEqual(service.type, "service")
 
+    def test_get_service_includes_status_field(self):
+        """Test that get_service returns a Service with the status field populated."""
+        sample = dict(self.sample_service_response)
+        sample["status"] = "active"
+        self.mock_client.rget.return_value = sample
+        with patch("pagerduty_mcp.tools.services.get_client", return_value=self.mock_client):
+            result = get_service("SVC123")
+        self.assertEqual(result.status, "active")
+
+    def test_list_services_includes_status_field(self):
+        """Test that list_services returns Services with the status field populated."""
+        samples = [dict(s) for s in self.sample_services_list_response]
+        samples[0]["status"] = "active"
+        samples[1]["status"] = "disabled"
+        with patch("pagerduty_mcp.tools.services.paginate", return_value=samples), \
+             patch("pagerduty_mcp.tools.services.get_client", return_value=self.mock_client):
+            result = list_services()
+        self.assertEqual(result.response[0].status, "active")
+        self.assertEqual(result.response[1].status, "disabled")
+
+    def test_service_model_accepts_various_status_values(self):
+        """Test that the Service model accepts all valid PagerDuty status values."""
+        escalation_policy = EscalationPolicyReference(id="EP123", summary="Test Escalation Policy")
+        for value in ("active", "warning", "critical", "maintenance", "disabled"):
+            svc = Service(
+                name="x",
+                escalation_policy=escalation_policy,
+                status=value,
+            )
+            self.assertEqual(svc.status, value)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- **FDE-250:** Exposes the `status` field (`active`, `warning`, `critical`, `maintenance`, `disabled`) on `get_service` and `list_services` responses. The PagerDuty API already returns this field; it was simply not included in the `Service` Pydantic model.
- **FDE-65:** Adds `PAGERDUTY_AUTH_TYPE` env var (default: `token`, accepted: `token` | `oauth2`) to control the Authorization header format — `Token token=<key>` for API keys vs `Bearer <key>` for OAuth2 access tokens. Invalid values raise `ValueError` at startup.

## Changes

- `pagerduty_mcp/models/services.py` — add `status: str | None = None` to `Service`
- `pagerduty_mcp/context/application_context_strategy.py` — read `PAGERDUTY_AUTH_TYPE`, validate, pass `auth_type` to `PagerdutyMCPClient`
- `tests/test_services.py` — 3 new tests for service status
- `tests/test_application_context.py` — 4 new tests for auth type handling
- `README.md` — new Configuration section documenting all env vars

## Test plan

- [ ] `uv run python -m pytest tests/ -v` passes (360 tests, 7 new)
- [ ] `uv run ruff check pagerduty_mcp/` — no new violations
- [ ] Verified `PAGERDUTY_AUTH_TYPE=oauth2` passes `Bearer` to client; default passes `Token token=`

Closes FDE-250, FDE-65