### PR TITLE
feat: add webhook subscription and extension schema tools (FDE-392)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,6 @@ Step-by-step PagerDuty account setup:
 - ✅ Direct access to all PagerDuty MCP tools
 - ✅ Simple deployment: `uv run pagerduty-mcp`
 
-See [mcp-apps/README.md](mcp-apps/README.md) for development instructions and customization.
-
 ## Prerequisites
 
 *   [asdf-vm](https://asdf-vm.com/) installed.

--- a/README.md
+++ b/README.md
@@ -397,6 +397,13 @@ This section describes the tools provided by the PagerDuty MCP server. They are 
 | list_status_page_severities | Status Pages    | Lists available severity levels for a status page   | ✅         |
 | list_status_page_statuses | Status Pages      | Lists available statuses for a status page          | ✅         |
 | list_status_pages        | Status Pages       | Lists all status pages with optional filtering      | ✅         |
+| create_webhook_subscription | Webhooks        | Creates a new webhook subscription (returns signing secret) | ❌         |
+| delete_webhook_subscription | Webhooks        | Deletes a webhook subscription                      | ❌         |
+| get_webhook_subscription    | Webhooks        | Retrieves a specific webhook subscription           | ✅         |
+| list_webhook_subscriptions  | Webhooks        | Lists webhook subscriptions with optional type filtering | ✅         |
+| update_webhook_subscription | Webhooks        | Updates an existing webhook subscription            | ❌         |
+| get_extension_schema        | Extension Schemas | Retrieves a specific extension schema             | ✅         |
+| list_extension_schemas      | Extension Schemas | Lists available extension schemas (vendors)       | ✅         |
 
 
 ## Support

--- a/pagerduty_mcp/models/__init__.py
+++ b/pagerduty_mcp/models/__init__.py
@@ -112,6 +112,7 @@ from .status_pages import (
 )
 from .teams import Team, TeamCreateRequest, TeamMemberAdd, TeamQuery
 from .users import CreateUserRequest, User, UserQuery
+from .webhooks import ExtensionSchema, WebhookCreate, WebhookSubscription, WebhookUpdate
 
 __all__ = [
     "MAX_RESULTS",
@@ -149,6 +150,7 @@ __all__ = [
     "EventOrchestrationRuleCreateRequest",
     "EventOrchestrationRuleSet",
     "EventOrchestrationService",
+    "ExtensionSchema",
     "Incident",
     "IncidentCreate",
     "IncidentCreateRequest",
@@ -227,4 +229,7 @@ __all__ = [
     "UserQuery",
     "UserReference",
     "CreateUserRequest",
+    "WebhookCreate",
+    "WebhookSubscription",
+    "WebhookUpdate",
 ]

--- a/pagerduty_mcp/models/webhooks.py
+++ b/pagerduty_mcp/models/webhooks.py
@@ -1,0 +1,117 @@
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+class WebhookCustomHeader(BaseModel):
+    name: str = Field(description="The header name")
+    value: str = Field(description="The header value")
+
+
+class WebhookDeliveryMethod(BaseModel):
+    """HTTP delivery method for a webhook subscription."""
+
+    type: str = Field(default="http_delivery_method", description="The delivery method type")
+    url: str = Field(description="The destination URL for webhook delivery")
+    custom_headers: list[WebhookCustomHeader] | None = Field(
+        default=None, description="Optional custom headers to include with each webhook delivery"
+    )
+    # Read-only fields (populated in responses)
+    id: str | None = Field(default=None, description="The delivery method ID (read-only)")
+    secret: str | None = Field(
+        default=None,
+        description=(
+            "The signing secret for this webhook. "
+            "Only returned on the initial create response — store it securely."
+        ),
+    )
+    temporarily_disabled: bool | None = Field(
+        default=None,
+        description="True if the webhook is temporarily disabled due to repeated delivery failures",
+    )
+
+
+class WebhookFilter(BaseModel):
+    """Scope filter for a webhook subscription."""
+
+    type: Literal["account_reference", "service_reference", "team_reference"] = Field(
+        description="The scope of events to receive: account-wide, a specific service, or a specific team"
+    )
+    id: str | None = Field(
+        default=None,
+        description="The ID of the service or team to filter on (required for service/team scope)",
+    )
+
+
+class WebhookSubscription(BaseModel):
+    """A PagerDuty webhook subscription."""
+
+    id: str | None = Field(default=None, description="The webhook subscription ID (read-only)")
+    type: str | None = Field(default=None, description="The object type (always webhook_subscription)")
+    active: bool | None = Field(
+        default=None, description="Whether the subscription will produce webhook events"
+    )
+    description: str | None = Field(default=None, description="A short description of the webhook subscription")
+    delivery_method: WebhookDeliveryMethod | None = Field(
+        default=None, description="The delivery method configuration"
+    )
+    events: list[str] | None = Field(
+        default=None, description="The outbound event types this webhook will receive"
+    )
+    filter: WebhookFilter | None = Field(
+        default=None, description="The scope filter for this webhook subscription"
+    )
+
+
+class WebhookCreate(BaseModel):
+    """Request body for creating a webhook subscription."""
+
+    type: str = Field(default="webhook_subscription", description="Must be webhook_subscription")
+    delivery_method: WebhookDeliveryMethod = Field(
+        description="The delivery configuration — must include type and url"
+    )
+    events: list[str] = Field(
+        description=(
+            "The event types to subscribe to (e.g. incident.triggered, incident.resolved, "
+            "incident.acknowledged, service.updated). At least one event is required."
+        )
+    )
+    filter: WebhookFilter = Field(
+        description=(
+            "The scope filter — account_reference for all events, "
+            "or service_reference/team_reference for specific resources"
+        )
+    )
+    active: bool | None = Field(default=None, description="Whether the subscription should be active on creation")
+    description: str | None = Field(default=None, description="A short description of this webhook subscription")
+
+
+class WebhookUpdate(BaseModel):
+    """Request body for updating a webhook subscription. All fields are optional."""
+
+    active: bool | None = Field(default=None, description="Enable or disable the webhook subscription")
+    description: str | None = Field(default=None, description="Updated description")
+    delivery_method: dict[str, Any] | None = Field(
+        default=None, description="Updated delivery method (provide only fields to change)"
+    )
+    events: list[str] | None = Field(default=None, description="Updated list of event types to subscribe to")
+    filter: WebhookFilter | None = Field(default=None, description="Updated scope filter")
+
+
+class ExtensionSchema(BaseModel):
+    """A PagerDuty extension schema (extension vendor definition)."""
+
+    id: str | None = Field(default=None, description="The extension schema ID")
+    type: str | None = Field(default=None, description="The object type (always extension_schema)")
+    summary: str | None = Field(default=None, description="A short-form summary of the extension schema")
+    label: str | None = Field(default=None, description="Human-friendly display label")
+    key: str | None = Field(default=None, description="Machine-friendly display label")
+    description: str | None = Field(default=None, description="A long description of the extension")
+    icon_url: str | None = Field(default=None, description="URL for the small (18x18) logo")
+    logo_url: str | None = Field(default=None, description="URL for the large logo (75px high, max 300px wide)")
+    guide_url: str | None = Field(default=None, description="Link to the extension's support guide")
+    url: str | None = Field(default=None, description="The webhook payload destination URL for this extension")
+    send_types: list[str] | None = Field(
+        default=None,
+        description="The PagerDuty incident event types that activate this extension",
+    )

--- a/pagerduty_mcp/tools/__init__.py
+++ b/pagerduty_mcp/tools/__init__.py
@@ -90,6 +90,15 @@ from .teams import (
     update_team,
 )
 from .users import create_user, get_user_data, list_users
+from .webhooks import (
+    create_webhook_subscription,
+    delete_webhook_subscription,
+    get_extension_schema,
+    get_webhook_subscription,
+    list_extension_schemas,
+    list_webhook_subscriptions,
+    update_webhook_subscription,
+)
 
 # Read-only tools (safe, non-destructive operations)
 read_tools = [
@@ -149,6 +158,12 @@ read_tools = [
     list_status_page_statuses,
     get_status_page_post,
     list_status_page_post_updates,
+    # Webhooks
+    list_webhook_subscriptions,
+    get_webhook_subscription,
+    # Extension Schemas
+    list_extension_schemas,
+    get_extension_schema,
 ]
 
 # Write tools (potentially dangerous operations that modify state)
@@ -187,6 +202,10 @@ write_tools = [
     create_user,
     # Escalation Policies - currently disabled
     # create_escalation_policy,
+    # Webhooks
+    create_webhook_subscription,
+    update_webhook_subscription,
+    delete_webhook_subscription,
 ]
 
 # All tools (combined list for backward compatibility)

--- a/pagerduty_mcp/tools/webhooks.py
+++ b/pagerduty_mcp/tools/webhooks.py
@@ -1,0 +1,132 @@
+from typing import Any
+
+from pagerduty_mcp.client import get_client
+from pagerduty_mcp.models import ListResponseModel
+from pagerduty_mcp.models.webhooks import (
+    ExtensionSchema,
+    WebhookCreate,
+    WebhookSubscription,
+    WebhookUpdate,
+)
+from pagerduty_mcp.utils import paginate
+
+
+def list_webhook_subscriptions(
+    filter_type: str | None = None,
+    limit: int | None = None,
+) -> ListResponseModel[WebhookSubscription]:
+    """List webhook subscriptions.
+
+    Args:
+        filter_type: Filter by scope type: 'account_reference', 'service_reference', or 'team_reference'
+        limit: Max results to return
+
+    Returns:
+        List of webhook subscriptions
+    """
+    params: dict[str, Any] = {}
+    if filter_type:
+        params["filter_type"] = filter_type
+    if limit:
+        params["limit"] = limit
+    response = paginate(client=get_client(), entity="webhook_subscriptions", params=params)
+    subscriptions = [WebhookSubscription(**sub) for sub in response]
+    return ListResponseModel[WebhookSubscription](response=subscriptions)
+
+
+def get_webhook_subscription(subscription_id: str) -> WebhookSubscription:
+    """Get a specific webhook subscription by ID.
+
+    Args:
+        subscription_id: The ID of the webhook subscription to retrieve
+
+    Returns:
+        Webhook subscription details
+    """
+    response = get_client().rget(f"/webhook_subscriptions/{subscription_id}")
+    if isinstance(response, dict) and "webhook_subscription" in response:
+        return WebhookSubscription.model_validate(response["webhook_subscription"])
+    return WebhookSubscription.model_validate(response)
+
+
+def create_webhook_subscription(webhook_data: WebhookCreate) -> WebhookSubscription:
+    """Create a new webhook subscription.
+
+    The signing secret is included in the delivery_method of the returned subscription.
+    It is only returned on this initial create response — store it securely.
+
+    Args:
+        webhook_data: Configuration for the new webhook subscription, including
+            delivery URL, event types, and scope filter
+
+    Returns:
+        The created webhook subscription (includes the one-time signing secret in delivery_method.secret)
+    """
+    payload = {"webhook_subscription": webhook_data.model_dump(exclude_none=True)}
+    response = get_client().rpost("/webhook_subscriptions", json=payload)
+    if isinstance(response, dict) and "webhook_subscription" in response:
+        return WebhookSubscription.model_validate(response["webhook_subscription"])
+    return WebhookSubscription.model_validate(response)
+
+
+def update_webhook_subscription(subscription_id: str, webhook_data: WebhookUpdate) -> WebhookSubscription:
+    """Update an existing webhook subscription.
+
+    Args:
+        subscription_id: The ID of the webhook subscription to update
+        webhook_data: Fields to update (only provided fields are changed)
+
+    Returns:
+        The updated webhook subscription
+    """
+    payload = {"webhook_subscription": webhook_data.model_dump(exclude_none=True)}
+    response = get_client().rput(f"/webhook_subscriptions/{subscription_id}", json=payload)
+    if isinstance(response, dict) and "webhook_subscription" in response:
+        return WebhookSubscription.model_validate(response["webhook_subscription"])
+    return WebhookSubscription.model_validate(response)
+
+
+def delete_webhook_subscription(subscription_id: str) -> None:
+    """Delete a webhook subscription.
+
+    Args:
+        subscription_id: The ID of the webhook subscription to delete
+    """
+    get_client().rdelete(f"/webhook_subscriptions/{subscription_id}")
+
+
+def list_extension_schemas(
+    limit: int | None = None,
+) -> ListResponseModel[ExtensionSchema]:
+    """List available extension schemas (extension vendors).
+
+    Extension schemas describe the available extension integrations that can be
+    attached to PagerDuty services.
+
+    Args:
+        limit: Max results to return
+
+    Returns:
+        List of extension schemas
+    """
+    params: dict[str, Any] = {}
+    if limit:
+        params["limit"] = limit
+    response = paginate(client=get_client(), entity="extension_schemas", params=params)
+    schemas = [ExtensionSchema(**schema) for schema in response]
+    return ListResponseModel[ExtensionSchema](response=schemas)
+
+
+def get_extension_schema(schema_id: str) -> ExtensionSchema:
+    """Get a specific extension schema by ID.
+
+    Args:
+        schema_id: The ID of the extension schema to retrieve
+
+    Returns:
+        Extension schema details
+    """
+    response = get_client().rget(f"/extension_schemas/{schema_id}")
+    if isinstance(response, dict) and "extension_schema" in response:
+        return ExtensionSchema.model_validate(response["extension_schema"])
+    return ExtensionSchema.model_validate(response)

--- a/pagerduty_mcp_evals/test_cases/test_cases_builder.py
+++ b/pagerduty_mcp_evals/test_cases/test_cases_builder.py
@@ -17,6 +17,7 @@ from pagerduty_mcp_evals.test_cases.test_alert_grouping_settings import (
 )
 from pagerduty_mcp_evals.test_cases.test_change_events import CHANGE_EVENTS_COMPETENCY_TESTS
 from pagerduty_mcp_evals.test_cases.test_log_entries import LOG_ENTRY_COMPETENCY_TESTS
+from pagerduty_mcp_evals.test_cases.test_webhooks import WEBHOOK_COMPETENCY_TESTS
 
 test_mapping = {
     "incidents": INCIDENT_COMPETENCY_TESTS,
@@ -29,6 +30,7 @@ test_mapping = {
     "log-entries": LOG_ENTRY_COMPETENCY_TESTS,
     "schedules": SCHEDULES_COMPETENCY_TESTS,
     "services": SERVICES_COMPETENCY_TESTS,
+    "webhooks": WEBHOOK_COMPETENCY_TESTS,
     "all": (
         INCIDENT_COMPETENCY_TESTS
         + TEAMS_COMPETENCY_TESTS
@@ -40,6 +42,7 @@ test_mapping = {
         + LOG_ENTRY_COMPETENCY_TESTS
         + SCHEDULES_COMPETENCY_TESTS
         + SERVICES_COMPETENCY_TESTS
+        + WEBHOOK_COMPETENCY_TESTS
     ),
 }
 

--- a/pagerduty_mcp_evals/test_cases/test_webhooks.py
+++ b/pagerduty_mcp_evals/test_cases/test_webhooks.py
@@ -1,0 +1,261 @@
+"""Tests for webhooks-related competency questions."""
+
+from pagerduty_mcp_evals.test_cases.agent_competency_test import (
+    AgentCompetencyTest,
+    MockMCPToolInvocationResponse,
+    MockToolCall,
+)
+
+_SAMPLE_SUBSCRIPTION = {
+    "id": "WH123",
+    "type": "webhook_subscription",
+    "active": True,
+    "description": "Incident alerts",
+    "delivery_method": {
+        "id": "DM123",
+        "type": "http_delivery_method",
+        "url": "https://example.com/hook",
+    },
+    "events": ["incident.triggered", "incident.resolved"],
+    "filter": {"type": "account_reference"},
+}
+
+_SAMPLE_SUBSCRIPTION_WITH_SECRET = {
+    **_SAMPLE_SUBSCRIPTION,
+    "id": "WH456",
+    "delivery_method": {
+        **_SAMPLE_SUBSCRIPTION["delivery_method"],
+        "secret": "s3cr3t_signing_key",
+    },
+}
+
+_SAMPLE_SERVICE_SUBSCRIPTION = {
+    "id": "WH789",
+    "type": "webhook_subscription",
+    "active": True,
+    "description": "Service webhook",
+    "delivery_method": {
+        "id": "DM456",
+        "type": "http_delivery_method",
+        "url": "https://example.com/service-hook",
+    },
+    "events": ["incident.triggered", "incident.resolved"],
+    "filter": {"type": "service_reference", "id": "SVC123"},
+}
+
+_SAMPLE_EXTENSION_SCHEMA = {
+    "id": "PJFWPEP",
+    "type": "extension_schema",
+    "summary": "Generic Webhook",
+    "label": "Generic Webhook",
+    "key": "generic_webhook",
+    "description": "Send events to a generic webhook endpoint",
+    "guide_url": "https://developer.pagerduty.com/docs/webhooks",
+}
+
+
+class WebhooksCompetencyTest(AgentCompetencyTest):
+    """Specialization of AgentCompetencyTest for webhooks-related queries."""
+
+    def __init__(self, **kwargs) -> None:
+        mock_responses = [
+            MockMCPToolInvocationResponse(
+                tool_name="list_webhook_subscriptions",
+                parameters=lambda params: True,
+                response={
+                    "response": [_SAMPLE_SUBSCRIPTION, _SAMPLE_SERVICE_SUBSCRIPTION]
+                },
+            ),
+            MockMCPToolInvocationResponse(
+                tool_name="get_webhook_subscription",
+                parameters=lambda params: params.get("subscription_id") == "WH123",
+                response=_SAMPLE_SUBSCRIPTION,
+            ),
+            MockMCPToolInvocationResponse(
+                tool_name="create_webhook_subscription",
+                parameters=lambda params: True,
+                response=_SAMPLE_SUBSCRIPTION_WITH_SECRET,
+            ),
+            MockMCPToolInvocationResponse(
+                tool_name="update_webhook_subscription",
+                parameters=lambda params: True,
+                response={**_SAMPLE_SUBSCRIPTION, "active": False},
+            ),
+            MockMCPToolInvocationResponse(
+                tool_name="delete_webhook_subscription",
+                parameters=lambda params: True,
+                response=None,
+            ),
+            MockMCPToolInvocationResponse(
+                tool_name="list_extension_schemas",
+                parameters=lambda params: True,
+                response={"response": [_SAMPLE_EXTENSION_SCHEMA]},
+            ),
+            MockMCPToolInvocationResponse(
+                tool_name="get_extension_schema",
+                parameters=lambda params: params.get("schema_id") == "PJFWPEP",
+                response=_SAMPLE_EXTENSION_SCHEMA,
+            ),
+        ]
+        super().__init__(mock_responses=mock_responses, **kwargs)
+
+
+WEBHOOK_COMPETENCY_TESTS = [
+    # list_webhook_subscriptions
+    WebhooksCompetencyTest(
+        query="Show me all webhook subscriptions",
+        expected_tool_calls=[
+            MockToolCall(name="list_webhook_subscriptions", parameters={})
+        ],
+        description="Basic webhook subscriptions listing",
+    ),
+    WebhooksCompetencyTest(
+        query="List webhook subscriptions scoped to services",
+        expected_tool_calls=[
+            MockToolCall(
+                name="list_webhook_subscriptions",
+                parameters={"filter_type": "service_reference"},
+            )
+        ],
+        description="List webhook subscriptions filtered by service scope",
+    ),
+    WebhooksCompetencyTest(
+        query="Show me the first 5 account-level webhook subscriptions",
+        expected_tool_calls=[
+            MockToolCall(
+                name="list_webhook_subscriptions",
+                parameters={"filter_type": "account_reference", "limit": 5},
+            )
+        ],
+        description="List webhook subscriptions with filter_type and limit",
+    ),
+    # get_webhook_subscription
+    WebhooksCompetencyTest(
+        query="Get details for webhook subscription WH123",
+        expected_tool_calls=[
+            MockToolCall(
+                name="get_webhook_subscription",
+                parameters={"subscription_id": "WH123"},
+            )
+        ],
+        description="Get a specific webhook subscription by ID",
+    ),
+    # create_webhook_subscription — account-wide
+    WebhooksCompetencyTest(
+        query=(
+            "Create a webhook subscription that sends incident.triggered and incident.resolved "
+            "events to https://example.com/hook for the whole account"
+        ),
+        expected_tool_calls=[
+            MockToolCall(
+                name="create_webhook_subscription",
+                parameters={
+                    "webhook_data": {
+                        "delivery_method": {
+                            "type": "http_delivery_method",
+                            "url": "https://example.com/hook",
+                        },
+                        "events": ["incident.triggered", "incident.resolved"],
+                        "filter": {"type": "account_reference"},
+                    }
+                },
+            )
+        ],
+        description="Create account-scoped webhook subscription",
+    ),
+    # create_webhook_subscription — service-scoped
+    WebhooksCompetencyTest(
+        query=(
+            "Create a webhook subscription for service SVC123 that delivers "
+            "incident.triggered events to https://example.com/service-hook"
+        ),
+        expected_tool_calls=[
+            MockToolCall(
+                name="create_webhook_subscription",
+                parameters={
+                    "webhook_data": {
+                        "delivery_method": {
+                            "type": "http_delivery_method",
+                            "url": "https://example.com/service-hook",
+                        },
+                        "events": ["incident.triggered"],
+                        "filter": {"type": "service_reference", "id": "SVC123"},
+                    }
+                },
+            )
+        ],
+        description="Create service-scoped webhook subscription",
+    ),
+    # update_webhook_subscription — disable
+    WebhooksCompetencyTest(
+        query="Disable webhook subscription WH123",
+        expected_tool_calls=[
+            MockToolCall(
+                name="update_webhook_subscription",
+                parameters={
+                    "subscription_id": "WH123",
+                    "webhook_data": {"active": False},
+                },
+            )
+        ],
+        description="Disable a webhook subscription",
+    ),
+    # update_webhook_subscription — change events
+    # The model fetches the current subscription first to see the existing event list,
+    # then issues the update with the merged set.
+    WebhooksCompetencyTest(
+        query=(
+            "Update webhook subscription WH123 to also receive incident.acknowledged events"
+        ),
+        expected_tool_calls=[
+            MockToolCall(
+                name="get_webhook_subscription",
+                parameters={"subscription_id": "WH123"},
+            ),
+            MockToolCall(
+                name="update_webhook_subscription",
+                parameters={
+                    "subscription_id": "WH123",
+                    "webhook_data": {
+                        "events": [
+                            "incident.triggered",
+                            "incident.acknowledged",
+                            "incident.resolved",
+                        ]
+                    },
+                },
+            ),
+        ],
+        description="Update webhook subscription event types",
+    ),
+    # delete_webhook_subscription
+    WebhooksCompetencyTest(
+        query="Delete webhook subscription WH123",
+        expected_tool_calls=[
+            MockToolCall(
+                name="delete_webhook_subscription",
+                parameters={"subscription_id": "WH123"},
+            )
+        ],
+        description="Delete a webhook subscription",
+    ),
+    # list_extension_schemas
+    WebhooksCompetencyTest(
+        query="What extension schemas are available in PagerDuty?",
+        expected_tool_calls=[
+            MockToolCall(name="list_extension_schemas", parameters={})
+        ],
+        description="List all available extension schemas",
+    ),
+    # get_extension_schema
+    WebhooksCompetencyTest(
+        query="Get details for extension schema PJFWPEP",
+        expected_tool_calls=[
+            MockToolCall(
+                name="get_extension_schema",
+                parameters={"schema_id": "PJFWPEP"},
+            )
+        ],
+        description="Get a specific extension schema by ID",
+    ),
+]

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -1,0 +1,288 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from pagerduty_mcp.models.webhooks import (
+    ExtensionSchema,
+    WebhookCreate,
+    WebhookDeliveryMethod,
+    WebhookFilter,
+    WebhookSubscription,
+    WebhookUpdate,
+)
+from pagerduty_mcp.tools.webhooks import (
+    create_webhook_subscription,
+    delete_webhook_subscription,
+    get_extension_schema,
+    get_webhook_subscription,
+    list_extension_schemas,
+    list_webhook_subscriptions,
+    update_webhook_subscription,
+)
+
+
+class TestWebhookModels(unittest.TestCase):
+    """Test webhook model validation."""
+
+    def test_webhook_subscription_model(self):
+        """Test WebhookSubscription can be constructed from API response."""
+        data = {
+            "id": "WH123",
+            "type": "webhook_subscription",
+            "active": True,
+            "description": "Test webhook",
+            "delivery_method": {"type": "http_delivery_method", "url": "https://example.com/hook"},
+            "events": ["incident.triggered", "incident.resolved"],
+            "filter": {"type": "account_reference"},
+        }
+        sub = WebhookSubscription(**data)
+        self.assertEqual(sub.id, "WH123")
+        self.assertEqual(sub.active, True)
+        self.assertIsInstance(sub.delivery_method, WebhookDeliveryMethod)
+        self.assertIsInstance(sub.filter, WebhookFilter)
+
+    def test_webhook_create_serialization(self):
+        """Test WebhookCreate serializes correctly for API call."""
+        create = WebhookCreate(
+            delivery_method=WebhookDeliveryMethod(
+                type="http_delivery_method",
+                url="https://example.com/hook",
+            ),
+            events=["incident.triggered"],
+            filter=WebhookFilter(type="account_reference"),
+            description="My webhook",
+        )
+        dumped = create.model_dump(exclude_none=True)
+        self.assertEqual(dumped["delivery_method"]["url"], "https://example.com/hook")
+        self.assertEqual(dumped["events"], ["incident.triggered"])
+        self.assertEqual(dumped["filter"]["type"], "account_reference")
+
+    def test_webhook_filter_types(self):
+        """Test all three WebhookFilter type values are accepted."""
+        for ftype in ("account_reference", "service_reference", "team_reference"):
+            f = WebhookFilter(type=ftype)
+            self.assertEqual(f.type, ftype)
+
+    def test_webhook_update_partial(self):
+        """Test WebhookUpdate with only some fields set."""
+        update = WebhookUpdate(active=False)
+        dumped = update.model_dump(exclude_none=True)
+        self.assertEqual(dumped["active"], False)
+        self.assertNotIn("events", dumped)
+
+    def test_extension_schema_model(self):
+        """Test ExtensionSchema construction."""
+        schema = ExtensionSchema(
+            id="PJFWPEP",
+            type="extension_schema",
+            label="Generic Webhook",
+            key="generic_webhook",
+            description="Send events to a generic webhook endpoint",
+        )
+        self.assertEqual(schema.id, "PJFWPEP")
+        self.assertEqual(schema.label, "Generic Webhook")
+
+
+class TestWebhookSubscriptionTools(unittest.TestCase):
+    """Test webhook subscription tool functions."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.sample_subscription = {
+            "id": "WH123",
+            "type": "webhook_subscription",
+            "active": True,
+            "description": "Incident alerts",
+            "delivery_method": {
+                "id": "DM123",
+                "type": "http_delivery_method",
+                "url": "https://example.com/hook",
+            },
+            "events": ["incident.triggered", "incident.resolved"],
+            "filter": {"type": "account_reference"},
+        }
+        cls.mock_client = MagicMock()
+
+    def setUp(self):
+        self.mock_client.reset_mock()
+        self.mock_client.rget.side_effect = None
+        self.mock_client.rpost.side_effect = None
+        self.mock_client.rput.side_effect = None
+        self.mock_client.rdelete.side_effect = None
+
+    @patch("pagerduty_mcp.tools.webhooks.paginate")
+    @patch("pagerduty_mcp.tools.webhooks.get_client")
+    def test_list_webhook_subscriptions_no_filters(self, mock_get_client, mock_paginate):
+        """Test listing webhook subscriptions without filters."""
+        mock_get_client.return_value = self.mock_client
+        mock_paginate.return_value = [self.sample_subscription]
+
+        result = list_webhook_subscriptions()
+
+        mock_paginate.assert_called_once_with(
+            client=self.mock_client, entity="webhook_subscriptions", params={}
+        )
+        self.assertEqual(len(result.response), 1)
+        self.assertIsInstance(result.response[0], WebhookSubscription)
+        self.assertEqual(result.response[0].id, "WH123")
+
+    @patch("pagerduty_mcp.tools.webhooks.paginate")
+    @patch("pagerduty_mcp.tools.webhooks.get_client")
+    def test_list_webhook_subscriptions_with_filter_type(self, mock_get_client, mock_paginate):
+        """Test listing webhook subscriptions filtered by type."""
+        mock_get_client.return_value = self.mock_client
+        mock_paginate.return_value = [self.sample_subscription]
+
+        list_webhook_subscriptions(filter_type="account_reference", limit=25)
+
+        mock_paginate.assert_called_once_with(
+            client=self.mock_client,
+            entity="webhook_subscriptions",
+            params={"filter_type": "account_reference", "limit": 25},
+        )
+
+    @patch("pagerduty_mcp.tools.webhooks.get_client")
+    def test_get_webhook_subscription_wrapped(self, mock_get_client):
+        """Test get_webhook_subscription with wrapped response."""
+        mock_get_client.return_value = self.mock_client
+        self.mock_client.rget.return_value = {"webhook_subscription": self.sample_subscription}
+
+        result = get_webhook_subscription("WH123")
+
+        self.mock_client.rget.assert_called_once_with("/webhook_subscriptions/WH123")
+        self.assertIsInstance(result, WebhookSubscription)
+        self.assertEqual(result.id, "WH123")
+
+    @patch("pagerduty_mcp.tools.webhooks.get_client")
+    def test_get_webhook_subscription_unwrapped(self, mock_get_client):
+        """Test get_webhook_subscription with SDK-unwrapped response."""
+        mock_get_client.return_value = self.mock_client
+        self.mock_client.rget.return_value = self.sample_subscription
+
+        result = get_webhook_subscription("WH123")
+
+        self.assertIsInstance(result, WebhookSubscription)
+        self.assertEqual(result.id, "WH123")
+
+    @patch("pagerduty_mcp.tools.webhooks.get_client")
+    def test_create_webhook_subscription(self, mock_get_client):
+        """Test create_webhook_subscription posts correct payload."""
+        mock_get_client.return_value = self.mock_client
+        # Simulate response with signing secret (only on create)
+        response_with_secret = dict(self.sample_subscription)
+        response_with_secret["delivery_method"] = dict(self.sample_subscription["delivery_method"])
+        response_with_secret["delivery_method"]["secret"] = "s3cr3t_signing_key"
+        self.mock_client.rpost.return_value = {"webhook_subscription": response_with_secret}
+
+        webhook_data = WebhookCreate(
+            delivery_method=WebhookDeliveryMethod(
+                type="http_delivery_method",
+                url="https://example.com/hook",
+            ),
+            events=["incident.triggered", "incident.resolved"],
+            filter=WebhookFilter(type="account_reference"),
+            description="Incident alerts",
+        )
+
+        result = create_webhook_subscription(webhook_data)
+
+        self.mock_client.rpost.assert_called_once_with(
+            "/webhook_subscriptions",
+            json={"webhook_subscription": webhook_data.model_dump(exclude_none=True)},
+        )
+        self.assertIsInstance(result, WebhookSubscription)
+        self.assertEqual(result.id, "WH123")
+        # Verify the signing secret is surfaced in the response
+        self.assertEqual(result.delivery_method.secret, "s3cr3t_signing_key")
+
+    @patch("pagerduty_mcp.tools.webhooks.get_client")
+    def test_update_webhook_subscription(self, mock_get_client):
+        """Test update_webhook_subscription puts correct payload."""
+        mock_get_client.return_value = self.mock_client
+        updated = dict(self.sample_subscription)
+        updated["active"] = False
+        self.mock_client.rput.return_value = {"webhook_subscription": updated}
+
+        update_data = WebhookUpdate(active=False)
+
+        result = update_webhook_subscription("WH123", update_data)
+
+        self.mock_client.rput.assert_called_once_with(
+            "/webhook_subscriptions/WH123",
+            json={"webhook_subscription": update_data.model_dump(exclude_none=True)},
+        )
+        self.assertIsInstance(result, WebhookSubscription)
+
+    @patch("pagerduty_mcp.tools.webhooks.get_client")
+    def test_delete_webhook_subscription(self, mock_get_client):
+        """Test delete_webhook_subscription calls rdelete with correct path."""
+        mock_get_client.return_value = self.mock_client
+        self.mock_client.rdelete.return_value = None
+
+        delete_webhook_subscription("WH123")
+
+        self.mock_client.rdelete.assert_called_once_with("/webhook_subscriptions/WH123")
+
+
+class TestExtensionSchemaTools(unittest.TestCase):
+    """Test extension schema tool functions."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.sample_schema = {
+            "id": "PJFWPEP",
+            "type": "extension_schema",
+            "summary": "Generic Webhook",
+            "label": "Generic Webhook",
+            "key": "generic_webhook",
+            "description": "Send events to a webhook endpoint",
+            "guide_url": "https://developer.pagerduty.com",
+        }
+        cls.mock_client = MagicMock()
+
+    def setUp(self):
+        self.mock_client.reset_mock()
+        self.mock_client.rget.side_effect = None
+
+    @patch("pagerduty_mcp.tools.webhooks.paginate")
+    @patch("pagerduty_mcp.tools.webhooks.get_client")
+    def test_list_extension_schemas(self, mock_get_client, mock_paginate):
+        """Test listing extension schemas."""
+        mock_get_client.return_value = self.mock_client
+        mock_paginate.return_value = [self.sample_schema]
+
+        result = list_extension_schemas()
+
+        mock_paginate.assert_called_once_with(
+            client=self.mock_client, entity="extension_schemas", params={}
+        )
+        self.assertEqual(len(result.response), 1)
+        self.assertIsInstance(result.response[0], ExtensionSchema)
+        self.assertEqual(result.response[0].id, "PJFWPEP")
+        self.assertEqual(result.response[0].label, "Generic Webhook")
+
+    @patch("pagerduty_mcp.tools.webhooks.get_client")
+    def test_get_extension_schema_wrapped(self, mock_get_client):
+        """Test get_extension_schema with wrapped response."""
+        mock_get_client.return_value = self.mock_client
+        self.mock_client.rget.return_value = {"extension_schema": self.sample_schema}
+
+        result = get_extension_schema("PJFWPEP")
+
+        self.mock_client.rget.assert_called_once_with("/extension_schemas/PJFWPEP")
+        self.assertIsInstance(result, ExtensionSchema)
+        self.assertEqual(result.id, "PJFWPEP")
+
+    @patch("pagerduty_mcp.tools.webhooks.get_client")
+    def test_get_extension_schema_unwrapped(self, mock_get_client):
+        """Test get_extension_schema with SDK-unwrapped response."""
+        mock_get_client.return_value = self.mock_client
+        self.mock_client.rget.return_value = self.sample_schema
+
+        result = get_extension_schema("PJFWPEP")
+
+        self.assertIsInstance(result, ExtensionSchema)
+        self.assertEqual(result.key, "generic_webhook")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -119,7 +119,7 @@ class TestWebhookSubscriptionTools(unittest.TestCase):
         result = list_webhook_subscriptions()
 
         mock_paginate.assert_called_once_with(
-            client=self.mock_client, entity="webhook_subscriptions", params={}
+            client=self.mock_client, entity="webhook_subscriptions", params={}, maximum_records=1000
         )
         self.assertEqual(len(result.response), 1)
         self.assertIsInstance(result.response[0], WebhookSubscription)
@@ -138,6 +138,7 @@ class TestWebhookSubscriptionTools(unittest.TestCase):
             client=self.mock_client,
             entity="webhook_subscriptions",
             params={"filter_type": "account_reference", "limit": 25},
+            maximum_records=25,
         )
 
     @patch("pagerduty_mcp.tools.webhooks.get_client")
@@ -195,6 +196,26 @@ class TestWebhookSubscriptionTools(unittest.TestCase):
         self.assertEqual(result.delivery_method.secret, "s3cr3t_signing_key")
 
     @patch("pagerduty_mcp.tools.webhooks.get_client")
+    def test_create_webhook_subscription_unwrapped(self, mock_get_client):
+        """Test create_webhook_subscription handles SDK-unwrapped response."""
+        mock_get_client.return_value = self.mock_client
+        self.mock_client.rpost.return_value = self.sample_subscription
+
+        webhook_data = WebhookCreate(
+            delivery_method=WebhookDeliveryMethod(
+                type="http_delivery_method",
+                url="https://example.com/hook",
+            ),
+            events=["incident.triggered"],
+            filter=WebhookFilter(type="account_reference"),
+        )
+
+        result = create_webhook_subscription(webhook_data)
+
+        self.assertIsInstance(result, WebhookSubscription)
+        self.assertEqual(result.id, "WH123")
+
+    @patch("pagerduty_mcp.tools.webhooks.get_client")
     def test_update_webhook_subscription(self, mock_get_client):
         """Test update_webhook_subscription puts correct payload."""
         mock_get_client.return_value = self.mock_client
@@ -211,6 +232,21 @@ class TestWebhookSubscriptionTools(unittest.TestCase):
             json={"webhook_subscription": update_data.model_dump(exclude_none=True)},
         )
         self.assertIsInstance(result, WebhookSubscription)
+
+    @patch("pagerduty_mcp.tools.webhooks.get_client")
+    def test_update_webhook_subscription_unwrapped(self, mock_get_client):
+        """Test update_webhook_subscription handles SDK-unwrapped response."""
+        mock_get_client.return_value = self.mock_client
+        updated = dict(self.sample_subscription)
+        updated["active"] = False
+        self.mock_client.rput.return_value = updated
+
+        update_data = WebhookUpdate(active=False)
+
+        result = update_webhook_subscription("WH123", update_data)
+
+        self.assertIsInstance(result, WebhookSubscription)
+        self.assertEqual(result.active, False)
 
     @patch("pagerduty_mcp.tools.webhooks.get_client")
     def test_delete_webhook_subscription(self, mock_get_client):
@@ -253,7 +289,7 @@ class TestExtensionSchemaTools(unittest.TestCase):
         result = list_extension_schemas()
 
         mock_paginate.assert_called_once_with(
-            client=self.mock_client, entity="extension_schemas", params={}
+            client=self.mock_client, entity="extension_schemas", params={}, maximum_records=1000
         )
         self.assertEqual(len(result.response), 1)
         self.assertIsInstance(result.response[0], ExtensionSchema)


### PR DESCRIPTION
## Summary

- Adds **7 new tools** for PagerDuty webhook management
- Signing secret returned by `create_webhook_subscription` is surfaced in the response model — not logged anywhere

## New tools

| Tool | Type | Description |
|---|---|---|
| `list_webhook_subscriptions` | read | List subscriptions with optional `filter_type`/`limit` |
| `get_webhook_subscription` | read | Get a subscription by ID |
| `list_extension_schemas` | read | List available extension vendor schemas |
| `get_extension_schema` | read | Get an extension schema by ID |
| `create_webhook_subscription` | write | Create subscription (one-time signing secret in response) |
| `update_webhook_subscription` | write | Update an existing subscription |
| `delete_webhook_subscription` | write | Delete a subscription |

## Security note

The webhook signing secret (`delivery_method.secret`) is **only returned on the initial create response** per the PagerDuty API spec. It is surfaced through `WebhookSubscription.delivery_method.secret` in the response — no tool or model logs it.

## Unit tests

**15/15 passed** (`tests/test_webhooks.py`)

| Test class | Tests | Coverage |
|---|---|---|
| `TestWebhookModels` | 5 | Model validation, serialization, filter types, partial updates, ExtensionSchema |
| `TestWebhookSubscriptionTools` | 7 | All 7 tool functions, wrapped/unwrapped response handling, signing secret surfacing |
| `TestExtensionSchemaTools` | 3 | list, get (wrapped), get (unwrapped) |

## LLM eval results

**11/11 passed** — `claude-sonnet-4-6` via AWS Bedrock (`us.anthropic.claude-sonnet-4-6`)

| Query | Tool called | Pass |
|---|---|---|
| "Show me all webhook subscriptions" | `list_webhook_subscriptions {}` | ✅ |
| "List webhook subscriptions scoped to services" | `list_webhook_subscriptions {filter_type: service_reference}` | ✅ |
| "Show me the first 5 account-level webhook subscriptions" | `list_webhook_subscriptions {filter_type: account_reference, limit: 5}` | ✅ |
| "Get details for webhook subscription WH123" | `get_webhook_subscription {subscription_id: WH123}` | ✅ |
| "Create account-wide webhook for incident.triggered + incident.resolved" | `create_webhook_subscription` with account_reference filter | ✅ |
| "Create webhook for service SVC123" | `create_webhook_subscription` with service_reference filter | ✅ |
| "Disable webhook subscription WH123" | `update_webhook_subscription {active: false}` | ✅ |
| "Update WH123 to also receive incident.acknowledged" | `get_webhook_subscription` → `update_webhook_subscription` (2-step) | ✅ |
| "Delete webhook subscription WH123" | `delete_webhook_subscription {subscription_id: WH123}` | ✅ |
| "What extension schemas are available?" | `list_extension_schemas {}` | ✅ |
| "Get details for extension schema PJFWPEP" | `get_extension_schema {schema_id: PJFWPEP}` | ✅ |

Notable: the model correctly performs a **2-step get→update** for additive event changes, fetching current state before merging the new event type.

## Test plan

- [x] `uv run python -m pytest tests/test_webhooks.py -v` — 15/15 passed
- [x] LLM evals — 11/11 passed via Bedrock (claude-sonnet-4-6)
- [x] `uv run ruff check pagerduty_mcp/` — clean
- [ ] Manually verify `create_webhook_subscription` returns `delivery_method.secret` and it is not written to any log