### PR TITLE
feat: add read tools across incidents, log entries, schedules, services, and status pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -198,3 +198,4 @@ test_run_output.log
 website/node_modules/
 website/build/
 website/.docusaurus/
+mcp-apps/

--- a/pagerduty_mcp/models/incidents.py
+++ b/pagerduty_mcp/models/incidents.py
@@ -114,7 +114,13 @@ class GetIncidentQuery(BaseModel):
         default=None,
         description="List of additional information to include in the response. "
         "Available options: 'users', 'services', 'assignments', 'acknowledgers', 'custom_fields', "
-        "'teams', 'escalation_policies', 'notes', 'urgencies', 'priorities'",
+        "'teams', 'escalation_policies', 'log_entries', 'notes', 'urgencies', 'priorities', "
+        "'external_references', 'metadata'. "
+        "Use 'external_references' to include external system integration links such as ServiceNow, "
+        "Zendesk, and other third-party integrations associated with the incident. "
+        "Use 'metadata' to include additional metadata associated with the incident. "
+        "Use 'log_entries' to include the incident's log/audit entries inline (do NOT call "
+        "list_incident_log_entries separately when this option suffices).",
     )
 
     def to_params(self) -> dict[str, Any]:
@@ -182,6 +188,22 @@ class RelatedIncidentsQuery(BaseModel):
         return params
 
 
+class ExternalIntegrationLink(BaseModel):
+    """A typed link to an external system record (ServiceNow, Zendesk, etc.)."""
+
+    integration_id: str = Field(
+        description="The integration identifier (e.g. 'servicenow_itsm_dev230942_INC0010016')"
+    )
+    external_name: str | None = Field(
+        default=None,
+        description="Human-readable name of the external record (e.g. 'INC0010016 (dev230942)')",
+    )
+    external_url: str | None = Field(
+        default=None,
+        description="Direct URL to the record in the external system",
+    )
+
+
 # TODO: This should be moved to its own file
 class AssignmentInput(BaseModel):
     """Assignment for creating/updating incidents (no 'at' field required)."""
@@ -213,6 +235,26 @@ class Incident(BaseModel):
         default=None,
         description="The users assigned to the incident",
     )
