### PR TITLE
feat: expose time_zone and job_title on User model

### DIFF
--- a/pagerduty_mcp/models/users.py
+++ b/pagerduty_mcp/models/users.py
@@ -29,6 +29,14 @@ class User(BaseModel):
     name: str = Field(description="The name of the user")
     email: str = Field(description="The email of the user")
     role: UserRole = Field(description="The user role in PagerDuty (admin, limited_user, observer, etc.)")
+    job_title: str | None = Field(
+        default=None,
+        description="The user's job title",
+    )
+    time_zone: str | None = Field(
+        default=None,
+        description="The user's preferred time zone as an IANA name (e.g., 'America/New_York')",
+    )
     teams: list[TeamReference] = Field(description="The list of teams to which the user belongs")
 
     @computed_field

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -19,6 +19,8 @@ class TestUserTools(unittest.TestCase):
             "name": "John Doe",
             "email": "john.doe@example.com",
             "role": "user",
+            "job_title": "Senior Engineer",
+            "time_zone": "America/New_York",
             "teams": [
                 {"id": "TEAM1", "summary": "Engineering Team", "type": "team_reference"},
                 {"id": "TEAM2", "summary": "DevOps Team", "type": "team_reference"},
@@ -32,6 +34,8 @@ class TestUserTools(unittest.TestCase):
                 "name": "John Doe",
                 "email": "john.doe@example.com",
                 "role": "user",
+                "job_title": "Senior Engineer",
+                "time_zone": "America/New_York",
                 "teams": [{"id": "TEAM1", "summary": "Engineering Team", "type": "team_reference"}],
             },
             {
@@ -40,6 +44,8 @@ class TestUserTools(unittest.TestCase):
                 "name": "Jane Smith",
                 "email": "jane.smith@example.com",
                 "role": "admin",
+                "job_title": "Engineering Manager",
+                "time_zone": "Europe/London",
                 "teams": [{"id": "TEAM2", "summary": "DevOps Team", "type": "team_reference"}],
             },
         ]
@@ -71,6 +77,8 @@ class TestUserTools(unittest.TestCase):
         self.assertEqual(result.email, "john.doe@example.com")
         self.assertEqual(result.role, "user")
         self.assertEqual(result.summary, "John Doe - Senior Engineer")
+        self.assertEqual(result.job_title, "Senior Engineer")
+        self.assertEqual(result.time_zone, "America/New_York")
         self.assertEqual(len(result.teams), 2)
         self.assertIsInstance(result.teams[0], TeamReference)
         self.assertEqual(result.teams[0].id, "TEAM1")
@@ -267,6 +275,27 @@ class TestUserTools(unittest.TestCase):
         user = User(name="Test User", email="test@example.com", role="user", teams=[])
 
         self.assertEqual(user.type, "user")
+
+    def test_user_model_job_title_and_time_zone_default_none(self):
+        """Test that job_title and time_zone default to None when omitted (backwards compat)."""
+        user = User(name="Test User", email="test@example.com", role="user", teams=[])
+
+        self.assertIsNone(user.job_title)
+        self.assertIsNone(user.time_zone)
+
+    def test_user_model_job_title_and_time_zone_populated(self):
+        """Test that job_title and time_zone round-trip from the API payload."""
+        user = User(
+            name="Test User",
+            email="test@example.com",
+            role="user",
+            teams=[],
+            job_title="Staff Engineer",
+            time_zone="Europe/Lisbon",
+        )
+
+        self.assertEqual(user.job_title, "Staff Engineer")
+        self.assertEqual(user.time_zone, "Europe/Lisbon")
 
     @patch("pagerduty_mcp.tools.users.get_client")
     def test_list_users_single_team_filter(self, mock_get_client):


### PR DESCRIPTION
## What

Adds two optional fields to the `User` Pydantic model:

- `time_zone: str | None` — the user's preferred IANA timezone (e.g. `America/New_York`, `Europe/Lisbon`)
- `job_title: str | None` — the user's job title

Both are populated by the PagerDuty REST API on `/users` and `/users/{id}` responses but are currently dropped by the model during `model_validate`/`User(**user)` because they aren't declared.

## Why

Without `time_zone` exposed, downstream tools can't correctly bucket per-user activity into off-hours / sleep-hours windows — they have to approximate against a single team timezone, which is biased for distributed teams (e.g. a Lisbon-based engineer's "sleep window" doesn't overlap with PT at all).

`job_title` is useful for grouping or excluding managers / specific roles in team-level analyses where role-based weighting matters.

Both fields are `Optional[str]` with `default=None`, so any caller that doesn't pass them (existing tests, mock data, partial payloads) continues to work unchanged.

## Tests

- Updated the shared fixtures in `tests/test_users.py` to include realistic values for both fields
- Added assertions in `test_get_user_data_success` to verify they round-trip
- Added `test_user_model_job_title_and_time_zone_default_none` to guard the backwards-compatible default
- Added `test_user_model_job_title_and_time_zone_populated` to confirm explicit construction works

Full suite: `355 passed in 0.34s`. `ruff check` and `ruff format --check` both clean.