### PR TITLE
feat: add on-call compensation report tool

### DIFF
--- a/pagerduty_mcp/tools/__init__.py
+++ b/pagerduty_mcp/tools/__init__.py
@@ -54,6 +54,7 @@ from .log_entries import (
     get_log_entry,
     list_log_entries,
 )
+from .oncall_compensation import get_oncall_compensation_report
 from .oncalls import list_oncalls
 from .schedules import (
     create_schedule,
@@ -130,6 +131,8 @@ read_tools = [
     list_schedule_users,
     # On-calls
     list_oncalls,
+    # On-Call Compensation
+    get_oncall_compensation_report,
     # Log Entries
     list_log_entries,
     get_log_entry,

--- a/pagerduty_mcp/tools/oncall_compensation.py
+++ b/pagerduty_mcp/tools/oncall_compensation.py
@@ -1,0 +1,885 @@
+"""
+Agentic On-Call Compensation Report tool.
+
+Replicates the full computation pipeline of the UI app server-side so agents
+can query, filter, and reason over the results without opening a browser.
+
+Data sources (same as the UI):
+  - /analytics/metrics/responders/teams  — oncall hours + interruption breakdown
+  - list_oncalls                          — raw shift windows for outside-hours math
+  - list_incidents                        — per-user urgency counts
+  - list_teams / list_users              — name resolution + timezone
+  - list_escalation_policies             — EP filter support
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone as dt_timezone
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from pagerduty_mcp.client import get_client
+from pagerduty_mcp.utils import paginate
+
+
+# ── Compliance templates ──────────────────────────────────────────────────────
+
+COMPLIANCE_TEMPLATES: dict[str, dict] = {
+    # EU Working Time Directive: 192h/4-week cap (48h/week avg), 11h daily rest between periods
+    # (min_rest_hours=11 corresponds to the WTD's 11-hour daily rest requirement),
+    # max 6 consecutive days, and a configurable max_consecutive_hours limit (not a specific WTD requirement).
+    "emea": dict(hours_cap=192, outside_hours_cap=80, max_consecutive_days=6,
+                 max_consecutive_hours=48, min_rest_hours=11),
+    # US: 40h/week × 4 weeks, 8h rest, max 7 consecutive days
+    "us": dict(hours_cap=160, outside_hours_cap=60, max_consecutive_days=7,
+               max_consecutive_hours=72, min_rest_hours=8),
+    # No compliance limits (default) — use for pay/burden reporting
+    "none": dict(hours_cap=0, outside_hours_cap=0, max_consecutive_days=0,
+                 max_consecutive_hours=0, min_rest_hours=0),
+}
+
+
+# ── Request model ────────────────────────────────────────────────────────────
+
+class OncallCompensationRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    since: str = Field(
+        description="Start of reporting period in ISO 8601 format (e.g. '2026-01-01T00:00:00Z'). "
+                    "Inclusive. Maximum recommended range: 90 days."
+    )
+    until: str = Field(
+        description="End of reporting period in ISO 8601 format (e.g. '2026-01-31T23:59:59Z'). "
+                    "Exclusive."
+    )
+    team_ids: list[str] | None = Field(
+        default=None,
+        description="Restrict report to specific team IDs. Leave null for all teams."
+    )
+    escalation_policy_id: str | None = Field(
+        default=None,
+        description="Restrict report to users in a specific escalation policy."
+    )
+    # Compliance / limits template
+    compliance_template: str = Field(
+        default="none",
+        description=(
+            "Pre-built compliance rule set. Determines the thresholds used in "
+            "compliance_flags on each user. Options:\n"
+            "  'emea'  — EU Working Time Directive: 192h/period cap, 11h rest, max 6 consecutive days\n"
+            "  'us'    — US defaults: 160h/period cap, 8h rest, max 7 consecutive days\n"
+            "  'none'  — No compliance checks (default). Use when you only need burden/pay data.\n"
+            "Custom overrides: set hours_cap, outside_hours_cap, max_consecutive_days, "
+            "max_consecutive_hours, or min_rest_hours to non-zero values alongside any template."
+        )
+    )
+    # Custom compliance overrides (0 = inherit from template or disabled)
+    hours_cap: float = Field(
+        default=0.0, ge=0,
+        description="Override: max scheduled hours allowed per period. 0 = use template value."
+    )
+    outside_hours_cap: float = Field(
+        default=0.0, ge=0,
+        description="Override: max outside-business-hours allowed per period. 0 = use template value."
+    )
+    max_consecutive_days: int = Field(
+        default=0, ge=0,
+        description="Override: max consecutive calendar days on-call. 0 = use template value."
+    )
+    max_consecutive_hours: float = Field(
+        default=0.0, ge=0,
+        description="Override: max single unbroken on-call shift in hours. 0 = use template value."
+    )
+    min_rest_hours: float = Field(
+        default=0.0, ge=0,
+        description="Override: minimum hours of rest required between consecutive shifts. 0 = use template value."
+    )
+    # Business hours config
+    biz_start_hour: int = Field(
+        default=9, ge=0, le=23,
+        description="Local hour when business hours begin (inclusive). Default 9 = 09:00."
+    )
+    biz_end_hour: int = Field(
+        default=18, ge=1, le=24,
+        description="Local hour when business hours end (exclusive). Default 18 = 18:00."
+    )
+    timezone: str = Field(
+        default="UTC",
+        description="IANA timezone for business-hours and weekend classification "
+                    "(e.g. 'America/New_York', 'Europe/London'). Default UTC."
+    )
+    work_days: list[int] = Field(
+        default=[1, 2, 3, 4, 5],
+        description="ISO weekday numbers that are business days. 1=Monday … 7=Sunday. "
+                    "Default Mon–Fri."
+    )
+    holidays: list[str] = Field(
+        default=[],
+        description="List of holiday dates as 'YYYY-MM-DD' strings in the configured timezone. "
+                    "Shifts on these dates count as holiday hours."
+    )
+    # Pay config
+    l1_rate_per_hour: float = Field(
+        default=0.0, ge=0,
+        description="Hourly pay rate for L1 on-call during business hours. "
+                    "Set to 0 to skip pay estimation."
+    )
+    l2_plus_rate_per_hour: float = Field(
+        default=0.0, ge=0,
+        description="Hourly pay rate for L2+ on-call shifts. Set to 0 to skip."
+    )
+    off_hours_multiplier: float = Field(
+        default=1.5, ge=1,
+        description="Multiplier applied to l1_rate_per_hour for weekday off-hours shifts."
+    )
+    weekend_multiplier: float = Field(
+        default=2.0, ge=1,
+        description="Multiplier applied to l1_rate_per_hour for weekend shifts."
+    )
+    holiday_multiplier: float = Field(
+        default=2.5, ge=1,
+        description="Multiplier applied to l1_rate_per_hour for holiday shifts."
+    )
+    # Output control
+    include_incidents: bool = Field(
+        default=False,
+        description="Include per-user incident list in the response. "
+                    "Adds detail but increases response size significantly."
+    )
+    include_directly_added: bool = Field(
+        default=False,
+        description="Include on-call entries that were added directly to an escalation policy "
+                    "layer (not backed by a schedule). Default False."
+    )
+    min_scheduled_hours: float = Field(
+        default=0.0,
+        ge=0,
+        description="Exclude users with fewer scheduled hours than this threshold. "
+                    "Useful to filter out noise from users briefly added to policies."
+    )
+    forward: bool = Field(
+        default=False,
+        description=(
+            "If True, run in forward-estimation (projection) mode. Skips the Analytics API "
+            "(which has no data for future dates). Scheduled hours are derived entirely from "
+            "list_oncalls shift windows. Interruptions, incident counts, and MTTA will be 0. "
+            "Use for projecting this month's on-call burden and compensation cost before the "
+            "period ends. The response includes is_forward=true to signal projection mode."
+        )
+    )
+
+
+# ── Output models ─────────────────────────────────────────────────────────────
+
+class UserCompensationSummary(BaseModel):
+    user_id: str
+    user_name: str
+    user_timezone: str | None = None
+    team_names: list[str]
+
+    # On-call hours (from Analytics — authoritative, deduped)
+    scheduled_hours: float
+    scheduled_hours_l1: float
+    scheduled_hours_l2_plus: float
+
+    # Interruption breakdown (PagerDuty native categories, from Analytics)
+    total_interruptions: int
+    business_hour_interruptions: int
+    off_hour_interruptions: int
+    sleep_hour_interruptions: int
+    interruption_rate: float  # interruptions per scheduled hour
+    mean_time_to_ack_seconds: float
+
+    # Incident counts
+    incident_count: int
+    incident_hours: float
+    high_urgency_incidents: int
+    low_urgency_incidents: int
+
+    # Direct EP targets — escalation policy layers where this user is added with no schedule
+    # These have no time bounds so hours cannot be calculated; only count is meaningful
+    direct_ep_count: int = 0
+
+    # Outside-hours breakdown (computed from raw shifts + biz-hours config)
+    outside_hours: float       # total off-hours: weekday OOH + weekends + holidays
+    weekend_hours: float
+    holiday_hours: float
+    weeknight_hours: float     # weekday outside-hours only
+    weekend_period_count: int  # distinct weekends touched
+    holiday_count: int         # distinct holidays touched
+    unique_ooh_periods: int    # total distinct outside-hours segments
+
+    # Fatigue / compliance signals
+    max_consecutive_on_call_hours: float
+    max_consecutive_on_call_days: int
+    min_rest_hours: float      # shortest gap between consecutive shifts; 999 = no gap
+
+    # Estimated pay (0 if l1_rate_per_hour=0)
+    estimated_pay: float
+
+    # Compliance flags (populated when compliance_template != 'none' or custom limits set)
+    compliance_status: str = "ok"         # "ok" | "near" | "over"
+    compliance_flags: list[str] = Field(  # human-readable list of triggered limits
+        default_factory=list,
+        description="List of triggered compliance rules, e.g. 'hours_cap exceeded (192h limit)'."
+    )
+
+
+class OncallCompensationReport(BaseModel):
+    since: str
+    until: str
+    timezone: str
+    compliance_template: str
+    generated_at: str
+    total_users: int
+    total_scheduled_hours: float
+    total_outside_hours: float
+    total_estimated_pay: float
+    compliance_violations: int  # users with status "over"
+    compliance_near_limit: int  # users with status "near"
+    is_forward: bool = False    # True when run in projection mode (future date range)
+    users: list[UserCompensationSummary]
+    # Summary by team
+    team_summary: list[dict[str, Any]]
+
+
+# ── Business-hours computation (pure Python port of businessHours.ts) ─────────
+
+def _get_tz_parts(ts_ms: float, tz: str) -> dict[str, Any]:
+    """Return year/month/day/hour/weekday for a UTC timestamp in given IANA tz."""
+    from zoneinfo import ZoneInfo
+    dt = datetime.fromtimestamp(ts_ms / 1000.0, tz=ZoneInfo(tz))
+    return {
+        "year": dt.year, "month": dt.month, "day": dt.day,
+        "hour": dt.hour, "minute": dt.minute,
+        "weekday": dt.isoweekday(),  # 1=Mon … 7=Sun
+        "date_str": dt.strftime("%Y-%m-%d"),
+    }
+
+
+def _midnight_ms(date_str: str, tz: str) -> float:
+    """UTC milliseconds for local midnight on date_str in tz."""
+    from zoneinfo import ZoneInfo
+    y, m, d = (int(x) for x in date_str.split("-"))
+    dt = datetime(y, m, d, 0, 0, tzinfo=ZoneInfo(tz))
+    return dt.timestamp() * 1000.0
+
+
+def _days_in_range(start_ms: float, end_ms: float, tz: str) -> list[str]:
+    """All local date strings 'YYYY-MM-DD' overlapping [start_ms, end_ms)."""
+    seen: set[str] = set()
+    result: list[str] = []
+    t = start_ms
+    step = 6 * 3_600_000  # 6 hours
+    while t < end_ms:
+        ds = _get_tz_parts(t, tz)["date_str"]
+        if ds not in seen:
+            seen.add(ds)
+            result.append(ds)
+        t += step
+    last = _get_tz_parts(end_ms - 1, tz)["date_str"]
+    if last not in seen:
+        result.append(last)
+    return result
+
+
+def _dedup_shifts(shifts: list[dict]) -> list[dict]:
+    """Merge overlapping/adjacent shift windows and return sorted, non-overlapping list."""
+    if not shifts:
+        return []
+    sorted_s = sorted(shifts, key=lambda s: s["start"])
+    merged = [dict(sorted_s[0])]
+    for s in sorted_s[1:]:
+        if s["start"] <= merged[-1]["end"]:
+            merged[-1]["end"] = max(merged[-1]["end"], s["end"])
+        else:
+            merged.append(dict(s))
+    return merged
+
+
+def _compute_outside_hours(
+    shifts: list[dict],
+    biz_start: int,
+    biz_end: int,
+    work_days_iso: set[int],
+    holidays: set[str],
+    tz: str,
+) -> dict[str, float | int]:
+    """
+    Given merged shift windows, compute outside-hours breakdown.
+    shifts: list of {"start": ms, "end": ms}
+    Returns dict matching UserCompensationSummary outside-hours fields.
+    """
+    if not shifts:
+        return dict(
+            outside_hours=0.0, weekend_hours=0.0, holiday_hours=0.0, weeknight_hours=0.0,
+            weekend_period_count=0, holiday_count=0, unique_ooh_periods=0,
+            max_consecutive_on_call_hours=0.0, max_consecutive_on_call_days=0, min_rest_hours=999.0,
+        )
+
+    # Sort and merge shifts to avoid double-counting
+    sorted_shifts = sorted(shifts, key=lambda s: s["start"])
+    merged: list[dict] = [dict(sorted_shifts[0])]
+    for s in sorted_shifts[1:]:
+        if s["start"] <= merged[-1]["end"]:
+            merged[-1]["end"] = max(merged[-1]["end"], s["end"])
+        else:
+            merged.append(dict(s))
+
+    outside_segs: list[dict] = []  # {"start", "end", "category"}
+    covered_dates: set[str] = set()
+    weekend_iso_weeks: set[str] = set()
+    holiday_dates: set[str] = set()
+
+    for shift in merged:
+        s_start, s_end = shift["start"], shift["end"]
+        for date_str in _days_in_range(s_start, s_end, tz):
+            covered_dates.add(date_str)
+            parts = _get_tz_parts(_midnight_ms(date_str, tz) + 12 * 3_600_000, tz)  # noon
+            iso_wd = parts["weekday"]  # 1=Mon…7=Sun
+
+            # Weekend period tracking (distinct weeks with Sat/Sun coverage)
+            if iso_wd in (6, 7):  # Sat=6, Sun=7
+                from zoneinfo import ZoneInfo as _ZI
+                noon_ms = _midnight_ms(date_str, tz) + 12 * 3_600_000
+                noon_dt = datetime.fromtimestamp(noon_ms / 1000.0, tz=_ZI(tz))
+                # Use ISO week Monday as week key
+                week_start = noon_dt - __import__("datetime").timedelta(days=noon_dt.weekday())
+                weekend_iso_weeks.add(week_start.strftime("%Y-%m-%d"))
+
+            if date_str in holidays:
+                holiday_dates.add(date_str)
+
+            # Compute outside segments for this day
+            y, m, d = (int(x) for x in date_str.split("-"))
+            day_start_ms = _midnight_ms(date_str, tz)
+            next_date = (datetime(y, m, d, tzinfo=__import__("zoneinfo").ZoneInfo(tz))
+                         + __import__("datetime").timedelta(days=1))
+            day_end_ms = next_date.timestamp() * 1000.0
+
+            seg_start = max(day_start_ms, s_start)
+            seg_end = min(day_end_ms, s_end)
+            if seg_start >= seg_end:
+                continue
+
+            if date_str in holidays:
+                outside_segs.append({"start": seg_start, "end": seg_end, "cat": "holiday"})
+            elif iso_wd not in work_days_iso:
+                outside_segs.append({"start": seg_start, "end": seg_end, "cat": "weekend"})
+            else:
+                from zoneinfo import ZoneInfo as _ZI2
+                biz_s = datetime(y, m, d, biz_start, 0, tzinfo=_ZI2(tz)).timestamp() * 1000.0
+                biz_e = datetime(y, m, d, biz_end, 0, tzinfo=_ZI2(tz)).timestamp() * 1000.0
+                if seg_start < biz_s:
+                    outside_segs.append({"start": seg_start, "end": min(seg_end, biz_s), "cat": "weeknight"})
+                if seg_end > biz_e:
+                    outside_segs.append({"start": max(seg_start, biz_e), "end": seg_end, "cat": "weeknight"})
+
+    # Merge outside segments
+    def _merge_segs(segs: list[dict]) -> list[dict]:
+        if not segs:
+            return []
+        ss = sorted(segs, key=lambda x: x["start"])
+        out = [dict(ss[0])]
+        for seg in ss[1:]:
+            if seg["start"] <= out[-1]["end"]:
+                out[-1]["end"] = max(out[-1]["end"], seg["end"])
+            else:
+                out.append(dict(seg))
+        return out
+
+    merged_segs = _merge_segs(outside_segs)
+
+    h = lambda ms: round(ms / 3_600_000 * 100) / 100
+
+    weekend_ms = sum((s["end"] - s["start"]) for s in outside_segs if s["cat"] == "weekend")
+    holiday_ms = sum((s["end"] - s["start"]) for s in outside_segs if s["cat"] == "holiday")
+    weeknight_ms = sum((s["end"] - s["start"]) for s in outside_segs if s["cat"] == "weeknight")
+    total_outside_ms = sum((s["end"] - s["start"]) for s in merged_segs)
+
+    # Max consecutive on-call days
+    sorted_dates = sorted(covered_dates)
+    max_consec_days = 1 if sorted_dates else 0
+    consec = 1
+    for i in range(1, len(sorted_dates)):
+        prev = datetime.strptime(sorted_dates[i - 1], "%Y-%m-%d")
+        curr = datetime.strptime(sorted_dates[i], "%Y-%m-%d")
+        if (curr - prev).days == 1:
+            consec += 1
+            max_consec_days = max(max_consec_days, consec)
+        else:
+            consec = 1
+
+    max_shift_ms = max((s["end"] - s["start"]) for s in merged) if merged else 0
+
+    min_rest = 999.0
+    for i in range(1, len(merged)):
+        gap = (merged[i]["start"] - merged[i - 1]["end"]) / 3_600_000
+        min_rest = min(min_rest, gap)
+
+    return dict(
+        outside_hours=h(total_outside_ms),
+        weekend_hours=h(weekend_ms),
+        holiday_hours=h(holiday_ms),
+        weeknight_hours=h(weeknight_ms),
+        weekend_period_count=len(weekend_iso_weeks),
+        holiday_count=len(holiday_dates),
+        unique_ooh_periods=len(merged_segs),
+        max_consecutive_on_call_hours=h(max_shift_ms),
+        max_consecutive_on_call_days=max_consec_days,
+        min_rest_hours=round(min_rest * 100) / 100,
+    )
+
+
+# ── Main tool ─────────────────────────────────────────────────────────────────
+
+def get_oncall_compensation_report(
+    since: str,
+    until: str,
+    team_ids: list[str] | None = None,
+    escalation_policy_id: str | None = None,
+    compliance_template: str = "none",
+    hours_cap: float = 0.0,
+    outside_hours_cap: float = 0.0,
+    max_consecutive_days: int = 0,
+    max_consecutive_hours: float = 0.0,
+    min_rest_hours: float = 0.0,
+    biz_start_hour: int = 9,
+    biz_end_hour: int = 18,
+    timezone: str = "UTC",
+    work_days: list[int] | None = None,
+    holidays: list[str] | None = None,
+    l1_rate_per_hour: float = 0.0,
+    l2_plus_rate_per_hour: float = 0.0,
+    off_hours_multiplier: float = 1.5,
+    weekend_multiplier: float = 2.0,
+    holiday_multiplier: float = 2.5,
+    include_incidents: bool = False,
+    include_directly_added: bool = False,
+    min_scheduled_hours: float = 0.0,
+    forward: bool = False,
+) -> str:
+    """Generate an on-call compensation and fairness report for a date range.
+
+    Computes per-user oncall hours, outside-business-hours breakdown (weekends,
+    holidays, weeknight off-hours), interruption metrics, and optional pay
+    estimates. All computation is done server-side — no UI required.
+
+    Use this tool to:
+    - Answer "who was on call the most last month?"
+    - Estimate compensation costs for a team or escalation policy
+    - Identify responders approaching compliance limits (consecutive days,
+      insufficient rest, excessive outside-hours)
+    - Compare on-call burden distribution across team members
+    - Generate data for payroll exports or HR reporting
+    - Project forward: set forward=True with a future date range to estimate
+      this month's on-call cost before the period ends (scheduled shifts only)
+
+    Args:
+        since: Start of reporting period in ISO 8601 format (e.g. '2026-01-01T00:00:00Z').
+            Inclusive. Maximum recommended range: 90 days.
+        until: End of reporting period in ISO 8601 format (e.g. '2026-01-31T23:59:59Z').
+            Exclusive.
+        team_ids: Restrict report to specific team IDs. Leave null for all teams.
+        escalation_policy_id: Restrict report to users in a specific escalation policy.
+        compliance_template: Pre-built compliance rule set. Options: 'emea' (EU Working Time
+            Directive: 192h/period cap, 11h rest, max 6 consecutive days), 'us' (US defaults:
+            160h/period cap, 8h rest, max 7 consecutive days), 'none' (default, no checks).
+        hours_cap: Override max scheduled hours allowed per period. 0 = use template value.
+        outside_hours_cap: Override max outside-business-hours allowed per period. 0 = use template.
+        max_consecutive_days: Override max consecutive calendar days on-call. 0 = use template.
+        max_consecutive_hours: Override max single unbroken on-call shift in hours. 0 = use template.
+        min_rest_hours: Override minimum hours of rest required between consecutive shifts. 0 = use template.
+        biz_start_hour: Local hour when business hours begin (inclusive). Default 9 = 09:00.
+        biz_end_hour: Local hour when business hours end (exclusive). Default 18 = 18:00.
+        timezone: IANA timezone for business-hours and weekend classification
+            (e.g. 'America/New_York', 'Europe/London'). Default UTC.
+        work_days: ISO weekday numbers that are business days. 1=Monday ... 7=Sunday.
+            Default Mon-Fri ([1,2,3,4,5]).
+        holidays: List of holiday dates as 'YYYY-MM-DD' strings in the configured timezone.
+            Shifts on these dates count as holiday hours.
+        l1_rate_per_hour: Hourly pay rate for L1 on-call during business hours. 0 = skip pay estimation.
+        l2_plus_rate_per_hour: Hourly pay rate for L2+ on-call shifts. 0 = skip.
+        off_hours_multiplier: Multiplier applied to l1_rate_per_hour for weekday off-hours shifts.
+        weekend_multiplier: Multiplier applied to l1_rate_per_hour for weekend shifts.
+        holiday_multiplier: Multiplier applied to l1_rate_per_hour for holiday shifts.
+        include_incidents: Include per-user incident list in the response.
+        include_directly_added: Include on-call entries added directly to an escalation policy
+            layer (not backed by a schedule).
+        min_scheduled_hours: Exclude users with fewer scheduled hours than this threshold.
+        forward: If True, run in projection mode (future date range). Skips Analytics API.
+
+    Returns:
+        JSON string containing OncallCompensationReport with per-user summaries,
+        team rollups, and aggregate totals.
+    """
+    request = OncallCompensationRequest(
+        since=since,
+        until=until,
+        team_ids=team_ids,
+        escalation_policy_id=escalation_policy_id,
+        compliance_template=compliance_template,
+        hours_cap=hours_cap,
+        outside_hours_cap=outside_hours_cap,
+        max_consecutive_days=max_consecutive_days,
+        max_consecutive_hours=max_consecutive_hours,
+        min_rest_hours=min_rest_hours,
+        biz_start_hour=biz_start_hour,
+        biz_end_hour=biz_end_hour,
+        timezone=timezone,
+        work_days=work_days if work_days is not None else [1, 2, 3, 4, 5],
+        holidays=holidays if holidays is not None else [],
+        l1_rate_per_hour=l1_rate_per_hour,
+        l2_plus_rate_per_hour=l2_plus_rate_per_hour,
+        off_hours_multiplier=off_hours_multiplier,
+        weekend_multiplier=weekend_multiplier,
+        holiday_multiplier=holiday_multiplier,
+        include_incidents=include_incidents,
+        include_directly_added=include_directly_added,
+        min_scheduled_hours=min_scheduled_hours,
+        forward=forward,
+    )
+    client = get_client()
+    since = request.since
+    until = request.until
+    work_days_iso = set(request.work_days)
+    holidays_set = set(request.holidays)
+    tz = request.timezone
+
+    # ── Fetch raw data via the PD REST API ────────────────────────────────────
+    # In forward mode we skip Analytics (no data for future dates) and incidents.
+    # 1. Analytics responder metrics (historical only)
+    analytics_rows: list[Any] = []
+    if not request.forward:
+        analytics_body: dict[str, Any] = {
+            "filters": {"date_range_start": since, "date_range_end": until}
+        }
+        if request.team_ids:
+            analytics_body["filters"]["team_ids"] = request.team_ids
+
+        analytics_raw = client.rpost("/analytics/metrics/responders/teams", json=analytics_body)
+        if isinstance(analytics_raw, dict):
+            analytics_rows = analytics_raw.get("data", [])
+        elif isinstance(analytics_raw, list):
+            analytics_rows = analytics_raw
+
+    # 2. Raw on-call shifts (used in both modes)
+    oncalls_params: dict[str, Any] = {"since": since, "until": until, "earliest": "false", "limit": 100}
+    if request.escalation_policy_id:
+        oncalls_params["escalation_policy_ids[]"] = [request.escalation_policy_id]
+    oncalls_rows = paginate(client=client, entity="oncalls", params=oncalls_params)
+
+    # 3. Incidents (historical only — no future incidents exist)
+    incident_rows: list[Any] = []
+    if not request.forward:
+        incident_params: dict[str, Any] = {"since": since, "until": until, "limit": 100}
+        incident_rows = paginate(client=client, entity="incidents", params=incident_params)
+
+    # 4. Teams + users for name resolution
+    teams_rows = paginate(client=client, entity="teams", params={"limit": 100})
+    users_rows = paginate(client=client, entity="users", params={"limit": 100})
+
+    # ── Build lookup tables ───────────────────────────────────────────────────
+    teams_map: dict[str, str] = {t["id"]: (t.get("name") or t.get("summary") or "Unknown") for t in teams_rows}
+    user_tz_map: dict[str, str] = {u["id"]: u["time_zone"] for u in users_rows if u.get("time_zone")}
+
+    # ── Build per-user shifts from list_oncalls ───────────────────────────────
+    since_ms = datetime.fromisoformat(since.replace("Z", "+00:00")).timestamp() * 1000.0
+    until_ms = datetime.fromisoformat(until.replace("Z", "+00:00")).timestamp() * 1000.0
+
+    user_shifts: dict[str, list[dict]] = {}
+    user_direct_ep_ids: dict[str, set[str]] = {}  # direct EP memberships (no shift window)
+    ep_user_ids: set[str] = set()
+
+    for entry in oncalls_rows:
+        uid: str | None = (entry.get("user") or {}).get("id")
+        if not uid:
+            continue
+        has_schedule = bool((entry.get("schedule") or {}).get("id"))
+        raw_start = entry.get("start")
+        raw_end = entry.get("end")
+
+        # Direct EP layer entry: no schedule and no time bounds — always-on, not a shift window.
+        # Track the distinct EP count but never add these to user_shifts (would inflate hours).
+        if not has_schedule and not raw_start and not raw_end:
+            ep_id: str | None = (entry.get("escalation_policy") or {}).get("id")
+            if ep_id:
+                user_direct_ep_ids.setdefault(uid, set()).add(ep_id)
+            ep_user_ids.add(uid)
+            continue
+
+        if not request.include_directly_added and not has_schedule:
+            continue
+
+        start_ms = (datetime.fromisoformat(raw_start.replace("Z", "+00:00")).timestamp() * 1000.0
+                    if raw_start else since_ms)
+        end_ms = (datetime.fromisoformat(raw_end.replace("Z", "+00:00")).timestamp() * 1000.0
+                  if raw_end else until_ms)
+
+        start_ms = max(start_ms, since_ms)
+        end_ms = min(end_ms, until_ms)
+        if start_ms >= end_ms:
+            continue
+
+        ep_user_ids.add(uid)
+        escalation_level = entry.get("escalation_level") or 1
+        user_shifts.setdefault(uid, []).append({"start": start_ms, "end": end_ms, "level": escalation_level})
+
+    # ── Build per-user incident records ───────────────────────────────────────
+    user_high_urgency: dict[str, int] = {}
+    user_low_urgency: dict[str, int] = {}
+    user_incidents: dict[str, list[dict]] = {}
+
+    for inc in incident_rows:
+        urgency = inc.get("urgency", "low")
+        for assignment in inc.get("assignments", []):
+            uid = assignment.get("assignee", {}).get("id")
+            if not uid:
+                continue
+            if urgency == "high":
+                user_high_urgency[uid] = user_high_urgency.get(uid, 0) + 1
+            else:
+                user_low_urgency[uid] = user_low_urgency.get(uid, 0) + 1
+            if request.include_incidents:
+                user_incidents.setdefault(uid, []).append({
+                    "id": inc.get("id"),
+                    "incident_number": inc.get("incident_number"),
+                    "title": inc.get("title", "Untitled"),
+                    "urgency": urgency,
+                    "created_at": inc.get("created_at"),
+                    "resolved_at": inc.get("resolved_at"),
+                    "service_name": inc.get("service", {}).get("summary"),
+                })
+
+    # ── Merge analytics rows per user (historical mode) ───────────────────────
+    merged_map: dict[str, dict] = {}
+
+    if not request.forward:
+        for row in analytics_rows:
+            uid = str(row.get("responder_id") or "")
+            if not uid:
+                continue
+
+            sched_h = round((row.get("total_seconds_on_call") or 0) / 3600, 2)
+            sched_h_l1 = round((row.get("total_seconds_on_call_level_1") or 0) / 3600, 2)
+            sched_h_l2 = round((row.get("total_seconds_on_call_level_2_plus") or 0) / 3600, 2)
+            total_int = row.get("total_interruptions") or 0
+            biz_int = row.get("total_business_hour_interruptions") or 0
+            off_int = row.get("total_off_hour_interruptions") or 0
+            sleep_int = row.get("total_sleep_hour_interruptions") or 0
+            inc_h = round((row.get("total_engaged_seconds") or 0) / 3600, 2)
+            inc_count = row.get("total_incident_count") or 0
+            mtta = row.get("mean_time_to_acknowledge_seconds") or 0
+            team_id = row.get("team_id")
+            team_name = (teams_map.get(team_id) if team_id else None) or row.get("team_name")
+
+            if uid in merged_map:
+                e = merged_map[uid]
+                e["scheduled_hours"] = max(e["scheduled_hours"], sched_h)
+                e["scheduled_hours_l1"] = max(e["scheduled_hours_l1"], sched_h_l1)
+                e["scheduled_hours_l2_plus"] = max(e["scheduled_hours_l2_plus"], sched_h_l2)
+                e["total_interruptions"] = max(e["total_interruptions"], total_int)
+                e["business_hour_interruptions"] = max(e["business_hour_interruptions"], biz_int)
+                e["off_hour_interruptions"] = max(e["off_hour_interruptions"], off_int)
+                e["sleep_hour_interruptions"] = max(e["sleep_hour_interruptions"], sleep_int)
+                e["incident_count"] = max(e["incident_count"], inc_count)
+                e["incident_hours"] = round(e["incident_hours"] + inc_h, 2)
+                if mtta > 0 and e["mean_time_to_ack_seconds"] == 0:
+                    e["mean_time_to_ack_seconds"] = mtta
+                if team_name and team_name not in e["team_names"]:
+                    e["team_names"].append(team_name)
+            else:
+                merged_map[uid] = {
+                    "user_id": uid,
+                    "user_name": row.get("responder_name") or "Unknown",
+                    "user_timezone": user_tz_map.get(uid),
+                    "team_names": [team_name] if team_name else [],
+                    "scheduled_hours": sched_h,
+                    "scheduled_hours_l1": sched_h_l1,
+                    "scheduled_hours_l2_plus": sched_h_l2,
+                    "total_interruptions": total_int,
+                    "business_hour_interruptions": biz_int,
+                    "off_hour_interruptions": off_int,
+                    "sleep_hour_interruptions": sleep_int,
+                    "incident_count": inc_count,
+                    "incident_hours": inc_h,
+                    "mean_time_to_ack_seconds": float(mtta),
+                }
+
+    # ── Forward mode: build merged_map from scheduled shifts only ─────────────
+    if request.forward:
+        user_name_map: dict[str, str] = {u["id"]: (u.get("name") or u.get("summary") or "Unknown")
+                                         for u in users_rows}
+        for uid, shifts in user_shifts.items():
+            deduped = _dedup_shifts(shifts)
+            l1_shifts = [s for s in deduped if s.get("level", 1) == 1]
+            l2_shifts = [s for s in deduped if s.get("level", 1) > 1]
+            sched_h = round(sum((s["end"] - s["start"]) for s in deduped) / 3_600_000, 2)
+            sched_h_l1 = round(sum((s["end"] - s["start"]) for s in l1_shifts) / 3_600_000, 2)
+            sched_h_l2 = round(sum((s["end"] - s["start"]) for s in l2_shifts) / 3_600_000, 2)
+            merged_map[uid] = {
+                "user_id": uid,
+                "user_name": user_name_map.get(uid, "Unknown"),
+                "user_timezone": user_tz_map.get(uid),
+                "team_names": [],
+                "scheduled_hours": sched_h,
+                "scheduled_hours_l1": sched_h_l1,
+                "scheduled_hours_l2_plus": sched_h_l2,
+                "total_interruptions": 0,
+                "business_hour_interruptions": 0,
+                "off_hour_interruptions": 0,
+                "sleep_hour_interruptions": 0,
+                "incident_count": 0,
+                "incident_hours": 0.0,
+                "mean_time_to_ack_seconds": 0.0,
+            }
+
+    # ── Filter by EP if requested ─────────────────────────────────────────────
+    if request.escalation_policy_id:
+        merged_map = {uid: v for uid, v in merged_map.items() if uid in ep_user_ids}
+
+    # ── Resolve compliance config (template + overrides) ──────────────────────
+    tmpl = COMPLIANCE_TEMPLATES.get(request.compliance_template, COMPLIANCE_TEMPLATES["none"])
+    eff_hours_cap = request.hours_cap if request.hours_cap > 0 else tmpl["hours_cap"]
+    eff_outside_cap = request.outside_hours_cap if request.outside_hours_cap > 0 else tmpl["outside_hours_cap"]
+    eff_max_consec_days = request.max_consecutive_days if request.max_consecutive_days > 0 else tmpl["max_consecutive_days"]
+    eff_max_consec_hours = request.max_consecutive_hours if request.max_consecutive_hours > 0 else tmpl["max_consecutive_hours"]
+    eff_min_rest = request.min_rest_hours if request.min_rest_hours > 0 else tmpl["min_rest_hours"]
+    near_threshold = 0.9  # flag at 90% of any limit
+
+    # ── Compute outside-hours + pay per user ──────────────────────────────────
+    user_summaries: list[UserCompensationSummary] = []
+
+    for uid, data in merged_map.items():
+        sched_h = data["scheduled_hours"]
+        if sched_h < request.min_scheduled_hours:
+            continue
+
+        shifts = user_shifts.get(uid, [])
+        ooh = _compute_outside_hours(shifts, request.biz_start_hour, request.biz_end_hour,
+                                     work_days_iso, holidays_set, tz)
+
+        total_int = data["total_interruptions"]
+        interruption_rate = round(total_int / sched_h, 3) if sched_h > 0 else 0.0
+
+        # Pay estimation
+        estimated_pay = 0.0
+        if request.l1_rate_per_hour > 0:
+            outside_h = ooh["outside_hours"]
+            weekend_h = ooh["weekend_hours"]
+            holiday_h = ooh["holiday_hours"]
+            weeknight_h = ooh["weeknight_hours"]
+            inside_h = max(0.0, sched_h - outside_h)
+            estimated_pay = round(
+                inside_h * request.l1_rate_per_hour
+                + weeknight_h * request.l1_rate_per_hour * request.off_hours_multiplier
+                + weekend_h * request.l1_rate_per_hour * request.weekend_multiplier
+                + holiday_h * request.l1_rate_per_hour * request.holiday_multiplier
+                + data["scheduled_hours_l2_plus"] * request.l2_plus_rate_per_hour,
+                2,
+            )
+
+        # Compliance evaluation
+        flags: list[str] = []
+        status = "ok"
+        def _check(value: float, cap: float, label: str) -> str | None:
+            if cap <= 0:
+                return None
+            pct = value / cap
+            if pct > 1:
+                return f"over:{label} ({value:.1f} / {cap:.0f} limit)"
+            if pct >= near_threshold:
+                return f"near:{label} ({value:.1f} / {cap:.0f} limit, {pct*100:.0f}%)"
+            return None
+
+        for flag in [
+            _check(sched_h, eff_hours_cap, "hours_cap"),
+            _check(ooh["outside_hours"], eff_outside_cap, "outside_hours_cap"),
+            _check(ooh["max_consecutive_on_call_days"], eff_max_consec_days, "max_consecutive_days"),
+            _check(ooh["max_consecutive_on_call_hours"], eff_max_consec_hours, "max_consecutive_hours"),
+        ]:
+            if flag:
+                flags.append(flag)
+                if flag.startswith("over:") and status != "over":
+                    status = "over"
+                elif flag.startswith("near:") and status == "ok":
+                    status = "near"
+
+        if eff_min_rest > 0 and 0 < ooh["min_rest_hours"] < eff_min_rest:
+            flags.append(f"over:min_rest_hours ({ooh['min_rest_hours']:.1f}h < {eff_min_rest:.0f}h required)")
+            status = "over"
+
+        user_summaries.append(UserCompensationSummary(
+            user_id=uid,
+            user_name=data["user_name"],
+            user_timezone=data.get("user_timezone"),
+            team_names=data["team_names"],
+            scheduled_hours=sched_h,
+            scheduled_hours_l1=data["scheduled_hours_l1"],
+            scheduled_hours_l2_plus=data["scheduled_hours_l2_plus"],
+            direct_ep_count=len(user_direct_ep_ids.get(uid, set())),
+            total_interruptions=total_int,
+            business_hour_interruptions=data["business_hour_interruptions"],
+            off_hour_interruptions=data["off_hour_interruptions"],
+            sleep_hour_interruptions=data["sleep_hour_interruptions"],
+            interruption_rate=interruption_rate,
+            mean_time_to_ack_seconds=data["mean_time_to_ack_seconds"],
+            incident_count=data["incident_count"],
+            incident_hours=data["incident_hours"],
+            high_urgency_incidents=user_high_urgency.get(uid, 0),
+            low_urgency_incidents=user_low_urgency.get(uid, 0),
+            outside_hours=ooh["outside_hours"],
+            weekend_hours=ooh["weekend_hours"],
+            holiday_hours=ooh["holiday_hours"],
+            weeknight_hours=ooh["weeknight_hours"],
+            weekend_period_count=int(ooh["weekend_period_count"]),
+            holiday_count=int(ooh["holiday_count"]),
+            unique_ooh_periods=int(ooh["unique_ooh_periods"]),
+            max_consecutive_on_call_hours=ooh["max_consecutive_on_call_hours"],
+            max_consecutive_on_call_days=int(ooh["max_consecutive_on_call_days"]),
+            min_rest_hours=ooh["min_rest_hours"],
+            estimated_pay=estimated_pay,
+            compliance_status=status,
+            compliance_flags=flags,
+        ))
+
+    user_summaries.sort(key=lambda u: u.scheduled_hours, reverse=True)
+
+    # ── Team rollup ───────────────────────────────────────────────────────────
+    team_agg: dict[str, dict] = {}
+    for u in user_summaries:
+        for tname in (u.team_names or ["(no team)"]):
+            t = team_agg.setdefault(tname, dict(
+                team_name=tname, user_count=0,
+                total_scheduled_hours=0.0, total_outside_hours=0.0,
+                total_interruptions=0, total_sleep_interruptions=0,
+                total_estimated_pay=0.0,
+            ))
+            t["user_count"] += 1
+            t["total_scheduled_hours"] += u.scheduled_hours
+            t["total_outside_hours"] += u.outside_hours
+            t["total_interruptions"] += u.total_interruptions
+            t["total_sleep_interruptions"] += u.sleep_hour_interruptions
+            t["total_estimated_pay"] += u.estimated_pay
+
+    team_summary = sorted(team_agg.values(), key=lambda t: t["total_scheduled_hours"], reverse=True)
+
+    report = OncallCompensationReport(
+        since=since,
+        until=until,
+        timezone=tz,
+        compliance_template=request.compliance_template,
+        generated_at=datetime.now(dt_timezone.utc).isoformat(),
+        is_forward=request.forward,
+        total_users=len(user_summaries),
+        total_scheduled_hours=round(sum(u.scheduled_hours for u in user_summaries), 2),
+        total_outside_hours=round(sum(u.outside_hours for u in user_summaries), 2),
+        total_estimated_pay=round(sum(u.estimated_pay for u in user_summaries), 2),
+        compliance_violations=sum(1 for u in user_summaries if u.compliance_status == "over"),
+        compliance_near_limit=sum(1 for u in user_summaries if u.compliance_status == "near"),
+        users=user_summaries,
+        team_summary=team_summary,
+    )
+
+    return report.model_dump_json()

--- a/pagerduty_mcp_evals/test_cases/test_oncall_compensation.py
+++ b/pagerduty_mcp_evals/test_cases/test_oncall_compensation.py
@@ -1,0 +1,147 @@
+"""Tests for on-call compensation competency questions."""
+
+from pagerduty_mcp_evals.test_cases.agent_competency_test import (
+    AgentCompetencyTest,
+    MockMCPToolInvocationResponse,
+    MockToolCall,
+)
+
+_MOCK_COMPENSATION_REPORT = {
+    "since": "2023-01-01T00:00:00Z",
+    "until": "2023-01-31T23:59:59Z",
+    "timezone": "UTC",
+    "compliance_template": "none",
+    "generated_at": "2023-02-01T10:00:00Z",
+    "total_users": 2,
+    "total_scheduled_hours": 240.0,
+    "total_outside_hours": 80.0,
+    "total_estimated_pay": 0.0,
+    "compliance_violations": 0,
+    "compliance_near_limit": 0,
+    "is_forward": False,
+    "users": [
+        {
+            "user_id": "U1",
+            "user_name": "Alice",
+            "scheduled_hours": 160.0,
+            "outside_hours": 48.0,
+            "total_interruptions": 10,
+        }
+    ],
+    "team_summary": [{"team_name": "Engineering", "user_count": 2}],
+}
+
+
+class OncallCompensationCompetencyTest(AgentCompetencyTest):
+    """Specialization of AgentCompetencyTest for on-call compensation queries."""
+
+    def __init__(self, **kwargs) -> None:
+        mock_responses = [
+            MockMCPToolInvocationResponse(
+                tool_name="get_oncall_compensation_report",
+                parameters=lambda params: True,
+                response=_MOCK_COMPENSATION_REPORT,
+            ),
+        ]
+        super().__init__(mock_responses=mock_responses, **kwargs)
+
+
+# Define the competency test cases
+ONCALL_COMPENSATION_COMPETENCY_TESTS = [
+    OncallCompensationCompetencyTest(
+        query="Generate an on-call compensation report for January 2023",
+        expected_tool_calls=[
+            MockToolCall(
+                name="get_oncall_compensation_report",
+                parameters={
+                    "since": "2023-01-01T00:00:00Z",
+                    "until": "2023-01-31T23:59:59Z",
+                },
+            )
+        ],
+        description="Generate a basic on-call compensation report for a month",
+    ),
+    OncallCompensationCompetencyTest(
+        query="Show me who was on call the most from 2023-01-01 to 2023-01-31",
+        expected_tool_calls=[
+            MockToolCall(
+                name="get_oncall_compensation_report",
+                parameters={
+                    "since": "2023-01-01T00:00:00Z",
+                    "until": "2023-01-31T23:59:59Z",
+                },
+            )
+        ],
+        description="Find the most on-call user for a date range",
+    ),
+    OncallCompensationCompetencyTest(
+        query="Generate an on-call compensation report from 2023-01-01 to 2023-03-31 for team_ids T1",
+        expected_tool_calls=[
+            MockToolCall(
+                name="get_oncall_compensation_report",
+                parameters={
+                    "since": "2023-01-01T00:00:00Z",
+                    "until": "2023-03-31T23:59:59Z",
+                    "team_ids": ["T1"],
+                },
+            )
+        ],
+        description="Get on-call compensation report filtered by team",
+    ),
+    OncallCompensationCompetencyTest(
+        query="Generate a pay estimation report for January 2023 at $10/hour",
+        expected_tool_calls=[
+            MockToolCall(
+                name="get_oncall_compensation_report",
+                parameters={
+                    "since": "2023-01-01T00:00:00Z",
+                    "until": "2023-01-31T23:59:59Z",
+                    "l1_rate_per_hour": 10.0,
+                },
+            )
+        ],
+        description="Generate pay estimation with hourly rate",
+    ),
+    OncallCompensationCompetencyTest(
+        query="Check EU compliance for January 2023 on-call shifts",
+        expected_tool_calls=[
+            MockToolCall(
+                name="get_oncall_compensation_report",
+                parameters={
+                    "since": "2023-01-01T00:00:00Z",
+                    "until": "2023-01-31T23:59:59Z",
+                    "compliance_template": "emea",
+                },
+            )
+        ],
+        description="Generate on-call report with EMEA compliance template",
+    ),
+    OncallCompensationCompetencyTest(
+        query="Project on-call costs for May 2026 (2026-05-01 to 2026-05-31)",
+        expected_tool_calls=[
+            MockToolCall(
+                name="get_oncall_compensation_report",
+                parameters={
+                    "since": "2026-05-01T00:00:00Z",
+                    "until": "2026-05-31T23:59:59Z",
+                    "forward": True,
+                },
+            )
+        ],
+        description="Project on-call costs for a future month using forward mode",
+    ),
+    OncallCompensationCompetencyTest(
+        query="Use get_oncall_compensation_report in forward mode to project on-call burden from 2026-06-01 to 2026-06-30",
+        expected_tool_calls=[
+            MockToolCall(
+                name="get_oncall_compensation_report",
+                parameters={
+                    "since": "2026-06-01T00:00:00Z",
+                    "until": "2026-06-30T23:59:59Z",
+                    "forward": True,
+                },
+            )
+        ],
+        description="Query scheduled on-call shifts for a future date range using forward mode",
+    ),
+]

--- a/tests/test_oncall_compensation.py
+++ b/tests/test_oncall_compensation.py
@@ -1,0 +1,492 @@
+"""
+Unit tests for pagerduty_mcp/tools/oncall_compensation.py
+Covers:
+  - Pure utility functions (_dedup_shifts, _get_tz_parts, _midnight_ms, _days_in_range,
+    _compute_outside_hours)
+  - OncallCompensationRequest model validation
+  - get_oncall_compensation_report integration (mocked PD client + paginate)
+"""
+import json
+import unittest
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+from pydantic import ValidationError
+
+from pagerduty_mcp.tools.oncall_compensation import (
+    COMPLIANCE_TEMPLATES,
+    OncallCompensationRequest,
+    _compute_outside_hours,
+    _days_in_range,
+    _dedup_shifts,
+    _get_tz_parts,
+    _midnight_ms,
+    get_oncall_compensation_report,
+)
+
+
+# ── Pure function tests ──────────────────────────────────────────────────────
+
+class TestOncallCompensationPureFunctions(unittest.TestCase):
+
+    # _dedup_shifts
+
+    def test_dedup_shifts_empty(self):
+        self.assertEqual(_dedup_shifts([]), [])
+
+    def test_dedup_shifts_single(self):
+        shift = {"start": 1000, "end": 2000}
+        result = _dedup_shifts([shift])
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["start"], 1000)
+        self.assertEqual(result[0]["end"], 2000)
+
+    def test_dedup_shifts_overlapping(self):
+        # Overlapping: [100, 300) and [200, 400) -> [100, 400)
+        shifts = [{"start": 100, "end": 300}, {"start": 200, "end": 400}]
+        result = _dedup_shifts(shifts)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["start"], 100)
+        self.assertEqual(result[0]["end"], 400)
+
+    def test_dedup_shifts_adjacent(self):
+        # Adjacent: end == start, should merge
+        shifts = [{"start": 100, "end": 200}, {"start": 200, "end": 300}]
+        result = _dedup_shifts(shifts)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["start"], 100)
+        self.assertEqual(result[0]["end"], 300)
+
+    def test_dedup_shifts_non_overlapping(self):
+        shifts = [{"start": 100, "end": 200}, {"start": 300, "end": 400}]
+        result = _dedup_shifts(shifts)
+        self.assertEqual(len(result), 2)
+
+    def test_dedup_shifts_sorts_by_start(self):
+        # Input in reverse order — should still sort and merge correctly
+        shifts = [
+            {"start": 300, "end": 500},
+            {"start": 100, "end": 350},
+        ]
+        result = _dedup_shifts(shifts)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["start"], 100)
+        self.assertEqual(result[0]["end"], 500)
+
+    # _get_tz_parts
+
+    def test_get_tz_parts_utc(self):
+        # Timestamp 0 is 1970-01-01T00:00:00Z (Thursday)
+        parts = _get_tz_parts(0, "UTC")
+        self.assertEqual(parts["year"], 1970)
+        self.assertEqual(parts["month"], 1)
+        self.assertEqual(parts["day"], 1)
+        self.assertEqual(parts["hour"], 0)
+        self.assertEqual(parts["weekday"], 4)  # Thursday in ISO = 4
+
+    # _midnight_ms
+
+    def test_midnight_ms_utc(self):
+        expected = datetime(2023, 1, 1, tzinfo=timezone.utc).timestamp() * 1000
+        result = _midnight_ms("2023-01-01", "UTC")
+        self.assertAlmostEqual(result, expected, places=0)
+
+    # _days_in_range
+
+    def test_days_in_range_single_day(self):
+        # Start and end within same day
+        ts_ms = datetime(2023, 1, 2, 9, 0, tzinfo=timezone.utc).timestamp() * 1000
+        end_ms = datetime(2023, 1, 2, 17, 0, tzinfo=timezone.utc).timestamp() * 1000
+        result = _days_in_range(ts_ms, end_ms, "UTC")
+        self.assertEqual(result, ["2023-01-02"])
+
+    def test_days_in_range_multi_day(self):
+        # Span 3 days: Jan 2, 3, 4
+        start_ms = datetime(2023, 1, 2, 23, 0, tzinfo=timezone.utc).timestamp() * 1000
+        end_ms = datetime(2023, 1, 4, 1, 0, tzinfo=timezone.utc).timestamp() * 1000
+        result = _days_in_range(start_ms, end_ms, "UTC")
+        self.assertIn("2023-01-02", result)
+        self.assertIn("2023-01-03", result)
+        self.assertIn("2023-01-04", result)
+        self.assertEqual(len(result), 3)
+
+    # _compute_outside_hours
+
+    def test_compute_outside_hours_empty_shifts(self):
+        result = _compute_outside_hours([], 9, 18, {1, 2, 3, 4, 5}, set(), "UTC")
+        self.assertEqual(result["outside_hours"], 0.0)
+        self.assertEqual(result["weekend_hours"], 0.0)
+        self.assertEqual(result["holiday_hours"], 0.0)
+        self.assertEqual(result["weeknight_hours"], 0.0)
+        self.assertEqual(result["weekend_period_count"], 0)
+        self.assertEqual(result["holiday_count"], 0)
+        self.assertEqual(result["unique_ooh_periods"], 0)
+        self.assertEqual(result["max_consecutive_on_call_hours"], 0.0)
+        self.assertEqual(result["max_consecutive_on_call_days"], 0)
+        self.assertEqual(result["min_rest_hours"], 999.0)
+
+    def test_compute_outside_hours_business_hours_only(self):
+        # Mon Jan 2 2023 09:00 - 17:00 UTC is entirely within biz hours (9-18, Mon-Fri)
+        start_ms = datetime(2023, 1, 2, 9, 0, tzinfo=timezone.utc).timestamp() * 1000
+        end_ms = datetime(2023, 1, 2, 17, 0, tzinfo=timezone.utc).timestamp() * 1000
+        shifts = [{"start": start_ms, "end": end_ms}]
+        result = _compute_outside_hours(shifts, 9, 18, {1, 2, 3, 4, 5}, set(), "UTC")
+        self.assertEqual(result["outside_hours"], 0.0)
+        self.assertEqual(result["weekend_hours"], 0.0)
+        self.assertEqual(result["weeknight_hours"], 0.0)
+
+    def test_compute_outside_hours_weekend(self):
+        # Jan 7 2023 is Saturday (weekday ISO = 6)
+        start_ms = datetime(2023, 1, 7, 9, 0, tzinfo=timezone.utc).timestamp() * 1000
+        end_ms = datetime(2023, 1, 7, 17, 0, tzinfo=timezone.utc).timestamp() * 1000
+        shifts = [{"start": start_ms, "end": end_ms}]
+        result = _compute_outside_hours(shifts, 9, 18, {1, 2, 3, 4, 5}, set(), "UTC")
+        self.assertGreater(result["weekend_hours"], 0)
+        self.assertGreater(result["outside_hours"], 0)
+
+
+# ── Model validation tests ───────────────────────────────────────────────────
+
+class TestOncallCompensationRequest(unittest.TestCase):
+
+    def test_request_minimal_valid(self):
+        req = OncallCompensationRequest(
+            since="2023-01-01T00:00:00Z",
+            until="2023-01-31T23:59:59Z",
+        )
+        self.assertEqual(req.since, "2023-01-01T00:00:00Z")
+        self.assertEqual(req.until, "2023-01-31T23:59:59Z")
+
+    def test_request_extra_fields_forbidden(self):
+        with self.assertRaises(ValidationError):
+            OncallCompensationRequest(
+                since="2023-01-01T00:00:00Z",
+                until="2023-01-31T23:59:59Z",
+                unknown_field="oops",
+            )
+
+    def test_request_compliance_template_default(self):
+        req = OncallCompensationRequest(
+            since="2023-01-01T00:00:00Z",
+            until="2023-01-31T23:59:59Z",
+        )
+        self.assertEqual(req.compliance_template, "none")
+
+    def test_request_biz_hours_defaults(self):
+        req = OncallCompensationRequest(
+            since="2023-01-01T00:00:00Z",
+            until="2023-01-31T23:59:59Z",
+        )
+        self.assertEqual(req.biz_start_hour, 9)
+        self.assertEqual(req.biz_end_hour, 18)
+
+    def test_request_work_days_default(self):
+        req = OncallCompensationRequest(
+            since="2023-01-01T00:00:00Z",
+            until="2023-01-31T23:59:59Z",
+        )
+        self.assertEqual(req.work_days, [1, 2, 3, 4, 5])
+
+    def test_compliance_templates_dict(self):
+        self.assertIn("emea", COMPLIANCE_TEMPLATES)
+        self.assertIn("us", COMPLIANCE_TEMPLATES)
+        self.assertIn("none", COMPLIANCE_TEMPLATES)
+        self.assertEqual(COMPLIANCE_TEMPLATES["emea"]["hours_cap"], 192)
+
+
+# ── Integration tests ────────────────────────────────────────────────────────
+
+class TestGetOncallCompensationReport(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.sample_analytics_data = {
+            "data": [{
+                "responder_id": "U1",
+                "responder_name": "Alice",
+                "team_id": "T1",
+                "total_seconds_on_call": 72000,       # 20 hours
+                "total_seconds_on_call_level_1": 72000,
+                "total_seconds_on_call_level_2_plus": 0,
+                "total_interruptions": 5,
+                "total_business_hour_interruptions": 3,
+                "total_off_hour_interruptions": 2,
+                "total_sleep_hour_interruptions": 0,
+                "total_engaged_seconds": 3600,
+                "total_incident_count": 3,
+                "mean_time_to_acknowledge_seconds": 120,
+            }]
+        }
+
+        # Mon Jan 2 2023 09:00 - 17:00 UTC (business hours shift)
+        cls.sample_oncalls = [{
+            "user": {"id": "U1", "summary": "Alice"},
+            "schedule": {"id": "SCHED1"},
+            "escalation_policy": {"id": "EP1"},
+            "escalation_level": 1,
+            "start": "2023-01-02T09:00:00Z",
+            "end": "2023-01-02T17:00:00Z",
+        }]
+
+        cls.sample_incidents = [{
+            "id": "INC1",
+            "urgency": "high",
+            "assignments": [{"assignee": {"id": "U1"}}],
+        }]
+
+        cls.sample_teams = [{"id": "T1", "name": "Engineering"}]
+        cls.sample_users = [{"id": "U1", "name": "Alice", "time_zone": "UTC"}]
+
+    # ── helpers ──────────────────────────────────────────────────────────────
+
+    def _make_kwargs(self, **kwargs):
+        defaults = {
+            "since": "2023-01-01T00:00:00Z",
+            "until": "2023-01-31T23:59:59Z",
+        }
+        defaults.update(kwargs)
+        return defaults
+
+    # ── tests ────────────────────────────────────────────────────────────────
+
+    @patch("pagerduty_mcp.tools.oncall_compensation.paginate")
+    @patch("pagerduty_mcp.tools.oncall_compensation.get_client")
+    def test_get_oncall_compensation_report_basic(self, mock_get_client, mock_paginate):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.rpost.return_value = self.sample_analytics_data
+        mock_paginate.side_effect = [
+            self.sample_oncalls,    # oncalls
+            self.sample_incidents,  # incidents
+            self.sample_teams,      # teams
+            self.sample_users,      # users
+        ]
+
+        result = get_oncall_compensation_report(**self._make_kwargs())
+
+        self.assertIsInstance(result, str)
+        parsed = json.loads(result)
+        self.assertEqual(parsed["total_users"], 1)
+        self.assertEqual(parsed["users"][0]["user_id"], "U1")
+        self.assertEqual(parsed["users"][0]["scheduled_hours"], 20.0)
+        self.assertEqual(parsed["since"], "2023-01-01T00:00:00Z")
+        self.assertEqual(parsed["until"], "2023-01-31T23:59:59Z")
+
+    @patch("pagerduty_mcp.tools.oncall_compensation.paginate")
+    @patch("pagerduty_mcp.tools.oncall_compensation.get_client")
+    def test_get_oncall_compensation_report_forward_mode(self, mock_get_client, mock_paginate):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        # paginate called 3 times in forward mode (no incidents)
+        mock_paginate.side_effect = [
+            self.sample_oncalls,   # oncalls
+            self.sample_teams,     # teams
+            self.sample_users,     # users
+        ]
+
+        result = get_oncall_compensation_report(**self._make_kwargs(forward=True))
+
+        parsed = json.loads(result)
+        self.assertTrue(parsed["is_forward"])
+        user_ids = [u["user_id"] for u in parsed["users"]]
+        self.assertIn("U1", user_ids)
+        # rpost (analytics) must NOT be called in forward mode
+        mock_client.rpost.assert_not_called()
+
+    @patch("pagerduty_mcp.tools.oncall_compensation.paginate")
+    @patch("pagerduty_mcp.tools.oncall_compensation.get_client")
+    def test_get_oncall_compensation_report_empty_no_users(self, mock_get_client, mock_paginate):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.rpost.return_value = {"data": []}
+        mock_paginate.side_effect = [
+            [],  # oncalls
+            [],  # incidents
+            [],  # teams
+            [],  # users
+        ]
+
+        result = get_oncall_compensation_report(**self._make_kwargs())
+
+        parsed = json.loads(result)
+        self.assertEqual(parsed["total_users"], 0)
+        self.assertEqual(parsed["users"], [])
+
+    @patch("pagerduty_mcp.tools.oncall_compensation.paginate")
+    @patch("pagerduty_mcp.tools.oncall_compensation.get_client")
+    def test_get_oncall_compensation_report_compliance_emea(self, mock_get_client, mock_paginate):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.rpost.return_value = self.sample_analytics_data  # 20h — well under 192h cap
+        mock_paginate.side_effect = [
+            self.sample_oncalls,
+            self.sample_incidents,
+            self.sample_teams,
+            self.sample_users,
+        ]
+
+        result = get_oncall_compensation_report(**self._make_kwargs(compliance_template="emea"))
+
+        parsed = json.loads(result)
+        self.assertEqual(len(parsed["users"]), 1)
+        self.assertEqual(parsed["users"][0]["compliance_status"], "ok")
+
+    @patch("pagerduty_mcp.tools.oncall_compensation.paginate")
+    @patch("pagerduty_mcp.tools.oncall_compensation.get_client")
+    def test_get_oncall_compensation_report_pay_estimation(self, mock_get_client, mock_paginate):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.rpost.return_value = self.sample_analytics_data  # 20h scheduled
+        mock_paginate.side_effect = [
+            self.sample_oncalls,    # Mon 09:00-17:00 UTC — 8h inside biz hours
+            self.sample_incidents,
+            self.sample_teams,
+            self.sample_users,
+        ]
+
+        result = get_oncall_compensation_report(**self._make_kwargs(l1_rate_per_hour=10.0))
+
+        parsed = json.loads(result)
+        self.assertEqual(len(parsed["users"]), 1)
+        # 20h scheduled, 8h inside biz hours, pay must be > 0
+        self.assertGreater(parsed["users"][0]["estimated_pay"], 0)
+
+    @patch("pagerduty_mcp.tools.oncall_compensation.paginate")
+    @patch("pagerduty_mcp.tools.oncall_compensation.get_client")
+    def test_get_oncall_compensation_report_team_summary(self, mock_get_client, mock_paginate):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.rpost.return_value = self.sample_analytics_data
+        mock_paginate.side_effect = [
+            self.sample_oncalls,
+            self.sample_incidents,
+            self.sample_teams,
+            self.sample_users,
+        ]
+
+        result = get_oncall_compensation_report(**self._make_kwargs())
+
+        parsed = json.loads(result)
+        self.assertIn("team_summary", parsed)
+        self.assertIsInstance(parsed["team_summary"], list)
+        team_names = [t["team_name"] for t in parsed["team_summary"]]
+        self.assertIn("Engineering", team_names)
+
+    @patch("pagerduty_mcp.tools.oncall_compensation.paginate")
+    @patch("pagerduty_mcp.tools.oncall_compensation.get_client")
+    def test_get_oncall_compensation_report_direct_ep_entry(self, mock_get_client, mock_paginate):
+        # Direct EP layer: no schedule, no start, no end — counts toward direct_ep_count,
+        # but should NOT add shift hours.
+        direct_ep_oncall = [{
+            "user": {"id": "U1", "summary": "Alice"},
+            "schedule": None,
+            "escalation_policy": {"id": "EP1"},
+            "escalation_level": 1,
+            "start": None,
+            "end": None,
+        }]
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        # Analytics data with 0 scheduled hours
+        mock_client.rpost.return_value = {
+            "data": [{
+                "responder_id": "U1",
+                "responder_name": "Alice",
+                "team_id": "T1",
+                "total_seconds_on_call": 0,
+                "total_seconds_on_call_level_1": 0,
+                "total_seconds_on_call_level_2_plus": 0,
+                "total_interruptions": 0,
+                "total_business_hour_interruptions": 0,
+                "total_off_hour_interruptions": 0,
+                "total_sleep_hour_interruptions": 0,
+                "total_engaged_seconds": 0,
+                "total_incident_count": 0,
+                "mean_time_to_acknowledge_seconds": 0,
+            }]
+        }
+        mock_paginate.side_effect = [
+            direct_ep_oncall,       # oncalls
+            [],                     # incidents
+            self.sample_teams,      # teams
+            self.sample_users,      # users
+        ]
+
+        result = get_oncall_compensation_report(**self._make_kwargs())
+
+        parsed = json.loads(result)
+        # User should be present (from analytics) with direct_ep_count >= 1
+        user = next((u for u in parsed["users"] if u["user_id"] == "U1"), None)
+        self.assertIsNotNone(user)
+        assert user is not None
+        self.assertGreaterEqual(user["direct_ep_count"], 1)
+        # Scheduled hours should remain 0 — no shift window was added
+        self.assertEqual(user["scheduled_hours"], 0.0)
+
+    @patch("pagerduty_mcp.tools.oncall_compensation.paginate")
+    @patch("pagerduty_mcp.tools.oncall_compensation.get_client")
+    def test_multi_team_user_interruptions_not_doubled(self, mock_get_client, mock_paginate):
+        # The analytics API returns one row per (user, team) pair but each row contains
+        # the user's *total* interruption counts (not per-team).  Merging with += would
+        # double-count for users on multiple teams.  Verify that max() is used instead.
+        multi_team_analytics = {
+            "data": [
+                {
+                    "responder_id": "U1",
+                    "responder_name": "Alice",
+                    "team_id": "T1",
+                    "total_seconds_on_call": 72000,
+                    "total_seconds_on_call_level_1": 72000,
+                    "total_seconds_on_call_level_2_plus": 0,
+                    "total_interruptions": 5,
+                    "total_business_hour_interruptions": 3,
+                    "total_off_hour_interruptions": 2,
+                    "total_sleep_hour_interruptions": 0,
+                    "total_engaged_seconds": 3600,
+                    "total_incident_count": 3,
+                    "mean_time_to_acknowledge_seconds": 120,
+                },
+                # Same user, second team — same total counts (as the API returns them)
+                {
+                    "responder_id": "U1",
+                    "responder_name": "Alice",
+                    "team_id": "T2",
+                    "total_seconds_on_call": 72000,
+                    "total_seconds_on_call_level_1": 72000,
+                    "total_seconds_on_call_level_2_plus": 0,
+                    "total_interruptions": 5,
+                    "total_business_hour_interruptions": 3,
+                    "total_off_hour_interruptions": 2,
+                    "total_sleep_hour_interruptions": 0,
+                    "total_engaged_seconds": 3600,
+                    "total_incident_count": 3,
+                    "mean_time_to_acknowledge_seconds": 120,
+                },
+            ]
+        }
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.rpost.return_value = multi_team_analytics
+        mock_paginate.side_effect = [
+            self.sample_oncalls,    # oncalls
+            self.sample_incidents,  # incidents
+            self.sample_teams,      # teams
+            self.sample_users,      # users
+        ]
+
+        result = get_oncall_compensation_report(**self._make_kwargs())
+
+        parsed = json.loads(result)
+        self.assertEqual(parsed["total_users"], 1)
+        user = parsed["users"][0]
+        self.assertEqual(user["user_id"], "U1")
+        # Interruption counts must NOT be doubled — max() should produce 5, not 10
+        self.assertEqual(user["total_interruptions"], 5)
+        self.assertEqual(user["business_hour_interruptions"], 3)
+        self.assertEqual(user["off_hour_interruptions"], 2)
+        self.assertEqual(user["sleep_hour_interruptions"], 0)
+        self.assertEqual(user["incident_count"], 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/website/docs/tools/oncall-compensation.md
+++ b/website/docs/tools/oncall-compensation.md
@@ -1,0 +1,56 @@
+---
+sidebar_position: 19
+---
+
+# On-Call Compensation
+
+The on-call compensation tool computes a detailed compensation and burden report for all responders in a given time window. It uses PagerDuty Analytics, on-call schedules, and incident data to produce a rich dataset suitable for payroll, compliance, and fairness analysis.
+
+## Tools
+
+### `get_oncall_compensation_report`
+
+Generate a full on-call compensation report for a time period. The report includes per-responder on-call hours, outside-hours breakdowns (evenings, weekends, sleep), incident counts by urgency, estimated compensation amounts, and optional compliance flag checks (EU Working Time Directive, US overtime, or custom thresholds).
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `request` | `OncallCompensationRequest` | Yes | Report parameters — see fields below |
+
+**`OncallCompensationRequest` fields:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `since` | `string` | Yes | Start of reporting period (ISO 8601, e.g. `"2026-01-01T00:00:00Z"`). Maximum recommended range: 90 days. |
+| `until` | `string` | Yes | End of reporting period (ISO 8601, exclusive). |
+| `team_ids` | `list[string]` | No | Filter to specific teams. If omitted, all teams are included. |
+| `escalation_policy_id` | `string` | No | Filter to users in a specific escalation policy. |
+| `compliance_template` | `string` | No | Compliance ruleset to apply: `"emea"` (EU Working Time Directive), `"us"` (US defaults), or `"none"` (no limits, default). |
+| `hours_cap` | `float` | No | Override: max scheduled hours allowed per period. `0` = use template value (default `0.0`). |
+| `outside_hours_cap` | `float` | No | Override: max outside-business-hours allowed per period. `0` = use template value (default `0.0`). |
+| `max_consecutive_days` | `integer` | No | Override: max consecutive on-call days. `0` = use template value (default `0`). |
+| `max_consecutive_hours` | `float` | No | Override: configurable cap on consecutive on-call hours. `0` = use template value (default `0.0`). |
+| `min_rest_hours` | `float` | No | Override: minimum rest hours between on-call periods. `0` = use template value (default `0.0`). |
+| `biz_start_hour` | `integer` | No | Start of business hours (24-hour clock, default `9`). |
+| `biz_end_hour` | `integer` | No | End of business hours (24-hour clock, default `18`). |
+| `timezone` | `string` | No | Timezone for outside-hours calculations (default `"UTC"`). |
+| `work_days` | `list[integer]` | No | ISO weekday numbers considered work days (default `[1, 2, 3, 4, 5]` = Mon–Fri). |
+| `holidays` | `list[string]` | No | List of holiday dates in `"YYYY-MM-DD"` format for holiday pay calculations. |
+| `l1_rate_per_hour` | `float` | No | Hourly rate (USD) for level-1 on-call shifts (default `0.0`). |
+| `l2_plus_rate_per_hour` | `float` | No | Hourly rate (USD) for level-2+ on-call shifts (default `0.0`). |
+| `off_hours_multiplier` | `float` | No | Multiplier applied to off-hours (evening) shifts (default `1.5`). |
+| `weekend_multiplier` | `float` | No | Multiplier applied to weekend shifts (default `2.0`). |
+| `holiday_multiplier` | `float` | No | Multiplier applied to holiday shifts (default `2.5`). |
+| `include_incidents` | `boolean` | No | If `true`, fetches incident data and includes urgency breakdown per user (default `false`). |
+| `include_directly_added` | `boolean` | No | If `true`, includes users added directly to an escalation policy without a schedule (default `false`). |
+| `min_scheduled_hours` | `float` | No | Exclude users with fewer than this many scheduled hours from the report (default `0.0`). |
+| `forward` | `boolean` | No | If `true`, returns a forward-looking projection based on current schedules rather than historical actuals (default `false`). |
+
+**Example prompts:**
+
+> "Generate an on-call compensation report for the platform team for January 2026, using a $50/hour rate with 1.5x for outside-hours shifts"
+
+> "Check if any responders are approaching EU Working Time Directive limits this month"
+
+> "Who carried the most on-call burden last quarter and what would their estimated compensation be?"
+
+> "Show me a breakdown of weeknight vs. weekend on-call hours for all responders"

--- a/website/docs/tools/overview.md
+++ b/website/docs/tools/overview.md
@@ -4,15 +4,15 @@ sidebar_position: 1
 
 # Tools Overview
 
-The PagerDuty MCP Server exposes **64 tools** across **14 domains**. By default, only the 42 read-only tools are available. The 22 write tools require starting the server with `--enable-write-tools`.
+The PagerDuty MCP Server exposes **65 tools** across **15 domains**. By default, only the 43 read-only tools are available. The 22 write tools require starting the server with `--enable-write-tools`.
 
 ## Read vs. Write Tools
 
 | Type | Count | Flag Required |
 |------|-------|---------------|
-| Read-only | 42 | None (always available) |
+| Read-only | 43 | None (always available) |
 | Write | 22 | `--enable-write-tools` |
-| **Total** | **64** | |
+| **Total** | **65** | |
 
 ## Complete Tool Reference
 
@@ -111,6 +111,12 @@ The PagerDuty MCP Server exposes **64 tools** across **14 domains**. By default,
 |------|------|-------------|
 | `list_oncalls` | Read | List current on-call assignments |
 
+### On-Call Compensation
+
+| Tool | Type | Description |
+|------|------|-------------|
+| `get_oncall_compensation_report` | Read | Compute on-call hours, cost estimates, and compliance checks for a time window |
+
 ### Log Entries
 
 | Tool | Type | Description |
@@ -157,5 +163,5 @@ See the individual domain pages for parameter details and usage examples:
 - [Alert Grouping](./alert-grouping) · [Alerts](./alerts) · [Change Events](./change-events)
 - [Incidents](./incidents) · [Incident Workflows](./incident-workflows)
 - [Services](./services) · [Teams](./teams) · [Users](./users)
-- [Schedules](./schedules) · [On-Call](./oncalls) · [Log Entries](./log-entries)
+- [Schedules](./schedules) · [On-Call](./oncalls) · [On-Call Compensation](./oncall-compensation) · [Log Entries](./log-entries)
 - [Escalation Policies](./escalation-policies) · [Event Orchestrations](./event-orchestrations) · [Status Pages](./status-pages)

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -55,6 +55,7 @@ const sidebars = {
         'tools/users',
         'tools/schedules',
         'tools/oncalls',
+        'tools/oncall-compensation',
         'tools/log-entries',
         'tools/escalation-policies',
         'tools/event-orchestrations',


### PR DESCRIPTION
## Summary

Adds `get_oncall_compensation_report` — an agentic read-only tool that:
- Computes on-call hours per user from PagerDuty schedule data
- Estimates compensation costs given configurable hourly rates
- Checks EU Working Time Directive and custom compliance thresholds
- Returns a structured markdown report

The tool is entirely self-contained in `oncall_compensation.py`. No existing tool files are modified.

## Depends on
Requires **PR #133** (`refactor/flatten-tool-signatures`) to be merged first.

## Test plan
- [ ] All existing tests pass
- [ ] `test_oncall_compensation.py` passes
- [ ] Spot-check: invoke `get_oncall_compensation_report` against a sandbox account and verify the report structure