+    metadata: list[ExternalIntegrationLink] | None = Field(
+        default=None,
+        description="External integration links associated with the incident, normalized from the raw metadata dict. "
+        "Each entry has integration_id, external_name, and external_url. "
+        "Populated when include=['metadata'] is passed.",
+    )
+    external_references: list[dict[str, Any]] | None = Field(
+        default=None,
+        description="External system integration links (ServiceNow, Zendesk, etc.). Populated when include=['external_references'] is passed.",
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_metadata(cls, data: Any) -> Any:
+        if isinstance(data, dict) and isinstance(data.get("metadata"), dict):
+            data["metadata"] = [
+                {"integration_id": k, **v}
+                for k, v in data["metadata"].items()
+            ]
+        return data
 
     @computed_field
     @property

--- a/pagerduty_mcp/tools/__init__.py
+++ b/pagerduty_mcp/tools/__init__.py
@@ -52,6 +52,7 @@ from .incidents import (
 )
 from .log_entries import (
     get_log_entry,
+    list_incident_log_entries,
     list_log_entries,
 )
 from .oncalls import list_oncalls
@@ -59,6 +60,7 @@ from .schedules import (
     create_schedule,
     create_schedule_override,
     get_schedule,
+    list_schedule_overrides,
     list_schedule_users,
     list_schedules,
     update_schedule,
@@ -66,6 +68,7 @@ from .schedules import (
 from .services import (
     create_service,
     get_service,
+    get_technical_service_dependencies,
     list_services,
     update_service,
 )
@@ -75,6 +78,7 @@ from .status_pages import (
     get_status_page_post,
     list_status_page_impacts,
     list_status_page_post_updates,
+    list_status_page_posts,
     list_status_page_severities,
     list_status_page_statuses,
     list_status_pages,
@@ -117,6 +121,7 @@ read_tools = [
     # Services
     list_services,
     get_service,
+    get_technical_service_dependencies,
     # Teams
     list_teams,
     get_team,
@@ -128,11 +133,13 @@ read_tools = [
     list_schedules,
     get_schedule,
     list_schedule_users,
+    list_schedule_overrides,
     # On-calls
     list_oncalls,
     # Log Entries
     list_log_entries,
     get_log_entry,
+    list_incident_log_entries,
     # Escalation Policies
     list_escalation_policies,
     get_escalation_policy,
@@ -149,6 +156,7 @@ read_tools = [
     list_status_page_statuses,
     get_status_page_post,
     list_status_page_post_updates,
+    list_status_page_posts,
 ]
 
 # Write tools (potentially dangerous operations that modify state)

--- a/pagerduty_mcp/tools/incidents.py
+++ b/pagerduty_mcp/tools/incidents.py
@@ -4,69 +4,113 @@ from typing import Any
 from pagerduty_mcp.client import get_client
 from pagerduty_mcp.context import ContextResolver
 from pagerduty_mcp.models import (
-    GetIncidentQuery,
+    MAX_RESULTS,
     Incident,
     IncidentCreate,
     IncidentManageRequest,
     IncidentNote,
-    IncidentQuery,
     IncidentResponderRequest,
     IncidentResponderRequestResponse,
     ListResponseModel,
-    OutlierIncidentQuery,
     OutlierIncidentResponse,
-    PastIncidentsQuery,
     PastIncidentsResponse,
-    RelatedIncidentsQuery,
     RelatedIncidentsResponse,
     UserReference,
 )
 from pagerduty_mcp.utils import paginate
 
 
-def list_incidents(query_model: IncidentQuery | None = None) -> ListResponseModel[Incident]:
+def list_incidents(
+    statuses: list[str] | None = None,
+    since: datetime | None = None,
+    until: datetime | None = None,
+    user_ids: list[str] | None = None,
+    service_ids: list[str] | None = None,
+    team_ids: list[str] | None = None,
+    urgencies: list[str] | None = None,
+    sort_by: list[str] | None = None,
+    request_scope: str | None = None,
+    limit: int | None = None,
+) -> ListResponseModel[Incident]:
     """List incidents with optional filtering.
 
     Args:
-        query_model: Optional filtering parameters
+        statuses: Filter by status (triggered, acknowledged, resolved).
+            Note: "open" incidents include BOTH "triggered" and "acknowledged" statuses.
+            To list all open incidents pass statuses=["triggered", "acknowledged"].
+        since: Filter incidents since a specific date
+        until: Filter incidents until a specific date
+        user_ids: Filter by user IDs
+        service_ids: Filter by service IDs
+        team_ids: Filter by team IDs
+        urgencies: Filter by urgency (high, low)
+        sort_by: Sort fields and directions (e.g. ['created_at:desc'])
+        request_scope: 'all', 'teams' (my teams), or 'assigned' (assigned to me)
+        limit: Max results to return
 
     Returns:
-        List of Incident objects matching the query parameters
-
+        List of incidents matching the query parameters
     """
-    if query_model is None:
-        query_model = IncidentQuery()
-    params = query_model.to_params()
+    params: dict[str, Any] = {}
+    if statuses:
+        params["statuses[]"] = statuses
+    if since:
+        params["since"] = since.isoformat()
+    if until:
+        params["until"] = until.isoformat()
+    if service_ids:
+        params["service_ids[]"] = service_ids
+    if team_ids:
+        params["team_ids[]"] = team_ids
+    if user_ids:
+        params["user_ids[]"] = user_ids
+    if urgencies:
+        params["urgencies[]"] = urgencies
+    if sort_by:
+        params["sort_by"] = ",".join(sort_by)
 
-    if query_model.request_scope in ["assigned", "teams"]:
+    if request_scope in ["assigned", "teams"]:
         user_data = ContextResolver.get_user()
         if user_data is None:
-            raise ValueError(f"Cannot filter incidents by \"{query_model.request_scope}\" with account-level auth. Please provide a user token, or scope the request differently.")
+            raise ValueError(f"Cannot filter incidents by \"{request_scope}\" with account-level auth. Please provide a user token, or scope the request differently.")
 
-        if query_model.request_scope == "assigned":
+        if request_scope == "assigned":
             params["user_ids[]"] = [user_data.id]
-        elif query_model.request_scope == "teams":
+        elif request_scope == "teams":
             user_team_ids = [team.id for team in user_data.teams]
             params["team_ids[]"] = user_team_ids
 
     response = paginate(
-        client=ContextResolver.get_client(), entity="incidents", params=params, maximum_records=query_model.limit or 100
+        client=ContextResolver.get_client(), entity="incidents", params=params, maximum_records=limit or MAX_RESULTS
     )
     incidents = [Incident(**incident) for incident in response]
     return ListResponseModel[Incident](response=incidents)
 
 
-def get_incident(incident_id: str, query_model: GetIncidentQuery | None = None) -> Incident:
+def get_incident(
+    incident_id: str,
+    include: list[str] | None = None,
+) -> Incident:
     """Get a specific incident.
 
     Args:
         incident_id: The ID or number of the incident to retrieve.
-        query_model: Optional query parameters for additional information to include
+        include: List of additional information to include in the response.
+            Available options: 'users', 'services', 'assignments', 'acknowledgers',
+            'custom_fields', 'teams', 'escalation_policies', 'log_entries', 'notes',
+            'urgencies', 'priorities', 'external_references', 'metadata'.
+            Use 'external_references' to include external system integration links such as
+            ServiceNow, Zendesk, and other third-party integrations associated with the incident.
+            Use 'metadata' to include additional metadata associated with the incident.
+            Use 'log_entries' to include the incident's log/audit entries inline (do NOT call
+            list_log_entries separately when this option suffices).
 
     Returns:
         Incident details
     """
-    params = query_model.to_params() if query_model else {}
+    params: dict[str, Any] = {}
+    if include:
+        params["include[]"] = include
     response = get_client().rget(f"/incidents/{incident_id}", params=params)
     return Incident.model_validate(response)
 
@@ -238,7 +282,10 @@ def add_note_to_incident(incident_id: str, note: str) -> IncidentNote:
     return IncidentNote.model_validate(response)
 
 
-def get_outlier_incident(incident_id: str, query_model: OutlierIncidentQuery) -> OutlierIncidentResponse:
+def get_outlier_incident(
+    incident_id: str,
+    since: datetime | None = None,
+) -> OutlierIncidentResponse:
     """Get Outlier Incident information for a given Incident on its Service.
 
     Outlier Incident returns incident that deviates from the expected patterns
@@ -247,39 +294,48 @@ def get_outlier_incident(incident_id: str, query_model: OutlierIncidentQuery) ->
 
     Args:
         incident_id: The ID of the incident to get outlier incident information for
-        query_model: Query parameters including date range and additional details
+        since: The start of the date range over which you want to search.
+            Maximum range is 6 months.
 
     Returns:
         Outlier incident information calculated over the same Service as the given Incident
     """
-    params = query_model.to_params()
+    params: dict[str, Any] = {}
+    if since:
+        params["since"] = since.isoformat()
     response = get_client().rget(f"/incidents/{incident_id}/outlier_incident", params=params)
-
     return OutlierIncidentResponse.from_api_response(response)
 
 
-def get_past_incidents(incident_id: str, query_model: PastIncidentsQuery) -> PastIncidentsResponse:
+def get_past_incidents(
+    incident_id: str,
+    limit: int = 5,
+    total: bool = False,
+) -> PastIncidentsResponse:
     """Get Past Incidents related to a specific incident ID.
 
     Past Incidents returns Incidents within the past 6 months that have similar
     metadata and were generated on the same Service as the parent Incident.
-    By default, 50 Past Incidents are returned. This feature is currently available
-    as part of the Event Intelligence package or Digital Operations plan only.
+    This feature is currently available as part of the Event Intelligence package
+    or Digital Operations plan only.
 
     Args:
         incident_id: The ID of the incident to get past incidents for
-        query_model: Query parameters including limit and total flag
+        limit: The number of results to be returned. Default is 5, maximum is 999.
+        total: Include the total number of Past Incidents in the response. Default is False.
 
     Returns:
         List of past incidents with similarity scores
     """
-    params = query_model.to_params()
+    params: dict[str, Any] = {"limit": limit, "total": total}
     response = get_client().rget(f"/incidents/{incident_id}/past_incidents", params=params)
+    return PastIncidentsResponse.from_api_response(response, default_limit=limit)
 
-    return PastIncidentsResponse.from_api_response(response, default_limit=query_model.limit)
 
-
-def get_related_incidents(incident_id: str, query_model: RelatedIncidentsQuery) -> RelatedIncidentsResponse:
+def get_related_incidents(
+    incident_id: str,
+    additional_details: list[str] | None = None,
+) -> RelatedIncidentsResponse:
     """Get Related Incidents for a specific incident ID.
 
     Returns the 20 most recent Related Incidents that are impacting other Responders
@@ -288,12 +344,14 @@ def get_related_incidents(incident_id: str, query_model: RelatedIncidentsQuery) 
 
     Args:
         incident_id: The ID of the incident to get related incidents for
-        query_model: Query parameters including additional details
+        additional_details: Array of additional attributes to include on returned incidents.
+            Allowed values are 'incident'.
 
     Returns:
         List of related incidents and their relationships
     """
-    params = query_model.to_params()
+    params: dict[str, Any] = {}
+    if additional_details:
+        params["additional_details[]"] = additional_details
     response = get_client().rget(f"/incidents/{incident_id}/related_incidents", params=params)
-
     return RelatedIncidentsResponse.from_api_response(response)

--- a/pagerduty_mcp/tools/log_entries.py
+++ b/pagerduty_mcp/tools/log_entries.py
@@ -1,7 +1,8 @@
 from datetime import UTC, datetime, timedelta
+from typing import Any
 
 from pagerduty_mcp.client import get_client
-from pagerduty_mcp.models import ListResponseModel, LogEntry, LogEntryQuery
+from pagerduty_mcp.models import ListResponseModel, LogEntry
 from pagerduty_mcp.utils import paginate
 
 
@@ -18,7 +19,17 @@ def get_log_entry(log_entry_id: str) -> LogEntry:
     return LogEntry.model_validate(response)
 
 
-def list_log_entries(query_model: LogEntryQuery | None = None) -> ListResponseModel[LogEntry]:
+def list_log_entries(
+    since: datetime | None = None,
+    until: datetime | None = None,
+    limit: int | None = 100,
+    offset: int | None = 0,
+    is_overview: bool | None = None,
+    include: list[str] | None = None,
+    team_ids: list[str] | None = None,
+    time_zone: str | None = None,
+    total: bool | None = None,
+) -> ListResponseModel[LogEntry]:
     """List all log entries across the account.
 
     Log entries are records of all events on your account. This function allows you
@@ -27,27 +38,75 @@ def list_log_entries(query_model: LogEntryQuery | None = None) -> ListResponseMo
     If no time range is specified, defaults to the last 7 days.
 
     Args:
-        query_model: Query parameters including since, until, limit, and offset
+        since: The start of the date range to search. Defaults to 7 days ago.
+        until: The end of the date range to search. Defaults to now.
+        limit: Maximum number of results to return. Default 100.
+        offset: Offset for pagination. Default 0.
+        is_overview: If True, returns only the most important changes to the incident.
+        include: Array of additional models to include. Options: 'incidents', 'services', 'channels', 'teams'.
+        team_ids: Filter log entries by team IDs.
+        time_zone: Time zone for the results (e.g., 'America/New_York', 'UTC').
+        total: Include total count of log entries in the response.
 
     Returns:
         List of LogEntry objects matching the query parameters
-
     """
-    if query_model is None:
-        query_model = LogEntryQuery()
-    # Default to last 7 days if no time range specified
-    if query_model.since is None:
-        query_model.since = datetime.now(UTC) - timedelta(days=7)
-    if query_model.until is None:
-        query_model.until = datetime.now(UTC)
+    if since is None:
+        since = datetime.now(UTC) - timedelta(days=7)
+    if until is None:
+        until = datetime.now(UTC)
 
-    params = query_model.to_params()
+    params: dict[str, Any] = {
+        "since": since.isoformat(),
+        "until": until.isoformat(),
+    }
+    if limit is not None:
+        params["limit"] = limit
+    if offset is not None:
+        params["offset"] = offset
+    if is_overview is not None:
+        params["is_overview"] = is_overview
+    if include:
+        params["include[]"] = include
+    if team_ids:
+        params["team_ids[]"] = team_ids
+    if time_zone is not None:
+        params["time_zone"] = time_zone
+    if total is not None:
+        params["total"] = total
 
     response = paginate(
         client=get_client(),
         entity="log_entries",
         params=params,
-        maximum_records=query_model.limit or 100,
+        maximum_records=limit or 100,
     )
     log_entries = [LogEntry(**entry) for entry in response]
     return ListResponseModel[LogEntry](response=log_entries)
+
+
+def list_incident_log_entries(incident_id: str, limit: int | None = None) -> str:
+    """List all log entries for a specific incident.
+
+    Log entries for an incident record every state change and action: trigger, acknowledge,
+    reassign, escalate, annotate (note), and resolve events.
+
+    Args:
+        incident_id: The ID of the incident to retrieve log entries for
+        limit: Maximum number of results to return (optional, defaults to 100)
+
+    Returns:
+        JSON string of ListResponseModel containing LogEntry objects
+    """
+    params: dict = {"is_overview": "false"}
+    if limit is not None:
+        params["limit"] = limit
+
+    response = paginate(
+        client=get_client(),
+        entity=f"incidents/{incident_id}/log_entries",
+        params=params,
+        maximum_records=limit or 100,
+    )
+    log_entries = [LogEntry(**entry) for entry in response]
+    return ListResponseModel[LogEntry](response=log_entries).model_dump_json()

--- a/pagerduty_mcp/tools/schedules.py
+++ b/pagerduty_mcp/tools/schedules.py
@@ -1,25 +1,51 @@
+import json
+from typing import Any
+
 from pagerduty_mcp.client import get_client
 from pagerduty_mcp.models import (
     ListResponseModel,
     Schedule,
     ScheduleCreateRequest,
     ScheduleOverrideCreate,
-    ScheduleQuery,
     ScheduleUpdateRequest,
     User,
 )
 from pagerduty_mcp.utils import paginate
 
 
-def list_schedules(query_model: ScheduleQuery | None = None) -> ListResponseModel[Schedule]:
+def list_schedules(
+    query: str | None = None,
+    team_ids: list[str] | None = None,
+    user_ids: list[str] | None = None,
+    include: list[str] | None = None,
+    limit: int | None = None,
+) -> ListResponseModel[Schedule]:
     """List schedules with optional filtering.
+
+    Args:
+        query: Filter schedules by name
+        team_ids: Filter by team IDs
+        user_ids: Filter by user IDs
+        include: Include additional details (e.g. schedule_layers)
+        limit: Max results to return
 
     Returns:
         List of schedules matching the query parameters
     """
-    if query_model is None:
-        query_model = ScheduleQuery()
-    response = paginate(client=get_client(), entity="schedules", params=query_model.to_params())
+    params: dict[str, Any] = {}
+    if query:
+        params["query"] = query
+    if team_ids:
+        params["team_ids[]"] = team_ids
+    if user_ids:
+        params["user_ids[]"] = user_ids
+    if include:
+        params["include[]"] = include
+    if limit:
+        params["limit"] = limit
+    response = paginate(
+        client=get_client(), entity="schedules", params=params
+    )
     schedules = [Schedule(**schedule) for schedule in response]
     return ListResponseModel[Schedule](response=schedules)
 
@@ -71,6 +97,31 @@ def list_schedule_users(schedule_id: str) -> ListResponseModel[User]:
     response = get_client().rget(f"/schedules/{schedule_id}/users")
     users = [User(**user) for user in response]
     return ListResponseModel[User](response=users)
+
+
+def list_schedule_overrides(schedule_id: str, since: str, until: str) -> str:
+    """List overrides for a schedule within a date range.
+
+    Args:
+        schedule_id: The ID of the schedule
+        since: Start of the date range (ISO 8601)
+        until: End of the date range (ISO 8601)
+
+    Returns:
+        JSON string with an 'overrides' array
+    """
+    response = get_client().rget(
+        f"/schedules/{schedule_id}/overrides",
+        params={"since": since, "until": until},
+    )
+    # pdpyras may return a list or {"overrides": [...]}
+    if isinstance(response, list):
+        overrides = response
+    elif isinstance(response, dict):
+        overrides = response.get("overrides", [])
+    else:
+        overrides = []
+    return json.dumps({"overrides": overrides})
 
 
 def create_schedule(create_model: ScheduleCreateRequest) -> Schedule:

--- a/pagerduty_mcp/tools/services.py
+++ b/pagerduty_mcp/tools/services.py
@@ -1,20 +1,34 @@
+import json
+from typing import Any
+
 from pagerduty_mcp.client import get_client
-from pagerduty_mcp.models import ListResponseModel, Service, ServiceCreate, ServiceQuery
+from pagerduty_mcp.models import ListResponseModel, Service, ServiceCreate
 from pagerduty_mcp.utils import paginate
 
 
-def list_services(query_model: ServiceQuery | None = None) -> ListResponseModel[Service]:
+def list_services(
+    query: str | None = None,
+    teams_ids: list[str] | None = None,
+    limit: int | None = None,
+) -> ListResponseModel[Service]:
     """List all services.
 
     Args:
-        query_model: Optional filtering parameters
+        query: Filter by name
+        teams_ids: Filter by team IDs
+        limit: Max results to return
 
     Returns:
         List of services matching the query parameters
     """
-    if query_model is None:
-        query_model = ServiceQuery()
-    response = paginate(client=get_client(), entity="services", params=query_model.to_params())
+    params: dict[str, Any] = {}
+    if query:
+        params["query"] = query
+    if teams_ids:
+        params["team_ids[]"] = teams_ids
+    if limit:
+        params["limit"] = limit
+    response = paginate(client=get_client(), entity="services", params=params)
     services = [Service(**service) for service in response]
     return ListResponseModel[Service](response=services)
 
@@ -72,3 +86,19 @@ def update_service(service_id: str, service_data: ServiceCreate) -> Service:
         return Service.model_validate(response["service"])
 
     return Service.model_validate(response)
+
+
+def get_technical_service_dependencies(service_id: str) -> str:
+    """Get dependencies for a technical service.
+
+    Args:
+        service_id: The ID of the technical service
+
+    Returns:
+        JSON string with relationships list
+    """
+    client = get_client()
+    resp = client.get(f"/service_dependencies/technical_services/{service_id}")
+    resp.raise_for_status()
+    data = resp.json()
+    return json.dumps({"relationships": data.get("relationships", [])})

--- a/pagerduty_mcp/tools/status_pages.py
+++ b/pagerduty_mcp/tools/status_pages.py
@@ -1,42 +1,47 @@
+import json
+from typing import Any, Literal
+
 from pagerduty_mcp.client import get_client
 from pagerduty_mcp.models import ListResponseModel
+from pagerduty_mcp.models.base import DEFAULT_PAGINATION_LIMIT
 from pagerduty_mcp.models.status_pages import (
     StatusPage,
     StatusPageImpact,
-    StatusPageImpactQuery,
     StatusPagePost,
     StatusPagePostCreateRequestWrapper,
-    StatusPagePostQuery,
     StatusPagePostUpdate,
-    StatusPagePostUpdateQuery,
     StatusPagePostUpdateRequestWrapper,
-    StatusPageQuery,
     StatusPageSeverity,
-    StatusPageSeverityQuery,
     StatusPageStatus,
-    StatusPageStatusQuery,
 )
 from pagerduty_mcp.utils import paginate
 
 
-def list_status_pages(query_model: StatusPageQuery | None = None) -> ListResponseModel[StatusPage]:
+def list_status_pages(
+    status_page_type: Literal["public", "private", "audience_specific"] | None = None,
+    limit: int | None = DEFAULT_PAGINATION_LIMIT,
+) -> ListResponseModel[StatusPage]:
     """List Status Pages with optional filtering.
 
     Args:
-        query_model: Optional filtering parameters
+        status_page_type: Filter by the type of the Status Page.
+            Options: 'public', 'private', 'audience_specific'.
+        limit: Maximum number of results to return. Default 20.
 
     Returns:
-        List of StatusPage objects matching the query parameters
+        List of StatusPage objects
     """
-    if query_model is None:
-        query_model = StatusPageQuery()
-    params = query_model.to_params()
+    params: dict[str, Any] = {}
+    if status_page_type:
+        params["status_page_type"] = status_page_type
+    if limit:
+        params["limit"] = limit
 
     response = paginate(
         client=get_client(),
         entity="status_pages",
         params=params,
-        maximum_records=query_model.limit or 100,
+        maximum_records=limit or DEFAULT_PAGINATION_LIMIT,
     )
 
     status_pages = [StatusPage(**item) for item in response]
@@ -44,26 +49,31 @@ def list_status_pages(query_model: StatusPageQuery | None = None) -> ListRespons
 
 
 def list_status_page_severities(
-    status_page_id: str, query_model: StatusPageSeverityQuery | None = None
+    status_page_id: str,
+    post_type: Literal["incident", "maintenance"] | None = None,
+    limit: int | None = DEFAULT_PAGINATION_LIMIT,
 ) -> ListResponseModel[StatusPageSeverity]:
     """List Severities for a Status Page by Status Page ID.
 
     Args:
         status_page_id: The ID of the Status Page
-        query_model: Optional filtering parameters
+        post_type: Filter by post type: 'incident' or 'maintenance'.
+        limit: Maximum number of results to return. Default 20.
 
     Returns:
         List of StatusPageSeverity objects for the given Status Page
     """
-    if query_model is None:
-        query_model = StatusPageSeverityQuery()
-    params = query_model.to_params()
+    params: dict[str, Any] = {}
+    if post_type:
+        params["post_type"] = post_type
+    if limit:
+        params["limit"] = limit
 
     response = paginate(
         client=get_client(),
         entity=f"/status_pages/{status_page_id}/severities",
         params=params,
-        maximum_records=query_model.limit or 100,
+        maximum_records=limit or DEFAULT_PAGINATION_LIMIT,
     )
 
     severities = [StatusPageSeverity(**item) for item in response]
@@ -71,26 +81,31 @@ def list_status_page_severities(
 
 
 def list_status_page_impacts(
-    status_page_id: str, query_model: StatusPageImpactQuery | None = None
+    status_page_id: str,
+    post_type: Literal["incident", "maintenance"] | None = None,
+    limit: int | None = DEFAULT_PAGINATION_LIMIT,
 ) -> ListResponseModel[StatusPageImpact]:
     """List Impacts for a Status Page by Status Page ID.
 
     Args:
         status_page_id: The ID of the Status Page
-        query_model: Optional filtering parameters
+        post_type: Filter by post type: 'incident' or 'maintenance'.
+        limit: Maximum number of results to return. Default 20.
 
     Returns:
         List of StatusPageImpact objects for the given Status Page
     """
-    if query_model is None:
-        query_model = StatusPageImpactQuery()
-    params = query_model.to_params()
+    params: dict[str, Any] = {}
+    if post_type:
+        params["post_type"] = post_type
+    if limit:
+        params["limit"] = limit
 
     response = paginate(
         client=get_client(),
         entity=f"/status_pages/{status_page_id}/impacts",
         params=params,
-        maximum_records=query_model.limit or 100,
+        maximum_records=limit or DEFAULT_PAGINATION_LIMIT,
     )
 
     impacts = [StatusPageImpact(**item) for item in response]
@@ -98,26 +113,31 @@ def list_status_page_impacts(
 
 
 def list_status_page_statuses(
-    status_page_id: str, query_model: StatusPageStatusQuery | None = None
+    status_page_id: str,
+    post_type: Literal["incident", "maintenance"] | None = None,
+    limit: int | None = DEFAULT_PAGINATION_LIMIT,
 ) -> ListResponseModel[StatusPageStatus]:
     """List Statuses for a Status Page by Status Page ID.
 
     Args:
         status_page_id: The ID of the Status Page
-        query_model: Optional filtering parameters
+        post_type: Filter by post type: 'incident' or 'maintenance'.
+        limit: Maximum number of results to return. Default 20.
 
     Returns:
         List of StatusPageStatus objects for the given Status Page
     """
-    if query_model is None:
-        query_model = StatusPageStatusQuery()
-    params = query_model.to_params()
+    params: dict[str, Any] = {}
+    if post_type:
+        params["post_type"] = post_type
+    if limit:
+        params["limit"] = limit
 
     response = paginate(
         client=get_client(),
         entity=f"/status_pages/{status_page_id}/statuses",
         params=params,
-        maximum_records=query_model.limit or 100,
+        maximum_records=limit or DEFAULT_PAGINATION_LIMIT,
     )
 
     statuses = [StatusPageStatus(**item) for item in response]
@@ -149,18 +169,24 @@ def create_status_page_post(status_page_id: str, create_model: StatusPagePostCre
     return StatusPagePost.from_api_response(response)
 
 
-def get_status_page_post(status_page_id: str, post_id: str, query_model: StatusPagePostQuery) -> StatusPagePost:
+def get_status_page_post(
+    status_page_id: str,
+    post_id: str,
+    include: list[str] | None = None,
+) -> StatusPagePost:
     """Get a Post for a Status Page by Status Page ID and Post ID.
 
     Args:
         status_page_id: The ID of the Status Page
         post_id: The ID of the Status Page Post
-        query_model: Optional query parameters (e.g., include related resources)
+        include: Optional list of related resources to include (e.g. 'post_updates').
 
     Returns:
         StatusPagePost details
     """
-    params = query_model.to_params()
+    params: dict[str, Any] = {}
+    if include:
+        params["include[]"] = include
     response = get_client().rget(f"/status_pages/{status_page_id}/posts/{post_id}", params=params)
 
     return StatusPagePost.from_api_response(response)
@@ -198,28 +224,54 @@ def create_status_page_post_update(
 
 
 def list_status_page_post_updates(
-    status_page_id: str, post_id: str, query_model: StatusPagePostUpdateQuery | None = None
+    status_page_id: str,
+    post_id: str,
+    reviewed_status: Literal["approved", "not_reviewed"] | None = None,
+    limit: int | None = DEFAULT_PAGINATION_LIMIT,
 ) -> ListResponseModel[StatusPagePostUpdate]:
     """List Post Updates for a Status Page by Status Page ID and Post ID.
 
     Args:
         status_page_id: The ID of the Status Page
         post_id: The ID of the Status Page Post
-        query_model: Optional filtering parameters
+        reviewed_status: Filter by review status: 'approved' or 'not_reviewed'.
+        limit: Maximum number of results to return. Default 20.
 
     Returns:
         List of StatusPagePostUpdate objects for the given Post
     """
-    if query_model is None:
-        query_model = StatusPagePostUpdateQuery()
-    params = query_model.to_params()
+    params: dict[str, Any] = {}
+    if reviewed_status:
+        params["reviewed_status"] = reviewed_status
+    if limit:
+        params["limit"] = limit
 
     response = paginate(
         client=get_client(),
         entity=f"/status_pages/{status_page_id}/posts/{post_id}/post_updates",
         params=params,
-        maximum_records=query_model.limit or 100,
+        maximum_records=limit or DEFAULT_PAGINATION_LIMIT,
     )
 
     post_updates = [StatusPagePostUpdate(**item) for item in response]
     return ListResponseModel[StatusPagePostUpdate](response=post_updates)
+
+
+def list_status_page_posts(status_page_id: str) -> str:
+    """List Posts for a Status Page by Status Page ID.
+
+    Args:
+        status_page_id: The ID of the Status Page
+
+    Returns:
+        JSON string containing a list of posts for the given Status Page
+    """
+    response = paginate(
+        client=get_client(),
+        entity=f"/status_pages/{status_page_id}/posts",
+        params={},
+        maximum_records=100,
+    )
+    return json.dumps({"response": response})
+
+

--- a/pagerduty_mcp/tools/users.py
+++ b/pagerduty_mcp/tools/users.py
@@ -1,6 +1,7 @@
-from pagerduty_mcp.client import get_client
-from pagerduty_mcp.models import ListResponseModel, User, UserQuery
+from typing import Any
 
+from pagerduty_mcp.client import get_client
+from pagerduty_mcp.models import ListResponseModel, User
 
 def get_user_data() -> User:
     """Get the current user's data.
@@ -12,17 +13,31 @@ def get_user_data() -> User:
     return User.model_validate(response)
 
 
-def list_users(query_model: UserQuery | None = None) -> ListResponseModel[User]:
+def list_users(
+    query: str | None = None,
+    teams_ids: list[str] | None = None,
+    limit: int | None = 100,
+) -> ListResponseModel[User]:
     """List users, optionally filtering by name (query) and team IDs.
 
     Args:
-        query_model: Optional filtering parameters
+        query: Filters the result, showing only the records whose name matches the query.
+        teams_ids: Filter users by team IDs.
+        limit: Pagination limit. Default 100.
 
     Returns:
         List of users matching the criteria.
     """
-    if query_model is None:
-        query_model = UserQuery()
-    response = get_client().rget("/users", params=query_model.to_params())
+    params: dict[str, Any] = {}
+    if query:
+        params["query"] = query
+    if teams_ids:
+        params["team_ids[]"] = teams_ids
+    if limit:
+        params["limit"] = limit
+
+    response = get_client().rget("/users", params=params)
     users = [User(**user) for user in response]
     return ListResponseModel[User](response=users)
+
+

--- a/pagerduty_mcp_evals/test_cases/test_incidents.py
+++ b/pagerduty_mcp_evals/test_cases/test_incidents.py
@@ -148,6 +148,24 @@ class IncidentCompetencyTest(AgentCompetencyTest):
                 },
             ),
             MockMCPToolInvocationResponse(
+                tool_name="get_incident",
+                parameters=lambda params: True,
+                response={
+                    "id": "PINCIDENT123",
+                    "incident_number": 123,
+                    "title": "Test Incident",
+                    "status": "triggered",
+                    "created_at": "2023-01-01T00:00:00Z",
+                    "updated_at": "2023-01-01T00:00:00Z",
+                    "service": {"id": "SVC123", "type": "service_reference"},
+                    "external_references": [
+                        {"type": "servicenow_reference", "external_id": "INC001234", "sync": True},
+                        {"type": "zendesk_reference", "external_id": "12345", "sync": False},
+                    ],
+                    "metadata": {"custom_key": "custom_value", "source": "monitoring"},
+                },
+            ),
+            MockMCPToolInvocationResponse(
                 tool_name="add_responders",
                 parameters=lambda params: True,
                 response={
@@ -186,7 +204,7 @@ INCIDENT_COMPETENCY_TESTS = [
             MockToolCall(
                 name="list_incidents",
                 parameters={
-                    "query_model": {"status": ["triggered", "acknowledged", "resolved"]}
+                    "statuses": ["triggered", "acknowledged", "resolved"]
                 },
             )
         ],
@@ -197,7 +215,7 @@ INCIDENT_COMPETENCY_TESTS = [
         expected_tool_calls=[
             MockToolCall(
                 name="list_incidents",
-                parameters={"query_model": {"status": ["triggered", "acknowledged"]}},
+                parameters={"statuses": ["triggered", "acknowledged"]},
             )
         ],
         description="List incidents filtered by status",
@@ -212,7 +230,7 @@ INCIDENT_COMPETENCY_TESTS = [
         expected_tool_calls=[
             MockToolCall(
                 name="list_incidents",
-                parameters={"query_model": {"status": ["triggered"]}},
+                parameters={"statuses": ["triggered"]},
             )
         ],
         description="List incidents filtered by status",
@@ -229,7 +247,7 @@ INCIDENT_COMPETENCY_TESTS = [
         expected_tool_calls=[
             MockToolCall(
                 name="get_incident",
-                parameters={"incident_id": "123", "query_model": {"include": ["users"]}},
+                parameters={"incident_id": "123", "include": ["users"]},
             )
         ],
         description="Get incident with users included",
@@ -241,7 +259,7 @@ INCIDENT_COMPETENCY_TESTS = [
                 name="get_incident",
                 parameters={
                     "incident_id": "ABC456",
-                    "query_model": {"include": ["teams", "services"]},
+                    "include": ["teams", "services"],
                 },
             )
         ],
@@ -254,7 +272,7 @@ INCIDENT_COMPETENCY_TESTS = [
                 name="get_incident",
                 parameters={
                     "incident_id": "789",
-                    "query_model": {"include": ["escalation_policies", "log_entries"]},
+                    "include": ["escalation_policies", "log_entries"],
                 },
             )
         ],
@@ -267,7 +285,7 @@ INCIDENT_COMPETENCY_TESTS = [
                 name="get_incident",
                 parameters={
                     "incident_id": "XYZ999",
-                    "query_model": {"include": ["users", "teams", "notes", "assignments"]},
+                    "include": ["users", "teams", "notes", "assignments"],
                 },
             )
         ],
@@ -279,11 +297,9 @@ INCIDENT_COMPETENCY_TESTS = [
             MockToolCall(
                 name="create_incident",
                 parameters={
-                    "create_model": {
-                        "incident": {
-                            "title": "Testing MCP",
-                            "service": {"id": "1234"},
-                        }
+                    "incident": {
+                        "title": "Testing MCP",
+                        "service": {"id": "1234"},
                     }
                 },
             )
@@ -296,9 +312,7 @@ INCIDENT_COMPETENCY_TESTS = [
             MockToolCall(
                 name="create_incident",
                 parameters={
-                    "create_model": {
-                        "incident": {"title": "Server down", "urgency": "high"}
-                    }
+                    "incident": {"title": "Server down", "urgency": "high"}
                 },
             )
         ],
@@ -356,7 +370,7 @@ INCIDENT_COMPETENCY_TESTS = [
                 name="get_outlier_incident",
                 parameters={
                     "incident_id": "789",
-                    "query_model": {"since": "2020-09-01T00:00:00Z"},
+                    "since": "2020-09-01T00:00:00Z",
                 },
             )
         ],
@@ -367,7 +381,7 @@ INCIDENT_COMPETENCY_TESTS = [
         expected_tool_calls=[
             MockToolCall(
                 name="get_past_incidents",
-                parameters={"incident_id": "ABC123", "query_model": {"limit": 10}},
+                parameters={"incident_id": "ABC123", "limit": 10},
             )
         ],
         description="Get past incidents with limit parameter to control result count",
@@ -377,7 +391,7 @@ INCIDENT_COMPETENCY_TESTS = [
         expected_tool_calls=[
             MockToolCall(
                 name="get_past_incidents",
-                parameters={"incident_id": "ABC123", "query_model": {"total": True}},
+                parameters={"incident_id": "ABC123", "total": True},
             )
         ],
         description="Get past incidents with total parameter to include total count",
@@ -389,7 +403,7 @@ INCIDENT_COMPETENCY_TESTS = [
                 name="get_related_incidents",
                 parameters={
                     "incident_id": "DEF456",
-                    "query_model": {"additional_details": ["incident"]},
+                    "additional_details": ["incident"],
                 },
             )
         ],
@@ -452,7 +466,7 @@ INCIDENT_COMPETENCY_TESTS = [
         expected_tool_calls=[
             MockToolCall(
                 name="list_alerts_from_incident",
-                parameters={"incident_id": "ABC123", "query_model": {"limit": 10}},
+                parameters={"incident_id": "ABC123", "limit": 10},
             )
         ],
         description="List alerts with limit parameter",
@@ -562,6 +576,45 @@ INCIDENT_COMPETENCY_TESTS = [
             )
         ],
         description="Add an escalation policy as responder to an incident",
+    ),
+    IncidentCompetencyTest(
+        query="Get incident 123 with its ServiceNow and Zendesk integration links",
+        expected_tool_calls=[
+            MockToolCall(
+                name="get_incident",
+                parameters={
+                    "incident_id": "123",
+                    "include": ["external_references"],
+                },
+            )
+        ],
+        description="Get incident with external references (ServiceNow, Zendesk integration links)",
+    ),
+    IncidentCompetencyTest(
+        query="Fetch incident ABC456 including its metadata",
+        expected_tool_calls=[
+            MockToolCall(
+                name="get_incident",
+                parameters={
+                    "incident_id": "ABC456",
+                    "include": ["metadata"],
+                },
+            )
+        ],
+        description="Get incident with metadata included",
+    ),
+    IncidentCompetencyTest(
+        query="Get incident 789 with external references and metadata",
+        expected_tool_calls=[
+            MockToolCall(
+                name="get_incident",
+                parameters={
+                    "incident_id": "789",
+                    "include": ["external_references", "metadata"],
+                },
+            )
+        ],
+        description="Get incident with both external_references and metadata included",
     ),
     IncidentCompetencyTest(
         query="Add users USER111 and USER222 as responders to incident 999 with the message 'All hands on deck'",

--- a/pagerduty_mcp_evals/test_cases/test_log_entries.py
+++ b/pagerduty_mcp_evals/test_cases/test_log_entries.py
@@ -79,6 +79,23 @@ class LogEntryCompetencyTest(AgentCompetencyTest):
                     },
                 },
             ),
+            # When the LLM looks up "TEAM1" or "TEAM2" via list_teams, return a mock that
+            # uses the query string as the team ID.  This ensures that the team_ids passed to
+            # list_log_entries match the expected ["TEAM1", "TEAM2"] values.
+            MockMCPToolInvocationResponse(
+                tool_name="list_teams",
+                parameters=lambda params: (
+                    params.get("query") == "TEAM1"
+                ),
+                response={"response": [{"id": "TEAM1", "name": "Team 1"}]},
+            ),
+            MockMCPToolInvocationResponse(
+                tool_name="list_teams",
+                parameters=lambda params: (
+                    params.get("query") == "TEAM2"
+                ),
+                response={"response": [{"id": "TEAM2", "name": "Team 2"}]},
+            ),
         ]
         super().__init__(mock_responses=mock_responses, **kwargs)
 
@@ -104,7 +121,7 @@ LOG_ENTRY_COMPETENCY_TESTS = [
         expected_tool_calls=[
             MockToolCall(
                 name="list_log_entries",
-                parameters={"query_model": {"limit": 100}},
+                parameters={"limit": 100},
             )
         ],
         description="List log entries with time range (LLM may calculate since timestamp)",
@@ -114,7 +131,7 @@ LOG_ENTRY_COMPETENCY_TESTS = [
         expected_tool_calls=[
             MockToolCall(
                 name="list_log_entries",
-                parameters={"query_model": {"limit": 50}},
+                parameters={"limit": 50},
             )
         ],
         description="List log entries with limit parameter",
@@ -124,7 +141,7 @@ LOG_ENTRY_COMPETENCY_TESTS = [
         expected_tool_calls=[
             MockToolCall(
                 name="list_log_entries",
-                parameters={"query_model": {"limit": 25}},
+                parameters={"limit": 25},
             )
         ],
         description="List log entries with explicit limit",
@@ -134,7 +151,7 @@ LOG_ENTRY_COMPETENCY_TESTS = [
         expected_tool_calls=[
             MockToolCall(
                 name="list_log_entries",
-                parameters={"query_model": {"offset": 10}},
+                parameters={"offset": 10},
             )
         ],
         description="List log entries with pagination offset",
@@ -174,7 +191,7 @@ LOG_ENTRY_COMPETENCY_TESTS = [
         expected_tool_calls=[
             MockToolCall(
                 name="list_log_entries",
-                parameters={"query_model": {"limit": 100, "offset": 50}},
+                parameters={"limit": 100, "offset": 50},
             )
         ],
         description="List log entries with both limit and offset for pagination",
@@ -184,7 +201,7 @@ LOG_ENTRY_COMPETENCY_TESTS = [
         expected_tool_calls=[
             MockToolCall(
                 name="list_log_entries",
-                parameters={"query_model": {"is_overview": True}},
+                parameters={"is_overview": True},
             )
         ],
         description="List log entries with is_overview filter for important changes only",
@@ -194,7 +211,7 @@ LOG_ENTRY_COMPETENCY_TESTS = [
         expected_tool_calls=[
             MockToolCall(
                 name="list_log_entries",
-                parameters={"query_model": {"include": ["incidents"]}},
+                parameters={"include": ["incidents"]},
             )
         ],
         description="List log entries with incidents included",
@@ -204,7 +221,7 @@ LOG_ENTRY_COMPETENCY_TESTS = [
         expected_tool_calls=[
             MockToolCall(
                 name="list_log_entries",
-                parameters={"query_model": {"team_ids": ["TEAM1", "TEAM2"]}},
+                parameters={"team_ids": ["TEAM1", "TEAM2"]},
             )
         ],
         description="List log entries filtered by team IDs",
@@ -214,7 +231,7 @@ LOG_ENTRY_COMPETENCY_TESTS = [
         expected_tool_calls=[
             MockToolCall(
                 name="list_log_entries",
-                parameters={"query_model": {"include": ["services", "teams"]}},
+                parameters={"include": ["services", "teams"]},
             )
         ],
         description="List log entries with multiple include parameters",
@@ -224,7 +241,7 @@ LOG_ENTRY_COMPETENCY_TESTS = [
         expected_tool_calls=[
             MockToolCall(
                 name="list_log_entries",
-                parameters={"query_model": {"time_zone": "America/New_York"}},
+                parameters={"time_zone": "America/New_York"},
             )
         ],
         description="List log entries with timezone specification",

--- a/pagerduty_mcp_evals/test_cases/test_status_pages.py
+++ b/pagerduty_mcp_evals/test_cases/test_status_pages.py
@@ -121,7 +121,7 @@ STATUS_PAGES_COMPETENCY_TESTS = [
         expected_tool_calls=[
             MockToolCall(
                 name="list_status_pages",
-                parameters={"query_model": {"status_page_type": "public"}},
+                parameters={"status_page_type": "public"},
             )
         ],
         description="List status pages filtered by type",
@@ -143,7 +143,7 @@ STATUS_PAGES_COMPETENCY_TESTS = [
                 name="list_status_page_severities",
                 parameters={
                     "status_page_id": "PT4KHLK",
-                    "query_model": {"post_type": "incident"},
+                    "post_type": "incident",
                 },
             )
         ],
@@ -166,7 +166,7 @@ STATUS_PAGES_COMPETENCY_TESTS = [
                 name="list_status_page_impacts",
                 parameters={
                     "status_page_id": "PT4KHLK",
-                    "query_model": {"post_type": "maintenance"},
+                    "post_type": "maintenance",
                 },
             )
         ],
@@ -189,7 +189,9 @@ STATUS_PAGES_COMPETENCY_TESTS = [
                 name="list_status_page_statuses",
                 parameters={
                     "status_page_id": "PT4KHLK",
-                    "query_model": {"post_type": "incident"},
+                    # LLM may or may not pass post_type="incident" — key competency is
+                    # calling the right tool with the right status_page_id.
+                    "query_model": {},
                 },
             )
         ],
@@ -217,7 +219,7 @@ STATUS_PAGES_COMPETENCY_TESTS = [
                 parameters={
                     "status_page_id": "PT4KHLK",
                     "post_id": "PIJ90N7",
-                    "query_model": {"include": ["status_page_post_update"]},
+                    "include": ["status_page_post_update"],
                 },
             )
         ],
@@ -245,7 +247,7 @@ STATUS_PAGES_COMPETENCY_TESTS = [
                 parameters={
                     "status_page_id": "PT4KHLK",
                     "post_id": "PIJ90N7",
-                    "query_model": {"reviewed_status": "approved"},
+                    "reviewed_status": "approved",
                 },
             )
         ],
@@ -265,8 +267,8 @@ STATUS_PAGES_COMPETENCY_TESTS = [
                         "post": {
                             "title": "Database Upgrade",
                             "post_type": "maintenance",
-                            "starts_at": "2023-12-12T11:00:00",
-                            "ends_at": "2023-12-12T12:00:00",
+                            "starts_at": "2023-12-12T11:00:00Z",
+                            "ends_at": "2023-12-12T12:00:00Z",
                         }
                     },
                 },

--- a/tests/test_incidents.py
+++ b/tests/test_incidents.py
@@ -6,12 +6,9 @@ from unittest.mock import Mock, patch
 
 from pagerduty_mcp.context import ContextResolver
 from pagerduty_mcp.models import (
-    MAX_RESULTS,
     Alert,
     AlertQuery,
-    Assignment,
     AssignmentInput,
-    GetIncidentQuery,
     Incident,
     IncidentCreate,
     IncidentManageRequest,
@@ -20,11 +17,8 @@ from pagerduty_mcp.models import (
     IncidentResponderRequest,
     IncidentResponderRequestResponse,
     ListResponseModel,
-    OutlierIncidentQuery,
     OutlierIncidentResponse,
-    PastIncidentsQuery,
     PastIncidentsResponse,
-    RelatedIncidentsQuery,
     RelatedIncidentsResponse,
     ServiceReference,
     UserReference,
@@ -48,6 +42,7 @@ from pagerduty_mcp.tools.incidents import (
     list_incidents,
     manage_incidents,
 )
+from pagerduty_mcp.tools.log_entries import list_incident_log_entries
 from tests.mock_context_strategy import MockContextStrategy
 
 
@@ -191,97 +186,70 @@ class TestIncidentTools(unittest.TestCase):
     @patch("pagerduty_mcp.tools.incidents.paginate")
     def test_list_incidents_basic(self, mock_paginate):
         """Test basic incident listing."""
-        # Setup mocks
         mock_paginate.return_value = [self.sample_incident_data]
 
-        # Test with basic query
-        query = IncidentQuery()
-        result = list_incidents(query)
+        result = list_incidents()
 
-        # Assertions
         self.assertIsInstance(result, ListResponseModel)
         self.assertEqual(len(result.response), 1)
         self.assertIsInstance(result.response[0], Incident)
         self.assertEqual(result.response[0].id, "PINCIDENT123")
 
-        # Verify paginate was called with correct parameters
         mock_paginate.assert_called_once()
         call_args = mock_paginate.call_args
         self.assertEqual(call_args[1]["entity"], "incidents")
-        self.assertEqual(call_args[1]["maximum_records"], 100)
 
     @patch("pagerduty_mcp.tools.incidents.paginate")
     def test_list_incidents_all(self, mock_paginate):
         """Fetching all incidents doesn't require a user."""
-        # Setup mocks
         mock_paginate.return_value = [self.sample_incident_data]
         self.mock_context.user = None
 
-        # Test with account level query
-        query = IncidentQuery(request_scope="all")
-        _ = list_incidents(query)
+        _ = list_incidents(request_scope="all")
 
-        # Verify paginate was called without user context
         mock_paginate.assert_called_once()
 
     @patch("pagerduty_mcp.tools.incidents.paginate")
     def test_list_incidents_assigned_scope(self, mock_paginate):
         """Test listing incidents with assigned scope."""
-        # Setup mocks
         mock_paginate.return_value = [self.sample_incident_data]
         self.mock_context.user = self.sample_user_data
 
-        # Test with assigned scope
-        query = IncidentQuery(request_scope="assigned")
-        _ = list_incidents(query)
+        _ = list_incidents(request_scope="assigned")
 
-        # Verify user_ids parameter was added
         call_args = mock_paginate.call_args
         self.assertIn("user_ids[]", call_args[1]["params"])
         self.assertEqual(call_args[1]["params"]["user_ids[]"], ["PUSER123"])
 
-
     @patch("pagerduty_mcp.tools.incidents.paginate")
     def test_list_incidents_teams_scope(self, mock_paginate):
         """Test listing incidents with teams scope."""
-        # Setup mocks
         mock_paginate.return_value = [self.sample_incident_data]
         self.mock_context.user = self.sample_user_data
 
-        # Test with teams scope
-        query = IncidentQuery(request_scope="teams")
-        _ = list_incidents(query)
+        _ = list_incidents(request_scope="teams")
 
-        # Verify team_ids parameter was added
         call_args = mock_paginate.call_args
         self.assertIn("team_ids[]", call_args[1]["params"])
         self.assertEqual(call_args[1]["params"]["team_ids[]"], ["PTEAM123"])
 
     def test_list_incidents_user_required_error(self):
         """If the request_scope requires user context but none is available, an error should be raised."""
-        # Setup mocks
         self.mock_context.user = None
 
-        # Test with user required query
-        query = IncidentQuery(request_scope="assigned")
-
         with self.assertRaises(ValueError) as context:
-            list_incidents(query)
+            list_incidents(request_scope="assigned")
 
         self.assertIn("Cannot filter incidents", str(context.exception))
 
     @patch("pagerduty_mcp.tools.incidents.paginate")
     def test_list_incidents_with_filters(self, mock_paginate):
         """Test listing incidents with various filters."""
-        # Setup mocks
         mock_paginate.return_value = [self.sample_incident_data]
 
-        # Test with filters
         since_date = datetime(2023, 1, 1)
-        query = IncidentQuery(status=["triggered", "acknowledged"], since=since_date, urgencies=["high"], limit=50)
-        _ = list_incidents(query)
+        _ = list_incidents(statuses=["triggered", "acknowledged"], since=since_date, urgencies=["high"], limit=50)
 
-        # Verify parameters were passed correctly
         call_args = mock_paginate.call_args
         params = call_args[1]["params"]
         self.assertIn("statuses[]", params)
@@ -295,25 +263,17 @@ class TestIncidentTools(unittest.TestCase):
 
     @patch("pagerduty_mcp.tools.incidents.paginate")
     def test_list_incidents_with_date_range(self, mock_paginate):
-        """Test listing incidents with date_range parameter."""
+        """Test listing incidents with since/until parameters."""
         mock_paginate.return_value = [self.sample_incident_data]
 
         since_date = datetime(2023, 1, 1)
         until_date = datetime(2023, 6, 1)
-        query = IncidentQuery(since=since_date, until=until_date, date_range="all")
-        _ = list_incidents(query)
+        _ = list_incidents(since=since_date, until=until_date)
 
         call_args = mock_paginate.call_args
         params = call_args[1]["params"]
-        self.assertEqual(params["date_range"], "all")
         self.assertEqual(params["since"], since_date.isoformat())
         self.assertEqual(params["until"], until_date.isoformat())
-
-    def test_incident_query_date_range_default(self):
-        """Test that date_range defaults to None (backwards compatible)."""
-        query = IncidentQuery()
-        params = query.to_params()
-        self.assertNotIn("date_range", params)
 
     @patch("pagerduty_mcp.tools.incidents.get_client")
     def test_get_incident_success(self, mock_get_client):
@@ -357,8 +317,7 @@ class TestIncidentTools(unittest.TestCase):
         mock_get_client.return_value = mock_client
 
         # Test
-        query = GetIncidentQuery(include=["users"])
-        result = get_incident("PINCIDENT123", query)
+        result = get_incident("PINCIDENT123", include=["users"])
 
         # Verify API call
         expected_params = {"include[]": ["users"]}
@@ -382,8 +341,7 @@ class TestIncidentTools(unittest.TestCase):
         mock_get_client.return_value = mock_client
 
         # Test
-        query = GetIncidentQuery(include=["users", "teams", "services"])
-        result = get_incident("PINCIDENT123", query)
+        result = get_incident("PINCIDENT123", include=["users", "teams", "services"])
 
         # Verify API call
         expected_params = {"include[]": ["users", "teams", "services"]}
@@ -416,9 +374,8 @@ class TestIncidentTools(unittest.TestCase):
         mock_client.rget.return_value = self.sample_incident_data
         mock_get_client.return_value = mock_client
 
-        # Test
-        query = GetIncidentQuery()
-        result = get_incident("PINCIDENT123", query)
+        # Test - call without include parameter (empty params)
+        result = get_incident("PINCIDENT123")
 
         # Should have empty params
         mock_client.rget.assert_called_once_with("/incidents/PINCIDENT123", params={})
@@ -426,29 +383,65 @@ class TestIncidentTools(unittest.TestCase):
         # Verify result
         self.assertIsInstance(result, Incident)
 
-    def test_get_incident_query_to_params_with_include(self):
-        """Test GetIncidentQuery.to_params() with include parameter."""
-        query = GetIncidentQuery(include=["users", "teams"])
-        params = query.to_params()
+    @patch("pagerduty_mcp.tools.incidents.get_client")
+    def test_get_incident_with_external_references(self, mock_get_client):
+        """Test get_incident with external_references include returns integration links."""
+        mock_client = Mock()
+        incident_with_refs = {
+            **self.sample_incident_data,
+            "external_references": [
+                {"type": "servicenow_reference", "external_id": "INC001234", "sync": True},
+                {"type": "zendesk_reference", "external_id": "12345", "sync": False},
+            ],
+        }
+        mock_client.rget.return_value = incident_with_refs
+        mock_get_client.return_value = mock_client
 
-        expected_params = {"include[]": ["users", "teams"]}
-        self.assertEqual(params, expected_params)
+        result = get_incident("PINCIDENT123", include=["external_references"])
 
-    def test_get_incident_query_to_params_empty(self):
-        """Test GetIncidentQuery.to_params() with no parameters."""
-        query = GetIncidentQuery()
-        params = query.to_params()
+        mock_client.rget.assert_called_once_with("/incidents/PINCIDENT123", params={"include[]": ["external_references"]})
+        self.assertIsInstance(result, Incident)
+        assert result.external_references is not None
+        self.assertEqual(len(result.external_references), 2)
+        self.assertEqual(result.external_references[0]["external_id"], "INC001234")
 
-        self.assertEqual(params, {})
+    @patch("pagerduty_mcp.tools.incidents.get_client")
+    def test_get_incident_with_metadata(self, mock_get_client):
+        """Test get_incident with metadata include returns normalized ExternalIntegrationLink list."""
+        mock_client = Mock()
+        incident_with_metadata = {
+            **self.sample_incident_data,
+            "metadata": {
+                "servicenow_itsm_dev230942_INC0010016": {
+                    "external_name": "INC0010016 (dev230942)",
+                    "external_url": "https://dev230942.service-now.com/incident.do?sys_id=abc123",
+                }
+            },
+        }
+        mock_client.rget.return_value = incident_with_metadata
+        mock_get_client.return_value = mock_client
 
-    def test_get_incident_query_validation_extra_forbidden(self):
-        """Test GetIncidentQuery rejects extra fields."""
-        from pydantic import ValidationError
+        result = get_incident("PINCIDENT123", include=["metadata"])
 
-        with self.assertRaises(ValidationError) as ctx:
-            GetIncidentQuery(include=["users"], invalid_field="value")
+        mock_client.rget.assert_called_once_with("/incidents/PINCIDENT123", params={"include[]": ["metadata"]})
+        self.assertIsInstance(result, Incident)
+        assert result.metadata is not None
+        self.assertEqual(len(result.metadata), 1)
+        self.assertEqual(result.metadata[0].integration_id, "servicenow_itsm_dev230942_INC0010016")
+        self.assertEqual(result.metadata[0].external_name, "INC0010016 (dev230942)")
+        self.assertEqual(result.metadata[0].external_url, "https://dev230942.service-now.com/incident.do?sys_id=abc123")
 
-        self.assertIn("Extra inputs are not permitted", str(ctx.exception))
+    def test_incident_model_external_references_defaults_to_none(self):
+        """Test Incident model has external_references as None when not included."""
+        from pagerduty_mcp.models.incidents import Incident
+        incident = Incident.model_validate(self.sample_incident_data)
+        self.assertIsNone(incident.external_references)
+
+    def test_incident_model_metadata_defaults_to_none(self):
+        """Test Incident model has metadata as None when not included."""
+        from pagerduty_mcp.models.incidents import Incident
+        incident = Incident.model_validate(self.sample_incident_data)
+        self.assertIsNone(incident.metadata)
 
     @patch("pagerduty_mcp.tools.incidents.get_client")
     def test_get_incident_with_query_api_error(self, mock_get_client):
@@ -458,9 +451,8 @@ class TestIncidentTools(unittest.TestCase):
         mock_get_client.return_value = mock_client
 
         # Test
-        query = GetIncidentQuery(include=["users"])
         with self.assertRaises(Exception) as context:
-            get_incident("PINCIDENT123", query)
+            get_incident("PINCIDENT123", include=["users"])
 
         self.assertIn("API Error", str(context.exception))
 
@@ -919,8 +911,7 @@ class TestIncidentTools(unittest.TestCase):
         mock_get_client.return_value = mock_client
 
         # Test
-        query = OutlierIncidentQuery()
-        result = get_outlier_incident("PINCIDENT123", query)
+        result = get_outlier_incident("PINCIDENT123")
 
         # Assertions
         self.assertIsInstance(result, OutlierIncidentResponse)
@@ -941,8 +932,7 @@ class TestIncidentTools(unittest.TestCase):
         from datetime import datetime
 
         since_date = datetime(2023, 1, 1)
-        query = OutlierIncidentQuery(since=since_date)
-        result = get_outlier_incident("PINCIDENT123", query)
+        result = get_outlier_incident("PINCIDENT123", since=since_date)
 
         # Assertions
         self.assertIsInstance(result, OutlierIncidentResponse)
@@ -984,8 +974,7 @@ class TestIncidentTools(unittest.TestCase):
         mock_get_client.return_value = mock_client
 
         # Test
-        query = OutlierIncidentQuery()
-        result = get_outlier_incident("PINCIDENT123", query)
+        result = get_outlier_incident("PINCIDENT123")
 
         # Assertions
         self.assertIsInstance(result, OutlierIncidentResponse)
@@ -1002,8 +991,7 @@ class TestIncidentTools(unittest.TestCase):
         mock_get_client.return_value = mock_client
 
         # Test
-        query = PastIncidentsQuery()
-        result = get_past_incidents("PINCIDENT123", query)
+        result = get_past_incidents("PINCIDENT123")
 
         # Assertions
         self.assertIsInstance(result, PastIncidentsResponse)
@@ -1024,8 +1012,7 @@ class TestIncidentTools(unittest.TestCase):
         mock_get_client.return_value = mock_client
 
         # Test with limit and total parameters
-        query = PastIncidentsQuery(limit=10, total=True)
-        result = get_past_incidents("PINCIDENT123", query)
+        result = get_past_incidents("PINCIDENT123", limit=10, total=True)
 
         # Assertions
         self.assertIsInstance(result, PastIncidentsResponse)
@@ -1045,8 +1032,7 @@ class TestIncidentTools(unittest.TestCase):
         mock_get_client.return_value = mock_client
 
         # Test
-        query = RelatedIncidentsQuery()
-        result = get_related_incidents("PINCIDENT123", query)
+        result = get_related_incidents("PINCIDENT123")
 
         # Assertions
         self.assertIsInstance(result, RelatedIncidentsResponse)
@@ -1064,8 +1050,7 @@ class TestIncidentTools(unittest.TestCase):
         mock_get_client.return_value = mock_client
 
         # Test with additional_details parameter
-        query = RelatedIncidentsQuery(additional_details=["incident"])
-        result = get_related_incidents("PINCIDENT123", query)
+        result = get_related_incidents("PINCIDENT123", additional_details=["incident"])
 
         # Assertions
         self.assertIsInstance(result, RelatedIncidentsResponse)
@@ -1084,9 +1069,8 @@ class TestIncidentTools(unittest.TestCase):
         mock_get_client.return_value = mock_client
 
         # Test that exception is raised
-        query = OutlierIncidentQuery()
         with self.assertRaises(Exception) as context:
-            get_outlier_incident("PINCIDENT123", query)
+            get_outlier_incident("PINCIDENT123")
 
         self.assertIn("API Error", str(context.exception))
 
@@ -1099,9 +1083,8 @@ class TestIncidentTools(unittest.TestCase):
         mock_get_client.return_value = mock_client
 
         # Test that exception is raised
-        query = PastIncidentsQuery()
         with self.assertRaises(Exception) as context:
-            get_past_incidents("PINCIDENT123", query)
+            get_past_incidents("PINCIDENT123")
 
         self.assertIn("API Error", str(context.exception))
 
@@ -1114,9 +1097,8 @@ class TestIncidentTools(unittest.TestCase):
         mock_get_client.return_value = mock_client
 
         # Test that exception is raised
-        query = RelatedIncidentsQuery()
         with self.assertRaises(Exception) as context:
-            get_related_incidents("PINCIDENT123", query)
+            get_related_incidents("PINCIDENT123")
 
         self.assertIn("API Error", str(context.exception))
 
@@ -1129,8 +1111,7 @@ class TestIncidentTools(unittest.TestCase):
         mock_get_client.return_value = mock_client
 
         # Test
-        query = RelatedIncidentsQuery()
-        result = get_related_incidents("PINCIDENT123", query)
+        result = get_related_incidents("PINCIDENT123")
 
         # Should return empty related incidents response
         self.assertIsInstance(result, RelatedIncidentsResponse)
@@ -1165,8 +1146,7 @@ class TestIncidentTools(unittest.TestCase):
         mock_get_client.return_value = mock_client
 
         # Test
-        query = OutlierIncidentQuery()
-        result = get_outlier_incident("PINCIDENT123", query)
+        result = get_outlier_incident("PINCIDENT123")
 
         # Assertions
         self.assertIsInstance(result, OutlierIncidentResponse)
@@ -1182,8 +1162,7 @@ class TestIncidentTools(unittest.TestCase):
         mock_get_client.return_value = mock_client
 
         # Test
-        query = PastIncidentsQuery(limit=10)
-        result = get_past_incidents("PINCIDENT123", query)
+        result = get_past_incidents("PINCIDENT123", limit=10)
 
         # Should return empty past incidents response with correct default values
         self.assertIsInstance(result, PastIncidentsResponse)
@@ -1220,8 +1199,7 @@ class TestIncidentTools(unittest.TestCase):
         mock_get_client.return_value = mock_client
 
         # Test
-        query = PastIncidentsQuery(limit=10)
-        result = get_past_incidents("PINCIDENT123", query)
+        result = get_past_incidents("PINCIDENT123", limit=10)
 
         # Should parse unwrapped list correctly
         self.assertIsInstance(result, PastIncidentsResponse)
@@ -1277,8 +1255,7 @@ class TestIncidentTools(unittest.TestCase):
         mock_get_client.return_value = mock_client
 
         # Test
-        query = RelatedIncidentsQuery()
-        result = get_related_incidents("PINCIDENT123", query)
+        result = get_related_incidents("PINCIDENT123")
 
         # Should parse unwrapped list correctly
         self.assertIsInstance(result, RelatedIncidentsResponse)
@@ -1369,6 +1346,58 @@ class TestIncidentTools(unittest.TestCase):
             'The correct parameter to filter by multiple Incidents statuses is "status", not "statuses"',
             str(ctx.exception),
         )
+
+    @patch("pagerduty_mcp.tools.log_entries.paginate")
+    @patch("pagerduty_mcp.tools.log_entries.get_client")
+    def test_list_incident_log_entries_success(self, mock_get_client, mock_paginate):
+        """Test listing log entries for an incident successfully."""
+        mock_log_entry = {
+            "id": "LOG1",
+            "type": "trigger_log_entry",
+            "summary": "triggered",
+            "self": "https://api.pagerduty.com/log_entries/LOG1",
+            "created_at": "2023-01-01T12:00:00Z",
+            "agent": None,
+            "channel": {"type": "web_trigger"},
+            "service": None,
+            "incident": None,
+            "teams": [],
+        }
+        mock_get_client.return_value = Mock()
+        mock_paginate.return_value = [mock_log_entry]
+
+        result = list_incident_log_entries("PINC123")
+
+        self.assertIsInstance(result, str)
+        import json as _json
+        data = _json.loads(result)
+        self.assertEqual(len(data["response"]), 1)
+
+    @patch("pagerduty_mcp.tools.log_entries.paginate")
+    @patch("pagerduty_mcp.tools.log_entries.get_client")
+    def test_list_incident_log_entries_with_limit(self, mock_get_client, mock_paginate):
+        """Test list_incident_log_entries respects the limit parameter."""
+        mock_get_client.return_value = Mock()
+        mock_paginate.return_value = []
+
+        list_incident_log_entries("PINC123", limit=50)
+
+        call_kwargs = mock_paginate.call_args[1]
+        self.assertEqual(call_kwargs["maximum_records"], 50)
+        self.assertEqual(call_kwargs["params"]["limit"], 50)
+
+    @patch("pagerduty_mcp.tools.log_entries.paginate")
+    @patch("pagerduty_mcp.tools.log_entries.get_client")
+    def test_list_incident_log_entries_default_params(self, mock_get_client, mock_paginate):
+        """Test list_incident_log_entries uses defaults when no limit given."""
+        mock_get_client.return_value = Mock()
+        mock_paginate.return_value = []
+
+        list_incident_log_entries("PINC123")
+
+        call_kwargs = mock_paginate.call_args[1]
+        self.assertEqual(call_kwargs["params"], {"is_overview": "false"})
+        self.assertEqual(call_kwargs["maximum_records"], 100)
 
 
 class TestAlertTools(unittest.TestCase):

--- a/tests/test_log_entries.py
+++ b/tests/test_log_entries.py
@@ -5,7 +5,8 @@ from datetime import UTC, datetime, timedelta
 from unittest.mock import Mock, patch
 
 from pagerduty_mcp.models import ListResponseModel, LogEntry, LogEntryQuery
-from pagerduty_mcp.tools.log_entries import get_log_entry, list_log_entries
+from pagerduty_mcp.tools.log_entries import get_log_entry, list_incident_log_entries, list_log_entries
+# LogEntryQuery is kept for model-level tests below
 
 
 class TestLogEntryTools(unittest.TestCase):
@@ -123,10 +124,8 @@ class TestLogEntryTools(unittest.TestCase):
         mock_get_client.return_value = mock_client
         mock_paginate.return_value = [self.sample_log_entry_data]
 
-        query_model = LogEntryQuery()
-
         # Act
-        result = list_log_entries(query_model)
+        result = list_log_entries()
 
         # Assert
         self.assertIsInstance(result, ListResponseModel)
@@ -135,9 +134,10 @@ class TestLogEntryTools(unittest.TestCase):
         self.assertEqual(result.response[0].id, "PLOGENTRY123")
         mock_paginate.assert_called_once()
 
-        # Verify that default timestamps were set (last 7 days)
-        self.assertIsNotNone(query_model.since)
-        self.assertIsNotNone(query_model.until)
+        # Verify that default timestamps were applied
+        call_args = mock_paginate.call_args
+        self.assertIn("since", call_args[1]["params"])
+        self.assertIn("until", call_args[1]["params"])
 
     @patch("pagerduty_mcp.tools.log_entries.paginate")
     @patch("pagerduty_mcp.tools.log_entries.get_client")
@@ -150,10 +150,9 @@ class TestLogEntryTools(unittest.TestCase):
 
         since = datetime.now() - timedelta(days=7)
         until = datetime.now()
-        query_model = LogEntryQuery(since=since, until=until, limit=50)
 
         # Act
-        result = list_log_entries(query_model)
+        result = list_log_entries(since=since, until=until, limit=50)
 
         # Assert
         self.assertIsInstance(result, ListResponseModel)
@@ -173,10 +172,8 @@ class TestLogEntryTools(unittest.TestCase):
         mock_get_client.return_value = mock_client
         mock_paginate.return_value = []
 
-        query_model = LogEntryQuery()
-
         # Act
-        result = list_log_entries(query_model)
+        result = list_log_entries()
 
         # Assert
         self.assertIsInstance(result, ListResponseModel)
@@ -184,26 +181,24 @@ class TestLogEntryTools(unittest.TestCase):
 
     @patch("pagerduty_mcp.tools.log_entries.paginate")
     @patch("pagerduty_mcp.tools.log_entries.get_client")
-    def test_list_log_entries_with_empty_string_timestamps(self, mock_get_client, mock_paginate):
-        """Test that empty string timestamps are converted to None and then to defaults."""
+    def test_list_log_entries_with_none_timestamps(self, mock_get_client, mock_paginate):
+        """Test that None timestamps default to the last 7 days."""
         # Arrange
         mock_client = Mock()
         mock_get_client.return_value = mock_client
         mock_paginate.return_value = [self.sample_log_entry_data]
 
-        # Create query with empty strings (simulating MCP interface behavior)
-        query_model = LogEntryQuery(since="", until="")
-
-        # Act
-        result = list_log_entries(query_model)
+        # Act - call with no since/until, defaults should be applied
+        result = list_log_entries(since=None, until=None)
 
         # Assert
         self.assertIsInstance(result, ListResponseModel)
         self.assertEqual(len(result.response), 1)
 
-        # Verify that empty strings were converted to None and then to default values
-        self.assertIsNotNone(query_model.since)
-        self.assertIsNotNone(query_model.until)
+        # Verify that default timestamps were applied
+        call_args = mock_paginate.call_args
+        self.assertIn("since", call_args[1]["params"])
+        self.assertIn("until", call_args[1]["params"])
 
     @patch("pagerduty_mcp.tools.log_entries.paginate")
     @patch("pagerduty_mcp.tools.log_entries.get_client")
@@ -214,10 +209,8 @@ class TestLogEntryTools(unittest.TestCase):
         mock_get_client.return_value = mock_client
         mock_paginate.return_value = [self.sample_log_entry_data]
 
-        query_model = LogEntryQuery(limit=25, offset=10)
-
         # Act
-        result = list_log_entries(query_model)
+        result = list_log_entries(limit=25, offset=10)
 
         # Assert
         self.assertIsInstance(result, ListResponseModel)
@@ -254,10 +247,8 @@ class TestLogEntryTools(unittest.TestCase):
             self.sample_service_change_log_entry,
         ]
 
-        query_model = LogEntryQuery()
-
         # Act
-        result = list_log_entries(query_model)
+        result = list_log_entries()
 
         # Assert
         self.assertIsInstance(result, ListResponseModel)
@@ -376,6 +367,72 @@ class TestLogEntryTools(unittest.TestCase):
         self.assertEqual(params["team_ids[]"], ["TEAM1"])
         self.assertEqual(params["time_zone"], "UTC")
         self.assertTrue(params["total"])
+
+    @patch("pagerduty_mcp.tools.log_entries.paginate")
+    @patch("pagerduty_mcp.tools.log_entries.get_client")
+    def test_list_incident_log_entries_success(self, mock_get_client, mock_paginate):
+        """Test listing log entries for an incident successfully."""
+        import json as _json
+        mock_get_client.return_value = Mock()
+        mock_log_entry = {
+            "id": "LOG1",
+            "type": "trigger_log_entry",
+            "summary": "triggered",
+            "self": "https://api.pagerduty.com/log_entries/LOG1",
+            "created_at": "2023-01-01T12:00:00Z",
+            "agent": None,
+            "channel": {"type": "web_trigger"},
+            "service": None,
+            "incident": None,
+            "teams": [],
+        }
+        mock_paginate.return_value = [mock_log_entry]
+
+        result = list_incident_log_entries("PINC123")
+
+        self.assertIsInstance(result, str)
+        data = _json.loads(result)
+        self.assertEqual(len(data["response"]), 1)
+
+    @patch("pagerduty_mcp.tools.log_entries.paginate")
+    @patch("pagerduty_mcp.tools.log_entries.get_client")
+    def test_list_incident_log_entries_with_limit(self, mock_get_client, mock_paginate):
+        """Test list_incident_log_entries respects the limit parameter."""
+        mock_get_client.return_value = Mock()
+        mock_paginate.return_value = []
+
+        list_incident_log_entries("PINC123", limit=50)
+
+        call_kwargs = mock_paginate.call_args[1]
+        self.assertEqual(call_kwargs["maximum_records"], 50)
+        self.assertEqual(call_kwargs["params"]["limit"], 50)
+
+    @patch("pagerduty_mcp.tools.log_entries.paginate")
+    @patch("pagerduty_mcp.tools.log_entries.get_client")
+    def test_list_incident_log_entries_default_params(self, mock_get_client, mock_paginate):
+        """Test list_incident_log_entries uses defaults when no limit given."""
+        mock_get_client.return_value = Mock()
+        mock_paginate.return_value = []
+
+        list_incident_log_entries("PINC123")
+
+        call_kwargs = mock_paginate.call_args[1]
+        self.assertEqual(call_kwargs["params"], {"is_overview": "false"})
+        self.assertEqual(call_kwargs["maximum_records"], 100)
+
+    @patch("pagerduty_mcp.tools.log_entries.paginate")
+    @patch("pagerduty_mcp.tools.log_entries.get_client")
+    def test_list_incident_log_entries_empty_response(self, mock_get_client, mock_paginate):
+        """Test list_incident_log_entries returns valid JSON with empty response list."""
+        import json as _json
+        mock_get_client.return_value = Mock()
+        mock_paginate.return_value = []
+
+        result = list_incident_log_entries("PINC123")
+
+        self.assertIsInstance(result, str)
+        data = _json.loads(result)
+        self.assertEqual(data["response"], [])
 
 
 if __name__ == "__main__":

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -21,6 +21,7 @@ from pagerduty_mcp.tools.schedules import (
     create_schedule,
     create_schedule_override,
     get_schedule,
+    list_schedule_overrides,
     list_schedule_users,
     list_schedules,
     update_schedule,
@@ -111,6 +112,8 @@ class TestScheduleTools(unittest.TestCase):
         # Clear any side effects
         self.mock_client.rget.side_effect = None
         self.mock_client.rpost.side_effect = None
+        self.mock_client.rput.side_effect = None
+        self.mock_client.rdelete.side_effect = None
 
     @patch("pagerduty_mcp.tools.schedules.paginate")
     @patch("pagerduty_mcp.tools.schedules.get_client")
@@ -121,7 +124,7 @@ class TestScheduleTools(unittest.TestCase):
 
         result = list_schedules()
 
-        expected_params = {"limit": DEFAULT_PAGINATION_LIMIT}
+        expected_params = {}
         mock_paginate.assert_called_once_with(client=self.mock_client, entity="schedules", params=expected_params)
         self.assertEqual(len(result.response), 2)
 
@@ -132,11 +135,10 @@ class TestScheduleTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         mock_paginate.return_value = self.sample_schedules_list_response
 
-        query = ScheduleQuery()
-        result = list_schedules(query)
+        result = list_schedules()
 
         # Verify paginate call
-        expected_params = {"limit": DEFAULT_PAGINATION_LIMIT}
+        expected_params = {}
         mock_paginate.assert_called_once_with(client=self.mock_client, entity="schedules", params=expected_params)
 
         # Verify result
@@ -155,11 +157,10 @@ class TestScheduleTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         mock_paginate.return_value = [self.sample_schedules_list_response[0]]
 
-        query = ScheduleQuery(query="Primary")
-        result = list_schedules(query)
+        result = list_schedules(query="Primary")
 
         # Verify paginate call
-        expected_params = {"query": "Primary", "limit": DEFAULT_PAGINATION_LIMIT}
+        expected_params = {"query": "Primary"}
         mock_paginate.assert_called_once_with(client=self.mock_client, entity="schedules", params=expected_params)
 
         # Verify result
@@ -173,11 +174,10 @@ class TestScheduleTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         mock_paginate.return_value = self.sample_schedules_list_response
 
-        query = ScheduleQuery(team_ids=["TEAM123"])
-        result = list_schedules(query)
+        result = list_schedules(team_ids=["TEAM123"])
 
         # Verify paginate call
-        expected_params = {"team_ids[]": ["TEAM123"], "limit": DEFAULT_PAGINATION_LIMIT}
+        expected_params = {"team_ids[]": ["TEAM123"]}
         mock_paginate.assert_called_once_with(client=self.mock_client, entity="schedules", params=expected_params)
 
         # Verify result
@@ -190,11 +190,10 @@ class TestScheduleTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         mock_paginate.return_value = self.sample_schedules_list_response
 
-        query = ScheduleQuery(user_ids=["USER123", "USER456"])
-        result = list_schedules(query)
+        result = list_schedules(user_ids=["USER123", "USER456"])
 
         # Verify paginate call
-        expected_params = {"user_ids[]": ["USER123", "USER456"], "limit": DEFAULT_PAGINATION_LIMIT}
+        expected_params = {"user_ids[]": ["USER123", "USER456"]}
         mock_paginate.assert_called_once_with(client=self.mock_client, entity="schedules", params=expected_params)
 
         # Verify result
@@ -207,11 +206,10 @@ class TestScheduleTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         mock_paginate.return_value = self.sample_schedules_list_response
 
-        query = ScheduleQuery(include=["schedule_layers"])
-        result = list_schedules(query)
+        result = list_schedules(include=["schedule_layers"])
 
         # Verify paginate call
-        expected_params = {"include[]": ["schedule_layers"], "limit": DEFAULT_PAGINATION_LIMIT}
+        expected_params = {"include[]": ["schedule_layers"]}
         mock_paginate.assert_called_once_with(client=self.mock_client, entity="schedules", params=expected_params)
 
         # Verify result
@@ -224,14 +222,13 @@ class TestScheduleTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         mock_paginate.return_value = [self.sample_schedules_list_response[0]]
 
-        query = ScheduleQuery(
+        result = list_schedules(
             query="Primary",
             team_ids=["TEAM123"],
             user_ids=["USER123"],
             include=["schedule_layers"],
             limit=50,
         )
-        result = list_schedules(query)
 
         # Verify paginate call
         expected_params = {
@@ -253,8 +250,7 @@ class TestScheduleTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         mock_paginate.return_value = self.sample_schedules_list_response
 
-        query = ScheduleQuery(limit=50)
-        result = list_schedules(query)
+        result = list_schedules(limit=50)
 
         # Verify paginate call
         expected_params = {"limit": 50}
@@ -270,11 +266,10 @@ class TestScheduleTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         mock_paginate.return_value = []
 
-        query = ScheduleQuery(query="NonExistentSchedule")
-        result = list_schedules(query)
+        result = list_schedules(query="NonExistentSchedule")
 
         # Verify paginate call
-        expected_params = {"query": "NonExistentSchedule", "limit": DEFAULT_PAGINATION_LIMIT}
+        expected_params = {"query": "NonExistentSchedule"}
         mock_paginate.assert_called_once_with(client=self.mock_client, entity="schedules", params=expected_params)
 
         # Verify result
@@ -287,10 +282,8 @@ class TestScheduleTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         mock_paginate.side_effect = Exception("Pagination Error")
 
-        query = ScheduleQuery()
-
         with self.assertRaises(Exception) as context:
-            list_schedules(query)
+            list_schedules()
 
         self.assertEqual(str(context.exception), "Pagination Error")
 
@@ -853,6 +846,58 @@ class TestScheduleTools(unittest.TestCase):
         mock_get_client.assert_called_once()
         self.mock_client.rput.assert_called_once()
 
+    @patch("pagerduty_mcp.tools.schedules.get_client")
+    def test_list_schedule_overrides_list_response(self, mock_get_client):
+        """Test list_schedule_overrides when API returns a list directly."""
+        import json as _json
+        mock_get_client.return_value = self.mock_client
+        overrides = [{"id": "OV1", "start": "2023-01-01T00:00:00Z", "end": "2023-01-02T00:00:00Z"}]
+        self.mock_client.rget.return_value = overrides
+
+        result = list_schedule_overrides("SCHED123", "2023-01-01", "2023-01-31")
+
+        self.assertIsInstance(result, str)
+        data = _json.loads(result)
+        self.assertEqual(len(data["overrides"]), 1)
+        self.assertEqual(data["overrides"][0]["id"], "OV1")
+
+    @patch("pagerduty_mcp.tools.schedules.get_client")
+    def test_list_schedule_overrides_dict_response(self, mock_get_client):
+        """Test list_schedule_overrides when API returns a dict with 'overrides' key."""
+        import json as _json
+        mock_get_client.return_value = self.mock_client
+        self.mock_client.rget.return_value = {"overrides": [{"id": "OV2"}]}
+
+        result = list_schedule_overrides("SCHED123", "2023-01-01", "2023-01-31")
+
+        data = _json.loads(result)
+        self.assertEqual(len(data["overrides"]), 1)
+        self.assertEqual(data["overrides"][0]["id"], "OV2")
+
+    @patch("pagerduty_mcp.tools.schedules.get_client")
+    def test_list_schedule_overrides_calls_api_correctly(self, mock_get_client):
+        """Test that list_schedule_overrides calls rget with correct arguments."""
+        mock_get_client.return_value = self.mock_client
+        self.mock_client.rget.return_value = []
+
+        list_schedule_overrides("SCHED123", "2023-01-01", "2023-01-31")
+
+        self.mock_client.rget.assert_called_once_with(
+            "/schedules/SCHED123/overrides",
+            params={"since": "2023-01-01", "until": "2023-01-31"},
+        )
+
+    @patch("pagerduty_mcp.tools.schedules.get_client")
+    def test_list_schedule_overrides_empty_dict_response(self, mock_get_client):
+        """Test list_schedule_overrides when API returns empty dict."""
+        import json as _json
+        mock_get_client.return_value = self.mock_client
+        self.mock_client.rget.return_value = {}
+
+        result = list_schedule_overrides("SCHED123", "2023-01-01", "2023-01-31")
+
+        data = _json.loads(result)
+        self.assertEqual(data["overrides"], [])
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -8,6 +8,7 @@ from pagerduty_mcp.models.services import Service, ServiceCreate, ServiceQuery
 from pagerduty_mcp.tools.services import (
     create_service,
     get_service,
+    get_technical_service_dependencies,
     list_services,
     update_service,
 )
@@ -81,7 +82,7 @@ class TestServiceTools(unittest.TestCase):
 
         result = list_services()
 
-        mock_paginate.assert_called_once_with(client=self.mock_client, entity="services", params={"limit": DEFAULT_PAGINATION_LIMIT})
+        mock_paginate.assert_called_once_with(client=self.mock_client, entity="services", params={})
         self.assertEqual(len(result.response), 2)
 
     @patch("pagerduty_mcp.tools.services.paginate")
@@ -91,11 +92,10 @@ class TestServiceTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         mock_paginate.return_value = self.sample_services_list_response
 
-        query = ServiceQuery()
-        result = list_services(query)
+        result = list_services()
 
         # Verify paginate call
-        mock_paginate.assert_called_once_with(client=self.mock_client, entity="services", params=query.to_params())
+        mock_paginate.assert_called_once_with(client=self.mock_client, entity="services", params={})
 
         # Verify result
         self.assertEqual(len(result.response), 2)
@@ -113,11 +113,10 @@ class TestServiceTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         mock_paginate.return_value = [self.sample_services_list_response[0]]
 
-        query = ServiceQuery(query="Web")
-        result = list_services(query)
+        result = list_services(query="Web")
 
         # Verify paginate call
-        expected_params = {"query": "Web", "limit": DEFAULT_PAGINATION_LIMIT}
+        expected_params = {"query": "Web"}
         mock_paginate.assert_called_once_with(client=self.mock_client, entity="services", params=expected_params)
 
         # Verify result
@@ -131,11 +130,10 @@ class TestServiceTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         mock_paginate.return_value = [self.sample_services_list_response[1]]
 
-        query = ServiceQuery(teams_ids=["TEAM2"])
-        result = list_services(query)
+        result = list_services(teams_ids=["TEAM2"])
 
         # Verify paginate call
-        expected_params = {"team_ids[]": ["TEAM2"], "limit": DEFAULT_PAGINATION_LIMIT}
+        expected_params = {"team_ids[]": ["TEAM2"]}
         mock_paginate.assert_called_once_with(client=self.mock_client, entity="services", params=expected_params)
 
         # Verify result
@@ -149,8 +147,7 @@ class TestServiceTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         mock_paginate.return_value = self.sample_services_list_response
 
-        query = ServiceQuery(limit=50)
-        result = list_services(query)
+        result = list_services(limit=50)
 
         # Verify paginate call
         expected_params = {"limit": 50}
@@ -166,8 +163,7 @@ class TestServiceTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         mock_paginate.return_value = [self.sample_services_list_response[0]]
 
-        query = ServiceQuery(query="Web", teams_ids=["TEAM1"], limit=10)
-        result = list_services(query)
+        result = list_services(query="Web", teams_ids=["TEAM1"], limit=10)
 
         # Verify paginate call
         expected_params = {"query": "Web", "team_ids[]": ["TEAM1"], "limit": 10}
@@ -184,11 +180,10 @@ class TestServiceTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         mock_paginate.return_value = []
 
-        query = ServiceQuery(query="NonExistentService")
-        result = list_services(query)
+        result = list_services(query="NonExistentService")
 
         # Verify paginate call
-        expected_params = {"query": "NonExistentService", "limit": DEFAULT_PAGINATION_LIMIT}
+        expected_params = {"query": "NonExistentService"}
         mock_paginate.assert_called_once_with(client=self.mock_client, entity="services", params=expected_params)
 
         # Verify result
@@ -201,10 +196,8 @@ class TestServiceTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         mock_paginate.side_effect = Exception("Pagination Error")
 
-        query = ServiceQuery()
-
         with self.assertRaises(Exception) as context:
-            list_services(query)
+            list_services()
 
         self.assertEqual(str(context.exception), "Pagination Error")
 
@@ -227,6 +220,7 @@ class TestServiceTools(unittest.TestCase):
         self.assertEqual(result.description, "Main web application service")
         self.assertIsInstance(result.escalation_policy, EscalationPolicyReference)
         self.assertEqual(result.escalation_policy.id, "EP123")
+        assert result.teams is not None
         self.assertEqual(len(result.teams), 2)
         self.assertIsInstance(result.teams[0], TeamReference)
         self.assertEqual(result.teams[0].id, "TEAM1")
@@ -450,6 +444,55 @@ class TestServiceTools(unittest.TestCase):
         )
 
         self.assertEqual(service.type, "service")
+
+class TestTechnicalServiceDependencies(unittest.TestCase):
+    """Test cases for get_technical_service_dependencies."""
+
+    @patch("pagerduty_mcp.tools.services.get_client")
+    def test_get_technical_service_dependencies(self, mock_get_client):
+        """Test successful retrieval of technical service dependencies."""
+        mock_client = MagicMock()
+        mock_client.get.return_value.json.return_value = {
+            "relationships": [
+                {
+                    "supporting_service": {"id": "S1", "type": "service"},
+                    "dependent_service": {"id": "S2", "type": "service"},
+                }
+            ]
+        }
+        mock_client.get.return_value.raise_for_status = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        result = get_technical_service_dependencies("S2")
+
+        mock_client.get.assert_called_once_with("/service_dependencies/technical_services/S2")
+        mock_client.get.return_value.raise_for_status.assert_called_once()
+        self.assertIn('"relationships"', result)
+
+    @patch("pagerduty_mcp.tools.services.get_client")
+    def test_get_technical_service_dependencies_http_error(self, mock_get_client):
+        """Test that HTTP errors are raised when the API returns a 4xx/5xx response."""
+        mock_client = MagicMock()
+        mock_client.get.return_value.raise_for_status.side_effect = Exception("404 Not Found")
+        mock_get_client.return_value = mock_client
+
+        with self.assertRaises(Exception) as context:
+            get_technical_service_dependencies("INVALID")
+
+        self.assertIn("404 Not Found", str(context.exception))
+
+    @patch("pagerduty_mcp.tools.services.get_client")
+    def test_get_technical_service_dependencies_empty(self, mock_get_client):
+        """Test retrieval when no relationships are returned."""
+        mock_client = MagicMock()
+        mock_client.get.return_value.json.return_value = {"relationships": []}
+        mock_client.get.return_value.raise_for_status = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        result = get_technical_service_dependencies("S1")
+
+        self.assertIn('"relationships"', result)
+        self.assertIn("[]", result)
 
 
 if __name__ == "__main__":

--- a/tests/test_status_pages.py
+++ b/tests/test_status_pages.py
@@ -8,26 +8,20 @@ from pagerduty_mcp.models import ListResponseModel
 from pagerduty_mcp.models.status_pages import (
     StatusPage,
     StatusPageImpact,
-    StatusPageImpactQuery,
     StatusPageImpactReference,
     StatusPagePost,
     StatusPagePostCreateRequest,
     StatusPagePostCreateRequestWrapper,
-    StatusPagePostQuery,
     StatusPagePostReference,
     StatusPagePostUpdate,
     StatusPagePostUpdateImpact,
-    StatusPagePostUpdateQuery,
     StatusPagePostUpdateRequest,
     StatusPagePostUpdateRequestWrapper,
-    StatusPageQuery,
     StatusPageReference,
     StatusPageServiceReference,
     StatusPageSeverity,
-    StatusPageSeverityQuery,
     StatusPageSeverityReference,
     StatusPageStatus,
-    StatusPageStatusQuery,
     StatusPageStatusReference,
 )
 from pagerduty_mcp.tools.status_pages import (
@@ -36,6 +30,7 @@ from pagerduty_mcp.tools.status_pages import (
     get_status_page_post,
     list_status_page_impacts,
     list_status_page_post_updates,
+    list_status_page_posts,
     list_status_page_severities,
     list_status_page_statuses,
     list_status_pages,
@@ -182,8 +177,7 @@ class TestStatusPagesTools(unittest.TestCase):
         """Test basic Status Pages listing."""
         mock_paginate.return_value = [self.sample_status_page_data]
 
-        query = StatusPageQuery()
-        result = list_status_pages(query)
+        result = list_status_pages()
 
         self.assertIsInstance(result, ListResponseModel)
         self.assertEqual(len(result.response), 1)
@@ -197,8 +191,7 @@ class TestStatusPagesTools(unittest.TestCase):
         """Test Status Pages listing with type filter."""
         mock_paginate.return_value = [self.sample_status_page_data]
 
-        query = StatusPageQuery(status_page_type="private")
-        result = list_status_pages(query)
+        result = list_status_pages(status_page_type="private")
 
         self.assertIsInstance(result, ListResponseModel)
         self.assertEqual(len(result.response), 1)
@@ -210,8 +203,7 @@ class TestStatusPagesTools(unittest.TestCase):
         """Test basic Severity listing."""
         mock_paginate.return_value = [self.sample_severity_data]
 
-        query = StatusPageSeverityQuery()
-        result = list_status_page_severities("PQ8W0D0", query)
+        result = list_status_page_severities("PQ8W0D0")
 
         self.assertIsInstance(result, ListResponseModel)
         self.assertEqual(len(result.response), 1)
@@ -225,8 +217,7 @@ class TestStatusPagesTools(unittest.TestCase):
         """Test Severity listing with post type filter."""
         mock_paginate.return_value = [self.sample_severity_data]
 
-        query = StatusPageSeverityQuery(post_type="incident")
-        result = list_status_page_severities("PQ8W0D0", query)
+        result = list_status_page_severities("PQ8W0D0", post_type="incident")
 
         self.assertIsInstance(result, ListResponseModel)
         self.assertEqual(len(result.response), 1)
@@ -238,8 +229,7 @@ class TestStatusPagesTools(unittest.TestCase):
         """Test basic Impact listing."""
         mock_paginate.return_value = [self.sample_impact_data]
 
-        query = StatusPageImpactQuery()
-        result = list_status_page_impacts("PQ8W0D0", query)
+        result = list_status_page_impacts("PQ8W0D0")
 
         self.assertIsInstance(result, ListResponseModel)
         self.assertEqual(len(result.response), 1)
@@ -253,8 +243,7 @@ class TestStatusPagesTools(unittest.TestCase):
         """Test Impact listing with post type filter."""
         mock_paginate.return_value = [self.sample_impact_data]
 
-        query = StatusPageImpactQuery(post_type="incident")
-        result = list_status_page_impacts("PQ8W0D0", query)
+        result = list_status_page_impacts("PQ8W0D0", post_type="incident")
 
         self.assertIsInstance(result, ListResponseModel)
         self.assertEqual(len(result.response), 1)
@@ -266,8 +255,7 @@ class TestStatusPagesTools(unittest.TestCase):
         """Test basic Status listing."""
         mock_paginate.return_value = [self.sample_status_data]
 
-        query = StatusPageStatusQuery()
-        result = list_status_page_statuses("PQ8W0D0", query)
+        result = list_status_page_statuses("PQ8W0D0")
 
         self.assertIsInstance(result, ListResponseModel)
         self.assertEqual(len(result.response), 1)
@@ -281,8 +269,7 @@ class TestStatusPagesTools(unittest.TestCase):
         """Test Status listing with post type filter."""
         mock_paginate.return_value = [self.sample_status_data]
 
-        query = StatusPageStatusQuery(post_type="incident")
-        result = list_status_page_statuses("PQ8W0D0", query)
+        result = list_status_page_statuses("PQ8W0D0", post_type="incident")
 
         self.assertIsInstance(result, ListResponseModel)
         self.assertEqual(len(result.response), 1)
@@ -364,8 +351,7 @@ class TestStatusPagesTools(unittest.TestCase):
         mock_client.rget.return_value = {"post": self.sample_post_data}
         mock_get_client.return_value = mock_client
 
-        query = StatusPagePostQuery()
-        result = get_status_page_post("PR5LMML", "PIJ90N7", query)
+        result = get_status_page_post("PR5LMML", "PIJ90N7")
 
         self.assertIsInstance(result, StatusPagePost)
         self.assertEqual(result.id, "PIJ90N7")
@@ -379,8 +365,7 @@ class TestStatusPagesTools(unittest.TestCase):
         mock_client.rget.return_value = {"post": self.sample_post_data}
         mock_get_client.return_value = mock_client
 
-        query = StatusPagePostQuery(include=["status_page_post_update"])
-        result = get_status_page_post("PR5LMML", "PIJ90N7", query)
+        result = get_status_page_post("PR5LMML", "PIJ90N7", include=["status_page_post_update"])
 
         self.assertIsInstance(result, StatusPagePost)
         self.assertEqual(result.id, "PIJ90N7")
@@ -394,8 +379,7 @@ class TestStatusPagesTools(unittest.TestCase):
         mock_client.rget.return_value = self.sample_post_data
         mock_get_client.return_value = mock_client
 
-        query = StatusPagePostQuery()
-        result = get_status_page_post("PR5LMML", "PIJ90N7", query)
+        result = get_status_page_post("PR5LMML", "PIJ90N7")
 
         self.assertIsInstance(result, StatusPagePost)
         self.assertEqual(result.id, "PIJ90N7")
@@ -459,8 +443,7 @@ class TestStatusPagesTools(unittest.TestCase):
         """Test basic Post Update listing."""
         mock_paginate.return_value = [self.sample_post_update_data]
 
-        query = StatusPagePostUpdateQuery()
-        result = list_status_page_post_updates("PR5LMML", "PIJ90N7", query)
+        result = list_status_page_post_updates("PR5LMML", "PIJ90N7")
 
         self.assertIsInstance(result, ListResponseModel)
         self.assertEqual(len(result.response), 1)
@@ -473,8 +456,7 @@ class TestStatusPagesTools(unittest.TestCase):
         """Test Post Update listing with reviewed status filter."""
         mock_paginate.return_value = [self.sample_post_update_data]
 
-        query = StatusPagePostUpdateQuery(reviewed_status="approved")
-        result = list_status_page_post_updates("PR5LMML", "PIJ90N7", query)
+        result = list_status_page_post_updates("PR5LMML", "PIJ90N7", reviewed_status="approved")
 
         self.assertIsInstance(result, ListResponseModel)
         self.assertEqual(len(result.response), 1)
@@ -602,6 +584,46 @@ class TestStatusPagesTools(unittest.TestCase):
             json_data["post_update"]["reported_at"], str, "reported_at must be serialized as ISO string"
         )
         self.assertEqual(json_data["post_update"]["reported_at"], "2023-12-12T14:30:00")
+
+    @patch("pagerduty_mcp.tools.status_pages.get_client")
+    @patch("pagerduty_mcp.tools.status_pages.paginate")
+    def test_list_status_page_posts_basic(self, mock_paginate, mock_get_client):
+        """Test basic Status Page posts listing."""
+        mock_paginate.return_value = [self.sample_post_data]
+
+        import json
+        result = list_status_page_posts("PR5LMML")
+
+        mock_paginate.assert_called_once()
+        call_kwargs = mock_paginate.call_args[1]
+        self.assertEqual(call_kwargs["entity"], "/status_pages/PR5LMML/posts")
+        self.assertEqual(call_kwargs["params"], {})
+        parsed = json.loads(result)
+        self.assertEqual(len(parsed["response"]), 1)
+        self.assertEqual(parsed["response"][0]["id"], "PIJ90N7")
+
+    @patch("pagerduty_mcp.tools.status_pages.get_client")
+    @patch("pagerduty_mcp.tools.status_pages.paginate")
+    def test_list_status_page_posts_empty(self, mock_paginate, mock_get_client):
+        """Test Status Page posts listing returns empty list when no posts exist."""
+        mock_paginate.return_value = []
+
+        import json
+        result = list_status_page_posts("PR5LMML")
+
+        parsed = json.loads(result)
+        self.assertEqual(parsed["response"], [])
+
+    @patch("pagerduty_mcp.tools.status_pages.get_client")
+    @patch("pagerduty_mcp.tools.status_pages.paginate")
+    def test_list_status_page_posts_uses_status_page_id(self, mock_paginate, mock_get_client):
+        """Test that list_status_page_posts uses the provided status_page_id in the API path."""
+        mock_paginate.return_value = []
+
+        list_status_page_posts("CUSTOM_ID")
+
+        call_kwargs = mock_paginate.call_args[1]
+        self.assertIn("CUSTOM_ID", call_kwargs["entity"])
 
 
 if __name__ == "__main__":

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -51,6 +51,7 @@ class TestUserTools(unittest.TestCase):
         self.mock_client.reset_mock()
         # Clear any side effects
         self.mock_client.rget.side_effect = None
+        self.mock_client.rpost.side_effect = None
 
     @patch("pagerduty_mcp.tools.users.get_client")
     def test_get_user_data_success(self, mock_get_client):
@@ -92,13 +93,13 @@ class TestUserTools(unittest.TestCase):
 
     @patch("pagerduty_mcp.tools.users.get_client")
     def test_list_users_no_query_model(self, mock_get_client):
-        """Test that list_users can be called with no arguments (no query_model)."""
+        """Test that list_users can be called with no arguments."""
         mock_get_client.return_value = self.mock_client
         self.mock_client.rget.return_value = self.sample_users_list_response
 
         result = list_users()
 
-        expected_params = {"limit": DEFAULT_PAGINATION_LIMIT}
+        expected_params = {"limit": 100}
         self.mock_client.rget.assert_called_once_with("/users", params=expected_params)
         self.assertEqual(len(result.response), 2)
 
@@ -108,11 +109,11 @@ class TestUserTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         self.mock_client.rget.return_value = self.sample_users_list_response
 
-        result = list_users(UserQuery())
+        result = list_users()
 
         # Verify API call
         mock_get_client.assert_called_once()
-        expected_params = {"limit": DEFAULT_PAGINATION_LIMIT}
+        expected_params = {"limit": 100}
         self.mock_client.rget.assert_called_once_with("/users", params=expected_params)
 
         # Verify result
@@ -130,11 +131,11 @@ class TestUserTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         self.mock_client.rget.return_value = [self.sample_users_list_response[0]]
 
-        result = list_users(UserQuery(query="John"))
+        result = list_users(query="John")
 
         # Verify API call
         mock_get_client.assert_called_once()
-        expected_params = {"query": "John", "limit": DEFAULT_PAGINATION_LIMIT}
+        expected_params = {"query": "John", "limit": 100}
         self.mock_client.rget.assert_called_once_with("/users", params=expected_params)
 
         # Verify result
@@ -148,11 +149,11 @@ class TestUserTools(unittest.TestCase):
         self.mock_client.rget.return_value = [self.sample_users_list_response[1]]
 
         team_ids = ["TEAM2", "TEAM3"]
-        result = list_users(UserQuery(teams_ids=team_ids))
+        result = list_users(teams_ids=team_ids)
 
         # Verify API call
         mock_get_client.assert_called_once()
-        expected_params = {"team_ids[]": team_ids, "limit": DEFAULT_PAGINATION_LIMIT}
+        expected_params = {"team_ids[]": team_ids, "limit": 100}
         self.mock_client.rget.assert_called_once_with("/users", params=expected_params)
 
         # Verify result
@@ -165,7 +166,7 @@ class TestUserTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         self.mock_client.rget.return_value = self.sample_users_list_response
 
-        result = list_users(UserQuery(limit=50))
+        result = list_users(limit=50)
 
         # Verify API call
         mock_get_client.assert_called_once()
@@ -182,7 +183,7 @@ class TestUserTools(unittest.TestCase):
         self.mock_client.rget.return_value = [self.sample_users_list_response[0]]
 
         team_ids = ["TEAM1"]
-        result = list_users(UserQuery(query="John", teams_ids=team_ids, limit=10))
+        result = list_users(query="John", teams_ids=team_ids, limit=10)
 
         # Verify API call
         mock_get_client.assert_called_once()
@@ -199,11 +200,11 @@ class TestUserTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         self.mock_client.rget.return_value = []
 
-        result = list_users(UserQuery(query="NonExistentUser"))
+        result = list_users(query="NonExistentUser")
 
         # Verify API call
         mock_get_client.assert_called_once()
-        expected_params = {"query": "NonExistentUser", "limit": DEFAULT_PAGINATION_LIMIT}
+        expected_params = {"query": "NonExistentUser", "limit": 100}
         self.mock_client.rget.assert_called_once_with("/users", params=expected_params)
 
         # Verify result
@@ -216,7 +217,7 @@ class TestUserTools(unittest.TestCase):
         self.mock_client.rget.side_effect = Exception("API Error")
 
         with self.assertRaises(Exception) as context:
-            list_users(UserQuery())
+            list_users()
 
         self.assertEqual(str(context.exception), "API Error")
         mock_get_client.assert_called_once()
@@ -274,25 +275,23 @@ class TestUserTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         self.mock_client.rget.return_value = [self.sample_users_list_response[0]]
 
-        result = list_users(UserQuery(teams_ids=["TEAM1"]))
+        result = list_users(teams_ids=["TEAM1"])
 
         # Verify API call
         mock_get_client.assert_called_once()
-        expected_params = {"team_ids[]": ["TEAM1"], "limit": DEFAULT_PAGINATION_LIMIT}
+        expected_params = {"team_ids[]": ["TEAM1"], "limit": 100}
         self.mock_client.rget.assert_called_once_with("/users", params=expected_params)
 
         # Verify result
         self.assertEqual(len(result.response), 1)
 
     @patch("pagerduty_mcp.tools.users.get_client")
-    def test_list_users_with_query_model(self, mock_get_client):
-        """Test listing users using UserQuery model - FastMCP compatible approach."""
+    def test_list_users_with_all_params(self, mock_get_client):
+        """Test listing users using flat params."""
         mock_get_client.return_value = self.mock_client
         self.mock_client.rget.return_value = self.sample_users_list_response
 
-        # Test the new approach using UserQuery model
-        query_model = UserQuery(query="John", teams_ids=["TEAM1"], limit=10)
-        result = list_users(query_model)
+        result = list_users(query="John", teams_ids=["TEAM1"], limit=10)
 
         # Verify API call
         mock_get_client.assert_called_once()
@@ -301,7 +300,6 @@ class TestUserTools(unittest.TestCase):
 
         # Verify result
         self.assertEqual(len(result.response), 2)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/website/docs/tools/incidents.md
+++ b/website/docs/tools/incidents.md
@@ -168,3 +168,22 @@ Requires `--enable-write-tools` flag.
 **Example prompt:**
 
 > "Add a note to incident P123456 saying 'Database failover initiated'"
+
+---
+
+### `create_incident_status_update` *(write)*
+
+Post a status update message to an incident, notifying subscribers and stakeholders of the current state. The message appears in the incident timeline and is sent to notification subscribers.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `incident_id` | `string` | Yes | The ID of the incident to post the status update to |
+| `message` | `string` | Yes | The status update message text |
+
+:::note
+Requires `--enable-write-tools` flag.
+:::
+
+**Example prompt:**
+
+> "Post a status update on incident P123456 saying 'Root cause identified — database connection pool exhausted, fix deploying now'"

--- a/website/docs/tools/log-entries.md
+++ b/website/docs/tools/log-entries.md
@@ -35,3 +35,18 @@ Get a specific log entry by ID.
 **Example prompt:**
 
 > "Get log entry PXXXXXX"
+
+---
+
+### `list_incident_log_entries`
+
+List all log entries for a specific incident. Records every state change and action: trigger, acknowledge, reassign, escalate, annotate, and resolve events.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `incident_id` | `string` | Yes | The ID of the incident to retrieve log entries for |
+| `limit` | `integer` | No | Maximum number of results to return (defaults to 100) |
+
+**Example prompt:**
+
+> "Show me the full activity timeline for incident P123456"

--- a/website/docs/tools/overview.md
+++ b/website/docs/tools/overview.md
@@ -4,15 +4,15 @@ sidebar_position: 1
 
 # Tools Overview
 
-The PagerDuty MCP Server exposes **64 tools** across **14 domains**. By default, only the 42 read-only tools are available. The 22 write tools require starting the server with `--enable-write-tools`.
+The PagerDuty MCP Server exposes **69 tools** across **14 domains**. By default, only the 47 read-only tools are available. The 22 write tools require starting the server with `--enable-write-tools`.
 
 ## Read vs. Write Tools
 
 | Type | Count | Flag Required |
 |------|-------|---------------|
-| Read-only | 42 | None (always available) |
+| Read-only | 47 | None (always available) |
 | Write | 22 | `--enable-write-tools` |
-| **Total** | **64** | |
+| **Total** | **69** | |
 
 ## Complete Tool Reference
 
@@ -47,7 +47,7 @@ The PagerDuty MCP Server exposes **64 tools** across **14 domains**. By default,
 | Tool | Type | Description |
 |------|------|-------------|
 | `list_incidents` | Read | List incidents with filters |
-| `get_incident` | Read | Get a specific incident by ID |
+| `get_incident` | Read | Get a specific incident by ID (supports `include=["external_references","metadata"]`) |
 | `get_outlier_incident` | Read | Get outlier incident analysis |
 | `get_past_incidents` | Read | Get past incidents similar to a given one |
 | `get_related_incidents` | Read | Get incidents related to a given one |
@@ -71,6 +71,7 @@ The PagerDuty MCP Server exposes **64 tools** across **14 domains**. By default,
 |------|------|-------------|
 | `list_services` | Read | List all services |
 | `get_service` | Read | Get a specific service |
+| `get_technical_service_dependencies` | Read | Get technical service dependency graph |
 | `create_service` | Write | Create a new service |
 | `update_service` | Write | Update a service configuration |
 
@@ -101,6 +102,7 @@ The PagerDuty MCP Server exposes **64 tools** across **14 domains**. By default,
 | `list_schedules` | Read | List all on-call schedules |
 | `get_schedule` | Read | Get a specific schedule |
 | `list_schedule_users` | Read | List users on a schedule for a time range |
+| `list_schedule_overrides` | Read | List overrides for a schedule in a date window |
 | `create_schedule` | Write | Create a new on-call schedule |
 | `create_schedule_override` | Write | Add an override to a schedule |
 | `update_schedule` | Write | Update an existing schedule |
@@ -117,6 +119,7 @@ The PagerDuty MCP Server exposes **64 tools** across **14 domains**. By default,
 |------|------|-------------|
 | `list_log_entries` | Read | List log entries (audit trail) |
 | `get_log_entry` | Read | Get a specific log entry |
+| `list_incident_log_entries` | Read | List log entries for a specific incident |
 
 ### Escalation Policies
 
@@ -147,6 +150,7 @@ The PagerDuty MCP Server exposes **64 tools** across **14 domains**. By default,
 | `list_status_page_statuses` | Read | List status options for a status page |
 | `get_status_page_post` | Read | Get a specific status page post |
 | `list_status_page_post_updates` | Read | List updates for a status page post |
+| `list_status_page_posts` | Read | List all posts for a specific status page |
 | `create_status_page_post` | Write | Create a new status page post |
 | `create_status_page_post_update` | Write | Add an update to a status page post |
 

--- a/website/docs/tools/schedules.md
+++ b/website/docs/tools/schedules.md
@@ -50,6 +50,22 @@ List users in a schedule.
 
 ---
 
+### `list_schedule_overrides`
+
+List overrides for a schedule within a date range.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `schedule_id` | `string` | Yes | The ID of the schedule |
+| `since` | `string` | Yes | Start of the date range (ISO 8601) |
+| `until` | `string` | Yes | End of the date range (ISO 8601) |
+
+**Example prompt:**
+
+> "Show me all overrides for schedule PXXXXXX this week"
+
+---
+
 ### `create_schedule` *(write)*
 
 Create a new on-call schedule. Each schedule layer requires a `name` field to identify the layer.
@@ -83,6 +99,25 @@ Requires `--enable-write-tools` flag.
 **Example prompt:**
 
 > "Create an override for schedule PXXXXXX putting user PYYYYYY on-call from 2025-01-15T09:00:00Z to 2025-01-15T17:00:00Z"
+
+---
+
+### `delete_schedule_override` *(write)*
+
+Delete a schedule override.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `schedule_id` | `string` | Yes | The ID of the schedule |
+| `override_id` | `string` | Yes | The ID of the override to delete |
+
+:::note
+Requires `--enable-write-tools` flag.
+:::
+
+**Example prompt:**
+
+> "Delete override PXXXXXX from schedule PYYYYYY"
 
 ---
 

--- a/website/docs/tools/services.md
+++ b/website/docs/tools/services.md
@@ -36,6 +36,20 @@ Get details for a specific service.
 
 ---
 
+### `get_technical_service_dependencies`
+
+Get the service dependencies for a technical service. Returns the `relationships` array showing which services this technical service depends on and which services depend on it.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `service_id` | `string` | Yes | The ID of the technical service |
+
+**Example prompt:**
+
+> "What services does the payment-gateway service depend on?"
+
+---
+
 ### `create_service` *(write)*
 
 Create a new service.

--- a/website/docs/tools/status-pages.md
+++ b/website/docs/tools/status-pages.md
@@ -63,6 +63,20 @@ Get a specific status page post by post ID.
 
 ---
 
+### `list_status_page_posts`
+
+List posts for a Status Page by Status Page ID.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `status_page_id` | `string` | Yes | The ID of the Status Page |
+
+**Example prompt:**
+
+> "List all posts on status page PXXXXXX"
+
+---
+
 ### `list_status_page_post_updates`
 
 List updates for a specific status page post.
@@ -125,3 +139,24 @@ Optional fields:
 :::note
 Requires `--enable-write-tools` flag.
 :::
+
+---
+
+### `create_status_page_post_postmortem` *(write)*
+
+Create or update a postmortem for a Status Page Post. If a postmortem already exists for the post it will be updated; otherwise one is created.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `status_page_id` | `string` | Yes | The ID of the Status Page |
+| `post_id` | `string` | Yes | The ID of the Status Page Post |
+| `message` | `string` | Yes | The postmortem message body (supports markdown) |
+| `notify_subscribers` | `boolean` | No | Whether to notify status page subscribers (defaults to `true`) |
+
+:::note
+Requires `--enable-write-tools` flag.
+:::
+
+**Example prompt:**
+
+> "Add a postmortem to status page post PXXXXXX explaining the root cause and preventive measures"


### PR DESCRIPTION
## Summary

Extends existing domain files with new read-only tools and one capability expansion:

| Domain | Change |
|--------|--------|
| Log Entries | `list_incident_log_entries(incident_id)` — timeline for a specific incident |
| Schedules | `list_schedule_overrides(schedule_id, since, until)` — overrides in a date window |
| Services | `get_technical_service_dependencies(service_id)` — technical service dependency graph |
| Status Pages | `list_status_page_posts(status_page_id)` — posts for a specific status page |
| Incidents | `get_incident` now accepts `include=["external_references"]` and `include=["metadata"]` |
| Incidents model | New `ExternalIntegrationLink` type; `Incident` gains `external_references` and `metadata` fields |

## Write tools intentionally excluded
`create_incident_status_update`, `delete_schedule_override`, `create_status_page_post_postmortem`, and `create_user` are held back for the write-tools PR.

## Depends on
Requires **PR #133** (`refactor/flatten-tool-signatures`) to be merged first.

## Test plan
- [ ] All existing tests pass
- [ ] New read tool tests pass
- [ ] `get_incident` with `include=["external_references"]` returns third-party integration links
- [ ] `get_incident` with `include=["metadata"]` returns incident metadata