### PR TITLE
feat: add write tools for escalation policies, incidents, schedules, status pages, and users

### DIFF
--- a/pagerduty_mcp/models/escalation_policies.py
+++ b/pagerduty_mcp/models/escalation_policies.py
@@ -90,6 +90,18 @@ class EscalationPolicy(BaseModel):
         return "escalation_policy"
 
 
+class EscalationPolicyCreate(BaseModel):
+    name: str = Field(description="The name of the escalation policy")
+    description: str | None = Field(default=None, description="Description of the policy")
+    num_loops: int = Field(default=0, description="Number of times the policy repeats after reaching the end")
+    escalation_rules: list[EscalationRule] = Field(description="Ordered list of escalation rules")
+    on_call_handoff_notifications: Literal["if_has_services", "always"] | None = Field(
+        default="if_has_services",
+        description="When to send on-call handoff notifications",
+    )
+    teams: list["TeamReference"] | None = Field(default=None, description="Teams to associate")
+
+
 class EscalationPolicyQuery(BaseModel):
     query: str | None = Field(description="Filter escalation policies by name or description", default=None)
     user_ids: list[str] | None = Field(description="Filter escalation policies by user IDs", default=None)

--- a/pagerduty_mcp/models/users.py
+++ b/pagerduty_mcp/models/users.py
@@ -59,3 +59,16 @@ class UserQuery(BaseModel):
         if self.limit:
             params["limit"] = self.limit
         return params
+
+
+class CreateUserRequest(BaseModel):
+    name: str = Field(description="The full name of the user")
+    email: str = Field(description="The user's email address (used as login)")
+    role: UserRole = Field(
+        default="user",
+        description="The user's role in PagerDuty (user, admin, read_only_user, etc.)",
+    )
+    time_zone: str = Field(
+        default="UTC",
+        description="The user's time zone (e.g. 'America/New_York')",
+    )

--- a/pagerduty_mcp/tools/__init__.py
+++ b/pagerduty_mcp/tools/__init__.py
@@ -15,14 +15,12 @@ from .change_events import (
     list_incident_change_events,
     list_service_change_events,
 )
-
-# Currently disabled to prevent issues with the escalation policies domain
 from .escalation_policies import (
-    # create_escalation_policy,
+    create_escalation_policy,
+    delete_escalation_policy,
     get_escalation_policy,
-    # get_escalation_policy_on_call,
-    # get_escalation_policy_services,
     list_escalation_policies,
+    update_escalation_policy,
 )
 from .event_orchestrations import (
     append_event_orchestration_router_rule,
@@ -42,6 +40,7 @@ from .incidents import (
     add_note_to_incident,
     add_responders,
     create_incident,
+    create_incident_status_update,
     get_incident,
     get_outlier_incident,
     get_past_incidents,
@@ -59,6 +58,7 @@ from .oncalls import list_oncalls
 from .schedules import (
     create_schedule,
     create_schedule_override,
+    delete_schedule_override,
     get_schedule,
     list_schedule_overrides,
     list_schedule_users,
@@ -74,6 +74,7 @@ from .services import (
 )
 from .status_pages import (
     create_status_page_post,
+    create_status_page_post_postmortem,
     create_status_page_post_update,
     get_status_page_post,
     list_status_page_impacts,
@@ -93,7 +94,7 @@ from .teams import (
     remove_team_member,
     update_team,
 )
-from .users import get_user_data, list_users
+from .users import create_user, get_user_data, list_users
 
 # Read-only tools (safe, non-destructive operations)
 read_tools = [
@@ -118,6 +119,12 @@ read_tools = [
     # Incident Workflows
     list_incident_workflows,
     get_incident_workflow,
+    # Log Entries
+    list_log_entries,
+    get_log_entry,
+    list_incident_log_entries,
+    # On-calls
+    list_oncalls,
     # Services
     list_services,
     get_service,
@@ -134,12 +141,6 @@ read_tools = [
     get_schedule,
     list_schedule_users,
     list_schedule_overrides,
-    # On-calls
-    list_oncalls,
-    # Log Entries
-    list_log_entries,
-    get_log_entry,
-    list_incident_log_entries,
     # Escalation Policies
     list_escalation_policies,
     get_escalation_policy,
@@ -170,6 +171,7 @@ write_tools = [
     manage_incidents,
     add_responders,
     add_note_to_incident,
+    create_incident_status_update,
     # Incident Workflows
     start_incident_workflow,
     # Services
@@ -181,18 +183,24 @@ write_tools = [
     delete_team,
     add_team_member,
     remove_team_member,
+    # Users
+    create_user,
     # Schedules
     create_schedule,
     create_schedule_override,
+    delete_schedule_override,
     update_schedule,
+    # Escalation Policies
+    create_escalation_policy,
+    update_escalation_policy,
+    delete_escalation_policy,
     # Event Orchestrations
     update_event_orchestration_router,
     append_event_orchestration_router_rule,
     # Status Pages
     create_status_page_post,
+    create_status_page_post_postmortem,
     create_status_page_post_update,
-    # Escalation Policies - currently disabled
-    # create_escalation_policy,
 ]
 
 # All tools (combined list for backward compatibility)

--- a/pagerduty_mcp/tools/alerts.py
+++ b/pagerduty_mcp/tools/alerts.py
@@ -1,5 +1,7 @@
+from typing import Any
+
 from pagerduty_mcp.client import get_client
-from pagerduty_mcp.models import Alert, AlertQuery, ListResponseModel
+from pagerduty_mcp.models import Alert, ListResponseModel
 from pagerduty_mcp.utils import paginate
 
 
@@ -17,24 +19,32 @@ def get_alert_from_incident(incident_id: str, alert_id: str) -> Alert:
     return Alert.model_validate(response)
 
 
-def list_alerts_from_incident(incident_id: str, query_model: AlertQuery) -> ListResponseModel[Alert]:
+def list_alerts_from_incident(
+    incident_id: str,
+    limit: int | None = 100,
+    offset: int | None = 0,
+) -> ListResponseModel[Alert]:
     """List alerts for a specific incident.
 
     Args:
         incident_id: The ID of the incident
-        query_model: Query parameters for pagination
+        limit: Maximum number of results to return (1-1000). Default is 100.
+        offset: Offset for pagination. Default is 0.
 
     Returns:
-        List of Alert objects for the incident
-
+        List of Alert objects for the given incident
     """
-    params = query_model.to_params()
+    params: dict[str, Any] = {}
+    if limit is not None:
+        params["limit"] = limit
+    if offset is not None:
+        params["offset"] = offset
 
     response = paginate(
         client=get_client(),
         entity=f"incidents/{incident_id}/alerts",
         params=params,
-        maximum_records=query_model.limit or 100,
+        maximum_records=limit or 100,
     )
     alerts = [Alert(**alert) for alert in response]
     return ListResponseModel[Alert](response=alerts)

--- a/pagerduty_mcp/tools/escalation_policies.py
+++ b/pagerduty_mcp/tools/escalation_policies.py
@@ -1,19 +1,45 @@
+import json
+from typing import Any
+
 from pagerduty_mcp.client import get_client
-from pagerduty_mcp.models import EscalationPolicy, EscalationPolicyQuery, ListResponseModel
+from pagerduty_mcp.models import EscalationPolicy, ListResponseModel
+from pagerduty_mcp.models.escalation_policies import EscalationPolicyCreate
 from pagerduty_mcp.utils import paginate
 
 
 def list_escalation_policies(
-    query_model: EscalationPolicyQuery | None = None,
+    query: str | None = None,
+    user_ids: list[str] | None = None,
+    team_ids: list[str] | None = None,
+    include: list[str] | None = None,
+    limit: int | None = None,
 ) -> ListResponseModel[EscalationPolicy]:
     """List escalation policies with optional filtering.
+
+    Args:
+        query: Filter by name
+        user_ids: Filter by user IDs
+        team_ids: Filter by team IDs
+        include: Include additional details (e.g. services, teams)
+        limit: Max results to return
 
     Returns:
         List of escalation policies matching the query parameters
     """
-    if query_model is None:
-        query_model = EscalationPolicyQuery()
-    response = paginate(client=get_client(), entity="escalation_policies", params=query_model.to_params())
+    params: dict[str, Any] = {}
+    if query:
+        params["query"] = query
+    if user_ids:
+        params["user_ids[]"] = user_ids
+    if team_ids:
+        params["team_ids[]"] = team_ids
+    if include:
+        params["include[]"] = include
+    if limit:
+        params["limit"] = limit
+    response = paginate(
+        client=get_client(), entity="escalation_policies", params=params
+    )
     policies = [EscalationPolicy(**policy) for policy in response]
     return ListResponseModel[EscalationPolicy](response=policies)
 
@@ -29,3 +55,51 @@ def get_escalation_policy(policy_id: str) -> EscalationPolicy:
     """
     response = get_client().rget(f"/escalation_policies/{policy_id}")
     return EscalationPolicy.model_validate(response)
+
+
+def create_escalation_policy(escalation_policy: EscalationPolicyCreate) -> str:
+    """Create a new escalation policy.
+
+    Args:
+        escalation_policy: The policy data to create
+
+    Returns:
+        JSON string of the created EscalationPolicy
+    """
+    payload = escalation_policy.model_dump(exclude_none=True)
+    response = get_client().rpost(
+        "/escalation_policies",
+        json={"escalation_policy": payload},
+    )
+    return EscalationPolicy.model_validate(response).model_dump_json()
+
+
+def update_escalation_policy(policy_id: str, escalation_policy: EscalationPolicyCreate) -> str:
+    """Update an existing escalation policy.
+
+    Args:
+        policy_id: The ID of the escalation policy to update
+        escalation_policy: The updated policy data
+
+    Returns:
+        JSON string of the updated EscalationPolicy
+    """
+    payload = escalation_policy.model_dump(exclude_none=True)
+    response = get_client().rput(
+        f"/escalation_policies/{policy_id}",
+        json={"escalation_policy": payload},
+    )
+    return EscalationPolicy.model_validate(response).model_dump_json()
+
+
+def delete_escalation_policy(policy_id: str) -> str:
+    """Delete an escalation policy.
+
+    Args:
+        policy_id: The ID of the escalation policy to delete
+
+    Returns:
+        JSON string confirming deletion
+    """
+    get_client().rdelete(f"/escalation_policies/{policy_id}")
+    return json.dumps({"success": True})

--- a/pagerduty_mcp/tools/incidents.py
+++ b/pagerduty_mcp/tools/incidents.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime
 from typing import Any
 
@@ -26,7 +27,7 @@ def list_incidents(
     until: datetime | None = None,
     user_ids: list[str] | None = None,
     service_ids: list[str] | None = None,
-    team_ids: list[str] | None = None,
+    teams_ids: list[str] | None = None,
     urgencies: list[str] | None = None,
     sort_by: list[str] | None = None,
     request_scope: str | None = None,
@@ -42,7 +43,7 @@ def list_incidents(
         until: Filter incidents until a specific date
         user_ids: Filter by user IDs
         service_ids: Filter by service IDs
-        team_ids: Filter by team IDs
+        teams_ids: Filter by team IDs
         urgencies: Filter by urgency (high, low)
         sort_by: Sort fields and directions (e.g. ['created_at:desc'])
         request_scope: 'all', 'teams' (my teams), or 'assigned' (assigned to me)
@@ -60,8 +61,8 @@ def list_incidents(
         params["until"] = until.isoformat()
     if service_ids:
         params["service_ids[]"] = service_ids
-    if team_ids:
-        params["team_ids[]"] = team_ids
+    if teams_ids:
+        params["teams_ids[]"] = teams_ids
     if user_ids:
         params["user_ids[]"] = user_ids
     if urgencies:
@@ -78,7 +79,7 @@ def list_incidents(
             params["user_ids[]"] = [user_data.id]
         elif request_scope == "teams":
             user_team_ids = [team.id for team in user_data.teams]
-            params["team_ids[]"] = user_team_ids
+            params["teams_ids[]"] = user_team_ids
 
     response = paginate(
         client=ContextResolver.get_client(), entity="incidents", params=params, maximum_records=limit or MAX_RESULTS
@@ -280,6 +281,27 @@ def add_note_to_incident(incident_id: str, note: str) -> IncidentNote:
         json={"note": {"content": note}},
     )
     return IncidentNote.model_validate(response)
+
+
+def create_incident_status_update(incident_id: str, message: str) -> str:
+    """Create a status update on an incident.
+
+    Posts a status update message to an incident, notifying subscribers and
+    stakeholders of the current state. The message appears in the incident
+    timeline and is sent to notification subscribers.
+
+    Args:
+        incident_id: The ID of the incident to post the status update to
+        message: The status update message text
+
+    Returns:
+        JSON string of the created status update
+    """
+    response = get_client().rpost(
+        f"/incidents/{incident_id}/status_updates",
+        json={"message": message},
+    )
+    return json.dumps(response)
 
 
 def get_outlier_incident(

--- a/pagerduty_mcp/tools/schedules.py
+++ b/pagerduty_mcp/tools/schedules.py
@@ -124,6 +124,20 @@ def list_schedule_overrides(schedule_id: str, since: str, until: str) -> str:
     return json.dumps({"overrides": overrides})
 
 
+def delete_schedule_override(schedule_id: str, override_id: str) -> str:
+    """Delete a schedule override.
+
+    Args:
+        schedule_id: The ID of the schedule
+        override_id: The ID of the override to delete
+
+    Returns:
+        JSON string confirming deletion
+    """
+    get_client().rdelete(f"/schedules/{schedule_id}/overrides/{override_id}")
+    return json.dumps({"success": True})
+
+
 def create_schedule(create_model: ScheduleCreateRequest) -> Schedule:
     """Create a new on-call schedule.
 

--- a/pagerduty_mcp/tools/status_pages.py
+++ b/pagerduty_mcp/tools/status_pages.py
@@ -275,3 +275,43 @@ def list_status_page_posts(status_page_id: str) -> str:
     return json.dumps({"response": response})
 
 
+def create_status_page_post_postmortem(
+    status_page_id: str,
+    post_id: str,
+    message: str,
+    notify_subscribers: bool = True,
+) -> str:
+    """Create or update a postmortem for a Status Page Post.
+
+    Publishes a post-mortem document to a Status Page Post. If a postmortem
+    already exists for the post it will be updated; otherwise one is created.
+
+    IMPORTANT: Postmortems can only be attached to posts with post_type="incident".
+    Calling this on a maintenance post will return a 400 error. Use get_status_page_post
+    or list_status_page_posts to verify the post_type is "incident" before calling this tool.
+
+    Args:
+        status_page_id: The ID of the Status Page
+        post_id: The ID of the Status Page Post to attach the postmortem to (must be an incident-type post)
+        message: The postmortem message body (supports rich text / markdown)
+        notify_subscribers: Whether to notify status page subscribers (defaults to True)
+
+    Returns:
+        JSON string of the created/updated postmortem
+    """
+    payload = {
+        "postmortem": {
+            "message": message,
+            "notify_subscribers": notify_subscribers,
+            "post": {
+                "id": post_id,
+                "self": f"https://api.pagerduty.com/status_pages/{status_page_id}/posts/{post_id}",
+                "type": "status_page_post",
+            },
+            "type": "status_page_post_postmortem",
+        }
+    }
+    response = get_client().rput(
+        f"/status_pages/{status_page_id}/posts/{post_id}/postmortem", json=payload
+    )
+    return json.dumps(response)

--- a/pagerduty_mcp/tools/users.py
+++ b/pagerduty_mcp/tools/users.py
@@ -2,6 +2,8 @@ from typing import Any
 
 from pagerduty_mcp.client import get_client
 from pagerduty_mcp.models import ListResponseModel, User
+from pagerduty_mcp.models.users import CreateUserRequest
+
 
 def get_user_data() -> User:
     """Get the current user's data.
@@ -41,3 +43,16 @@ def list_users(
     return ListResponseModel[User](response=users)
 
 
+def create_user(request: CreateUserRequest) -> User:
+    """Create a new PagerDuty user account. No invitation email is sent.
+
+    Args:
+        request: User creation parameters (name, email, role, time_zone)
+
+    Returns:
+        The created User object.
+    """
+    response = get_client().rpost("/users", json=request.model_dump())
+    if isinstance(response, dict) and "user" in response:
+        return User(**response["user"])
+    return User.model_validate(response)

--- a/tests/test_escalation_policies.py
+++ b/tests/test_escalation_policies.py
@@ -1,16 +1,21 @@
+import json
 import unittest
 from unittest.mock import MagicMock, patch
 
 from pagerduty_mcp.models.base import DEFAULT_PAGINATION_LIMIT, MAXIMUM_PAGINATION_LIMIT
 from pagerduty_mcp.models.escalation_policies import (
     EscalationPolicy,
+    EscalationPolicyCreate,
     EscalationPolicyQuery,
     EscalationRule,
     EscalationTarget,
 )
 from pagerduty_mcp.tools.escalation_policies import (
+    create_escalation_policy,
+    delete_escalation_policy,
     get_escalation_policy,
     list_escalation_policies,
+    update_escalation_policy,
 )
 
 
@@ -92,19 +97,21 @@ class TestEscalationPolicyTools(unittest.TestCase):
         self.mock_client.reset_mock()
         # Clear any side effects
         self.mock_client.rget.side_effect = None
+        self.mock_client.rpost.side_effect = None
+        self.mock_client.rput.side_effect = None
+        self.mock_client.rdelete.side_effect = None
 
     @patch("pagerduty_mcp.tools.escalation_policies.paginate")
     @patch("pagerduty_mcp.tools.escalation_policies.get_client")
     def test_list_escalation_policies_no_query_model(self, mock_get_client, mock_paginate):
-        """Test that list_escalation_policies can be called with no arguments (no query_model)."""
+        """Test that list_escalation_policies can be called with no arguments."""
         mock_get_client.return_value = self.mock_client
         mock_paginate.return_value = self.sample_escalation_policies_list_response
 
         result = list_escalation_policies()
 
-        expected_params = {"limit": DEFAULT_PAGINATION_LIMIT}
         mock_paginate.assert_called_once_with(
-            client=self.mock_client, entity="escalation_policies", params=expected_params
+            client=self.mock_client, entity="escalation_policies", params={}
         )
         self.assertEqual(len(result.response), 2)
 
@@ -115,16 +122,12 @@ class TestEscalationPolicyTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         mock_paginate.return_value = self.sample_escalation_policies_list_response
 
-        query = EscalationPolicyQuery()
-        result = list_escalation_policies(query)
+        result = list_escalation_policies()
 
-        # Verify paginate call
-        expected_params = {"limit": DEFAULT_PAGINATION_LIMIT}
         mock_paginate.assert_called_once_with(
-            client=self.mock_client, entity="escalation_policies", params=expected_params
+            client=self.mock_client, entity="escalation_policies", params={}
         )
 
-        # Verify result
         self.assertEqual(len(result.response), 2)
         self.assertIsInstance(result.response[0], EscalationPolicy)
         self.assertIsInstance(result.response[1], EscalationPolicy)
@@ -140,16 +143,12 @@ class TestEscalationPolicyTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         mock_paginate.return_value = [self.sample_escalation_policies_list_response[0]]
 
-        query = EscalationPolicyQuery(query="Engineering")
-        result = list_escalation_policies(query)
+        result = list_escalation_policies(query="Engineering")
 
-        # Verify paginate call
-        expected_params = {"query": "Engineering", "limit": DEFAULT_PAGINATION_LIMIT}
         mock_paginate.assert_called_once_with(
-            client=self.mock_client, entity="escalation_policies", params=expected_params
+            client=self.mock_client, entity="escalation_policies", params={"query": "Engineering"}
         )
 
-        # Verify result
         self.assertEqual(len(result.response), 1)
         self.assertEqual(result.response[0].name, "Engineering Team Escalation")
 
@@ -160,16 +159,12 @@ class TestEscalationPolicyTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         mock_paginate.return_value = self.sample_escalation_policies_list_response
 
-        query = EscalationPolicyQuery(user_ids=["USER123", "USER456"])
-        result = list_escalation_policies(query)
+        result = list_escalation_policies(user_ids=["USER123", "USER456"])
 
-        # Verify paginate call
-        expected_params = {"user_ids[]": ["USER123", "USER456"], "limit": DEFAULT_PAGINATION_LIMIT}
         mock_paginate.assert_called_once_with(
-            client=self.mock_client, entity="escalation_policies", params=expected_params
+            client=self.mock_client, entity="escalation_policies", params={"user_ids[]": ["USER123", "USER456"]}
         )
 
-        # Verify result
         self.assertEqual(len(result.response), 2)
 
     @patch("pagerduty_mcp.tools.escalation_policies.paginate")
@@ -179,16 +174,12 @@ class TestEscalationPolicyTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         mock_paginate.return_value = self.sample_escalation_policies_list_response
 
-        query = EscalationPolicyQuery(team_ids=["TEAM123"])
-        result = list_escalation_policies(query)
+        result = list_escalation_policies(team_ids=["TEAM123"])
 
-        # Verify paginate call
-        expected_params = {"team_ids[]": ["TEAM123"], "limit": DEFAULT_PAGINATION_LIMIT}
         mock_paginate.assert_called_once_with(
-            client=self.mock_client, entity="escalation_policies", params=expected_params
+            client=self.mock_client, entity="escalation_policies", params={"team_ids[]": ["TEAM123"]}
         )
 
-        # Verify result
         self.assertEqual(len(result.response), 2)
 
     @patch("pagerduty_mcp.tools.escalation_policies.paginate")
@@ -198,16 +189,12 @@ class TestEscalationPolicyTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         mock_paginate.return_value = self.sample_escalation_policies_list_response
 
-        query = EscalationPolicyQuery(include=["services", "teams"])
-        result = list_escalation_policies(query)
+        result = list_escalation_policies(include=["services", "teams"])
 
-        # Verify paginate call
-        expected_params = {"include[]": ["services", "teams"], "limit": DEFAULT_PAGINATION_LIMIT}
         mock_paginate.assert_called_once_with(
-            client=self.mock_client, entity="escalation_policies", params=expected_params
+            client=self.mock_client, entity="escalation_policies", params={"include[]": ["services", "teams"]}
         )
 
-        # Verify result
         self.assertEqual(len(result.response), 2)
 
     @patch("pagerduty_mcp.tools.escalation_policies.paginate")
@@ -217,28 +204,26 @@ class TestEscalationPolicyTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         mock_paginate.return_value = [self.sample_escalation_policies_list_response[0]]
 
-        query = EscalationPolicyQuery(
+        result = list_escalation_policies(
             query="Engineering",
             user_ids=["USER123"],
             team_ids=["TEAM123"],
             include=["services"],
             limit=50,
         )
-        result = list_escalation_policies(query)
 
-        # Verify paginate call
-        expected_params = {
-            "query": "Engineering",
-            "user_ids[]": ["USER123"],
-            "team_ids[]": ["TEAM123"],
-            "include[]": ["services"],
-            "limit": 50,
-        }
         mock_paginate.assert_called_once_with(
-            client=self.mock_client, entity="escalation_policies", params=expected_params
+            client=self.mock_client,
+            entity="escalation_policies",
+            params={
+                "query": "Engineering",
+                "user_ids[]": ["USER123"],
+                "team_ids[]": ["TEAM123"],
+                "include[]": ["services"],
+                "limit": 50,
+            },
         )
 
-        # Verify result
         self.assertEqual(len(result.response), 1)
 
     @patch("pagerduty_mcp.tools.escalation_policies.paginate")
@@ -248,16 +233,12 @@ class TestEscalationPolicyTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         mock_paginate.return_value = self.sample_escalation_policies_list_response
 
-        query = EscalationPolicyQuery(limit=50)
-        result = list_escalation_policies(query)
+        result = list_escalation_policies(limit=50)
 
-        # Verify paginate call
-        expected_params = {"limit": 50}
         mock_paginate.assert_called_once_with(
-            client=self.mock_client, entity="escalation_policies", params=expected_params
+            client=self.mock_client, entity="escalation_policies", params={"limit": 50}
         )
 
-        # Verify result
         self.assertEqual(len(result.response), 2)
 
     @patch("pagerduty_mcp.tools.escalation_policies.paginate")
@@ -267,16 +248,12 @@ class TestEscalationPolicyTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         mock_paginate.return_value = []
 
-        query = EscalationPolicyQuery(query="NonExistentPolicy")
-        result = list_escalation_policies(query)
+        result = list_escalation_policies(query="NonExistentPolicy")
 
-        # Verify paginate call
-        expected_params = {"query": "NonExistentPolicy", "limit": DEFAULT_PAGINATION_LIMIT}
         mock_paginate.assert_called_once_with(
-            client=self.mock_client, entity="escalation_policies", params=expected_params
+            client=self.mock_client, entity="escalation_policies", params={"query": "NonExistentPolicy"}
         )
 
-        # Verify result
         self.assertEqual(len(result.response), 0)
 
     @patch("pagerduty_mcp.tools.escalation_policies.paginate")
@@ -286,10 +263,8 @@ class TestEscalationPolicyTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         mock_paginate.side_effect = Exception("Pagination Error")
 
-        query = EscalationPolicyQuery()
-
         with self.assertRaises(Exception) as context:
-            list_escalation_policies(query)
+            list_escalation_policies()
 
         self.assertEqual(str(context.exception), "Pagination Error")
 
@@ -420,6 +395,127 @@ class TestEscalationPolicyTools(unittest.TestCase):
         )
 
         self.assertEqual(policy.type, "escalation_policy")
+
+    def _make_escalation_policy_create(self):
+        """Helper to build a minimal EscalationPolicyCreate object."""
+        rule = EscalationRule(
+            escalation_delay_in_minutes=30,
+            targets=[EscalationTarget(id="USER123", type="user_reference")],
+        )
+        return EscalationPolicyCreate(
+            name="Engineering Team Escalation",
+            escalation_rules=[rule],
+        )
+
+    @patch("pagerduty_mcp.tools.escalation_policies.get_client")
+    def test_create_escalation_policy_success(self, mock_get_client):
+        """Test successful creation of an escalation policy."""
+        mock_get_client.return_value = self.mock_client
+        self.mock_client.rpost.return_value = self.sample_escalation_policy_response
+
+        ep = self._make_escalation_policy_create()
+        result = create_escalation_policy(ep)
+
+        self.assertIsInstance(result, str)
+        data = json.loads(result)
+        self.assertEqual(data["id"], "EP123")
+        self.assertEqual(data["name"], "Engineering Team Escalation")
+
+    @patch("pagerduty_mcp.tools.escalation_policies.get_client")
+    def test_create_escalation_policy_calls_api_correctly(self, mock_get_client):
+        """Test that create_escalation_policy calls rpost with correct arguments."""
+        mock_get_client.return_value = self.mock_client
+        self.mock_client.rpost.return_value = self.sample_escalation_policy_response
+
+        ep = self._make_escalation_policy_create()
+        payload = ep.model_dump(exclude_none=True)
+        create_escalation_policy(ep)
+
+        self.mock_client.rpost.assert_called_once_with(
+            "/escalation_policies",
+            json={"escalation_policy": payload},
+        )
+
+    @patch("pagerduty_mcp.tools.escalation_policies.get_client")
+    def test_create_escalation_policy_client_error(self, mock_get_client):
+        """Test create_escalation_policy propagates client exceptions."""
+        mock_get_client.return_value = self.mock_client
+        self.mock_client.rpost.side_effect = Exception("Create Error")
+
+        with self.assertRaises(Exception) as ctx:
+            create_escalation_policy(self._make_escalation_policy_create())
+
+        self.assertEqual(str(ctx.exception), "Create Error")
+
+    @patch("pagerduty_mcp.tools.escalation_policies.get_client")
+    def test_update_escalation_policy_success(self, mock_get_client):
+        """Test successful update of an escalation policy."""
+        mock_get_client.return_value = self.mock_client
+        self.mock_client.rput.return_value = self.sample_escalation_policy_response
+
+        ep = self._make_escalation_policy_create()
+        result = update_escalation_policy("EP123", ep)
+
+        self.assertIsInstance(result, str)
+        data = json.loads(result)
+        self.assertEqual(data["id"], "EP123")
+
+    @patch("pagerduty_mcp.tools.escalation_policies.get_client")
+    def test_update_escalation_policy_calls_api_correctly(self, mock_get_client):
+        """Test that update_escalation_policy calls rput with the correct URL."""
+        mock_get_client.return_value = self.mock_client
+        self.mock_client.rput.return_value = self.sample_escalation_policy_response
+
+        ep = self._make_escalation_policy_create()
+        payload = ep.model_dump(exclude_none=True)
+        update_escalation_policy("EP123", ep)
+
+        self.mock_client.rput.assert_called_once_with(
+            "/escalation_policies/EP123",
+            json={"escalation_policy": payload},
+        )
+
+    @patch("pagerduty_mcp.tools.escalation_policies.get_client")
+    def test_update_escalation_policy_client_error(self, mock_get_client):
+        """Test update_escalation_policy propagates client exceptions."""
+        mock_get_client.return_value = self.mock_client
+        self.mock_client.rput.side_effect = Exception("Update Error")
+
+        with self.assertRaises(Exception) as ctx:
+            update_escalation_policy("EP123", self._make_escalation_policy_create())
+
+        self.assertEqual(str(ctx.exception), "Update Error")
+
+    @patch("pagerduty_mcp.tools.escalation_policies.get_client")
+    def test_delete_escalation_policy_success(self, mock_get_client):
+        """Test successful deletion of an escalation policy."""
+        mock_get_client.return_value = self.mock_client
+
+        result = delete_escalation_policy("EP123")
+
+        self.assertIsInstance(result, str)
+        data = json.loads(result)
+        self.assertTrue(data["success"])
+
+    @patch("pagerduty_mcp.tools.escalation_policies.get_client")
+    def test_delete_escalation_policy_calls_api_correctly(self, mock_get_client):
+        """Test that delete_escalation_policy calls rdelete with correct URL."""
+        mock_get_client.return_value = self.mock_client
+
+        delete_escalation_policy("EP123")
+
+        self.mock_client.rdelete.assert_called_once_with("/escalation_policies/EP123")
+
+    @patch("pagerduty_mcp.tools.escalation_policies.get_client")
+    def test_delete_escalation_policy_client_error(self, mock_get_client):
+        """Test delete_escalation_policy propagates client exceptions."""
+        mock_get_client.return_value = self.mock_client
+        self.mock_client.rdelete.side_effect = Exception("Delete Error")
+
+        with self.assertRaises(Exception) as ctx:
+            delete_escalation_policy("EP123")
+
+        self.assertEqual(str(ctx.exception), "Delete Error")
 
 
 if __name__ == "__main__":

--- a/tests/test_incidents.py
+++ b/tests/test_incidents.py
@@ -7,7 +7,6 @@ from unittest.mock import Mock, patch
 from pagerduty_mcp.context import ContextResolver
 from pagerduty_mcp.models import (
     Alert,
-    AlertQuery,
     AssignmentInput,
     Incident,
     IncidentCreate,
@@ -34,6 +33,7 @@ from pagerduty_mcp.tools.incidents import (
     add_note_to_incident,
     add_responders,
     create_incident,
+    create_incident_status_update,
     get_incident,
     get_outlier_incident,
     get_past_incidents,
@@ -230,8 +230,8 @@ class TestIncidentTools(unittest.TestCase):
         _ = list_incidents(request_scope="teams")
 
         call_args = mock_paginate.call_args
-        self.assertIn("team_ids[]", call_args[1]["params"])
-        self.assertEqual(call_args[1]["params"]["team_ids[]"], ["PTEAM123"])
+        self.assertIn("teams_ids[]", call_args[1]["params"])
+        self.assertEqual(call_args[1]["params"]["teams_ids[]"], ["PTEAM123"])
 
     def test_list_incidents_user_required_error(self):
         """If the request_scope requires user context but none is available, an error should be raised."""
@@ -1347,6 +1347,46 @@ class TestIncidentTools(unittest.TestCase):
             str(ctx.exception),
         )
 
+    @patch("pagerduty_mcp.tools.incidents.get_client")
+    def test_create_incident_status_update_success(self, mock_get_client):
+        """Test creating a status update for an incident successfully."""
+        mock_client = Mock()
+        mock_client.rpost.return_value = {"id": "SU123", "message": "System is recovering"}
+        mock_get_client.return_value = mock_client
+
+        result = create_incident_status_update("P123", "System is recovering")
+
+        self.assertIsInstance(result, str)
+        import json as _json
+        data = _json.loads(result)
+        self.assertEqual(data["message"], "System is recovering")
+
+    @patch("pagerduty_mcp.tools.incidents.get_client")
+    def test_create_incident_status_update_calls_api_correctly(self, mock_get_client):
+        """Test that create_incident_status_update calls rpost with correct arguments."""
+        mock_client = Mock()
+        mock_client.rpost.return_value = {"id": "SU123", "message": "System is recovering"}
+        mock_get_client.return_value = mock_client
+
+        create_incident_status_update("P123", "System is recovering")
+
+        mock_client.rpost.assert_called_once_with(
+            "/incidents/P123/status_updates",
+            json={"message": "System is recovering"},
+        )
+
+    @patch("pagerduty_mcp.tools.incidents.get_client")
+    def test_create_incident_status_update_client_error(self, mock_get_client):
+        """Test create_incident_status_update propagates client exceptions."""
+        mock_client = Mock()
+        mock_client.rpost.side_effect = Exception("Status Update Error")
+        mock_get_client.return_value = mock_client
+
+        with self.assertRaises(Exception) as ctx:
+            create_incident_status_update("P123", "System is recovering")
+
+        self.assertEqual(str(ctx.exception), "Status Update Error")
+
     @patch("pagerduty_mcp.tools.log_entries.paginate")
     @patch("pagerduty_mcp.tools.log_entries.get_client")
     def test_list_incident_log_entries_success(self, mock_get_client, mock_paginate):
@@ -1469,10 +1509,8 @@ class TestAlertTools(unittest.TestCase):
         mock_get_client.return_value = mock_client
         mock_paginate.return_value = [self.sample_alert_data]
 
-        query_model = AlertQuery(limit=10, offset=0)
-
         # Act
-        result = list_alerts_from_incident("PINCIDENT123", query_model)
+        result = list_alerts_from_incident("PINCIDENT123", limit=10, offset=0)
 
         # Assert
         self.assertIsInstance(result, ListResponseModel)
@@ -1490,10 +1528,8 @@ class TestAlertTools(unittest.TestCase):
         mock_get_client.return_value = mock_client
         mock_paginate.return_value = []
 
-        query_model = AlertQuery()
-
         # Act
-        result = list_alerts_from_incident("PINCIDENT123", query_model)
+        result = list_alerts_from_incident("PINCIDENT123")
 
         # Assert
         self.assertIsInstance(result, ListResponseModel)

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -20,6 +20,7 @@ from pagerduty_mcp.models.users import User
 from pagerduty_mcp.tools.schedules import (
     create_schedule,
     create_schedule_override,
+    delete_schedule_override,
     get_schedule,
     list_schedule_overrides,
     list_schedule_users,
@@ -898,6 +899,39 @@ class TestScheduleTools(unittest.TestCase):
 
         data = _json.loads(result)
         self.assertEqual(data["overrides"], [])
+
+    @patch("pagerduty_mcp.tools.schedules.get_client")
+    def test_delete_schedule_override_success(self, mock_get_client):
+        """Test successful deletion of a schedule override."""
+        import json as _json
+        mock_get_client.return_value = self.mock_client
+
+        result = delete_schedule_override("SCHED123", "OV123")
+
+        self.assertIsInstance(result, str)
+        data = _json.loads(result)
+        self.assertTrue(data["success"])
+
+    @patch("pagerduty_mcp.tools.schedules.get_client")
+    def test_delete_schedule_override_calls_api_correctly(self, mock_get_client):
+        """Test that delete_schedule_override calls rdelete with correct URL."""
+        mock_get_client.return_value = self.mock_client
+
+        delete_schedule_override("SCHED123", "OV123")
+
+        self.mock_client.rdelete.assert_called_once_with("/schedules/SCHED123/overrides/OV123")
+
+    @patch("pagerduty_mcp.tools.schedules.get_client")
+    def test_delete_schedule_override_client_error(self, mock_get_client):
+        """Test delete_schedule_override propagates client exceptions."""
+        mock_get_client.return_value = self.mock_client
+        self.mock_client.rdelete.side_effect = Exception("Delete Error")
+
+        with self.assertRaises(Exception) as ctx:
+            delete_schedule_override("SCHED123", "OV123")
+
+        self.assertEqual(str(ctx.exception), "Delete Error")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_status_pages.py
+++ b/tests/test_status_pages.py
@@ -26,6 +26,7 @@ from pagerduty_mcp.models.status_pages import (
 )
 from pagerduty_mcp.tools.status_pages import (
     create_status_page_post,
+    create_status_page_post_postmortem,
     create_status_page_post_update,
     get_status_page_post,
     list_status_page_impacts,
@@ -584,6 +585,86 @@ class TestStatusPagesTools(unittest.TestCase):
             json_data["post_update"]["reported_at"], str, "reported_at must be serialized as ISO string"
         )
         self.assertEqual(json_data["post_update"]["reported_at"], "2023-12-12T14:30:00")
+
+    @patch("pagerduty_mcp.tools.status_pages.get_client")
+    def test_create_status_page_post_postmortem_success(self, mock_get_client):
+        """Test creating a post-mortem for a status page post successfully."""
+        import json as _json
+        mock_client = Mock()
+        mock_client.rput.return_value = {"id": "PM123", "message": "Post-incident review"}
+        mock_get_client.return_value = mock_client
+
+        result = create_status_page_post_postmortem("SP123", "P123", "Post-incident review")
+
+        self.assertIsInstance(result, str)
+        data = _json.loads(result)
+        self.assertEqual(data["message"], "Post-incident review")
+
+    @patch("pagerduty_mcp.tools.status_pages.get_client")
+    def test_create_status_page_post_postmortem_default_notify(self, mock_get_client):
+        """Test that create_status_page_post_postmortem defaults notify_subscribers to True."""
+        import json as _json
+        mock_client = Mock()
+        mock_client.rput.return_value = {}
+        mock_get_client.return_value = mock_client
+
+        create_status_page_post_postmortem("SP123", "P123", "Review message")
+
+        call_args = mock_client.rput.call_args
+        payload = call_args[1]["json"]
+        self.assertTrue(payload["postmortem"]["notify_subscribers"])
+
+    @patch("pagerduty_mcp.tools.status_pages.get_client")
+    def test_create_status_page_post_postmortem_no_notify(self, mock_get_client):
+        """Test create_status_page_post_postmortem with notify_subscribers=False."""
+        mock_client = Mock()
+        mock_client.rput.return_value = {}
+        mock_get_client.return_value = mock_client
+
+        create_status_page_post_postmortem("SP123", "P123", "Review message", notify_subscribers=False)
+
+        call_args = mock_client.rput.call_args
+        payload = call_args[1]["json"]
+        self.assertFalse(payload["postmortem"]["notify_subscribers"])
+
+    @patch("pagerduty_mcp.tools.status_pages.get_client")
+    def test_create_status_page_post_postmortem_calls_api_correctly(self, mock_get_client):
+        """Test that create_status_page_post_postmortem calls rput with correct URL and payload."""
+        mock_client = Mock()
+        mock_client.rput.return_value = {}
+        mock_get_client.return_value = mock_client
+
+        create_status_page_post_postmortem("SP123", "P123", "Post-incident review")
+
+        expected_payload = {
+            "postmortem": {
+                "message": "Post-incident review",
+                "notify_subscribers": True,
+                "post": {
+                    "id": "P123",
+                    "self": "https://api.pagerduty.com/status_pages/SP123/posts/P123",
+                    "type": "status_page_post",
+                },
+                "type": "status_page_post_postmortem",
+            }
+        }
+        mock_client.rput.assert_called_once_with(
+            "/status_pages/SP123/posts/P123/postmortem",
+            json=expected_payload,
+        )
+
+    @patch("pagerduty_mcp.tools.status_pages.get_client")
+    def test_create_status_page_post_postmortem_client_error(self, mock_get_client):
+        """Test create_status_page_post_postmortem propagates client exceptions."""
+        mock_client = Mock()
+        mock_client.rput.side_effect = Exception("Postmortem Error")
+        mock_get_client.return_value = mock_client
+
+        with self.assertRaises(Exception) as ctx:
+            create_status_page_post_postmortem("SP123", "P123", "Review message")
+
+        self.assertEqual(str(ctx.exception), "Postmortem Error")
+
 
     @patch("pagerduty_mcp.tools.status_pages.get_client")
     @patch("pagerduty_mcp.tools.status_pages.paginate")

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -3,8 +3,8 @@ from unittest.mock import MagicMock, patch
 
 from pagerduty_mcp.models.base import DEFAULT_PAGINATION_LIMIT, MAXIMUM_PAGINATION_LIMIT
 from pagerduty_mcp.models.references import TeamReference
-from pagerduty_mcp.models.users import User, UserQuery
-from pagerduty_mcp.tools.users import get_user_data, list_users
+from pagerduty_mcp.models.users import CreateUserRequest, User, UserQuery
+from pagerduty_mcp.tools.users import create_user, get_user_data, list_users
 
 
 class TestUserTools(unittest.TestCase):
@@ -300,6 +300,57 @@ class TestUserTools(unittest.TestCase):
 
         # Verify result
         self.assertEqual(len(result.response), 2)
+
+    @patch("pagerduty_mcp.tools.users.get_client")
+    def test_create_user_success_wrapped_response(self, mock_get_client):
+        """Test create_user when API wraps the user in a 'user' key."""
+        mock_get_client.return_value = self.mock_client
+        self.mock_client.rpost.return_value = {"user": self.sample_user_response}
+
+        request = CreateUserRequest(name="John Doe", email="john.doe@example.com")
+        result = create_user(request)
+
+        self.assertIsInstance(result, User)
+        self.assertEqual(result.name, "John Doe")
+        self.assertEqual(result.email, "john.doe@example.com")
+
+    @patch("pagerduty_mcp.tools.users.get_client")
+    def test_create_user_success_unwrapped_response(self, mock_get_client):
+        """Test create_user when API returns the user object directly."""
+        mock_get_client.return_value = self.mock_client
+        self.mock_client.rpost.return_value = self.sample_user_response
+
+        request = CreateUserRequest(name="John Doe", email="john.doe@example.com")
+        result = create_user(request)
+
+        self.assertIsInstance(result, User)
+        self.assertEqual(result.id, "USER123")
+
+    @patch("pagerduty_mcp.tools.users.get_client")
+    def test_create_user_calls_api_correctly(self, mock_get_client):
+        """Test that create_user calls rpost with the correct arguments."""
+        mock_get_client.return_value = self.mock_client
+        self.mock_client.rpost.return_value = self.sample_user_response
+
+        request = CreateUserRequest(name="John Doe", email="john.doe@example.com")
+        create_user(request)
+
+        self.mock_client.rpost.assert_called_once_with(
+            "/users",
+            json=request.model_dump(),
+        )
+
+    @patch("pagerduty_mcp.tools.users.get_client")
+    def test_create_user_client_error(self, mock_get_client):
+        """Test create_user propagates client exceptions."""
+        mock_get_client.return_value = self.mock_client
+        self.mock_client.rpost.side_effect = Exception("Create Error")
+
+        with self.assertRaises(Exception) as ctx:
+            create_user(CreateUserRequest(name="John Doe", email="john.doe@example.com"))
+
+        self.assertEqual(str(ctx.exception), "Create Error")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/website/docs/tools/escalation-policies.md
+++ b/website/docs/tools/escalation-policies.md
@@ -35,3 +35,58 @@ Get a specific escalation policy by ID.
 **Example prompt:**
 
 > "Get the details of escalation policy PXXXXXX"
+
+---
+
+### `create_escalation_policy` *(write)*
+
+Create a new escalation policy.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `escalation_policy` | `EscalationPolicyCreate` | Yes | Policy data including `name`, `escalation_rules` (ordered list of targets and delays), optional `description`, `num_loops`, `on_call_handoff_notifications`, and `teams` |
+
+:::note
+Requires `--enable-write-tools` flag.
+:::
+
+**Example prompt:**
+
+> "Create an escalation policy called 'Platform On-Call' with a 5-minute delay to user PXXXXXX, then escalate to schedule PXXXXXX"
+
+---
+
+### `update_escalation_policy` *(write)*
+
+Update an existing escalation policy.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `policy_id` | `string` | Yes | The ID of the escalation policy to update |
+| `escalation_policy` | `EscalationPolicyCreate` | Yes | The updated policy data |
+
+:::note
+Requires `--enable-write-tools` flag.
+:::
+
+**Example prompt:**
+
+> "Update escalation policy PXXXXXX to add a second escalation step to the platform team schedule"
+
+---
+
+### `delete_escalation_policy` *(write)*
+
+Delete an escalation policy. The policy must not be in use by any services.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `policy_id` | `string` | Yes | The ID of the escalation policy to delete |
+
+:::note
+Requires `--enable-write-tools` flag.
+:::
+
+**Example prompt:**
+
+> "Delete escalation policy PXXXXXX"

--- a/website/docs/tools/users.md
+++ b/website/docs/tools/users.md
@@ -4,7 +4,7 @@ sidebar_position: 9
 
 # Users
 
-User tools let you retrieve information about the currently authenticated user and list all users in the account.
+User tools let you retrieve information about the currently authenticated user, list users in the account, and create new users.
 
 ## Tools
 
@@ -33,3 +33,23 @@ List users, optionally filtering by name and team IDs.
 **Example prompt:**
 
 > "List all users on the platform team"
+
+---
+
+### `create_user` *(write)*
+
+Create a new PagerDuty user account. No invitation email is sent automatically.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `request` | `CreateUserRequest` | Yes | User creation parameters including `name`, `email`, `role` (default: `"user"`), and `time_zone` (default: `"UTC"`) |
+
+**Valid roles:** `admin`, `limited_user`, `observer`, `owner`, `read_only_user`, `restricted_access`, `read_only_limited_user`, `user`
+
+:::note
+Requires `--enable-write-tools` flag.
+:::
+
+**Example prompt:**
+
+> "Create a new user account for Jane Smith with email jane.smith@example.com in the America/New_York timezone"


### PR DESCRIPTION
## Summary

Adds 7 write/delete tools, all gated behind \`--enable-write-tools\`:

| Domain | New tools |
|--------|-----------|
| Escalation Policies | \`create_escalation_policy\`, \`update_escalation_policy\`, \`delete_escalation_policy\` |
| Incidents | \`create_incident_status_update\` |
| Schedules | \`delete_schedule_override\` |
| Status Pages | \`create_status_page_post_postmortem\` |
| Users | \`create_user\` |

Re-enables escalation policy write tools that were previously commented out. Also flattens the `list_alerts_from_incident` signature to use `limit`/`offset` params directly (part of the flatten-tool-signatures refactor).

## ⚠️ Write tool risk
These tools modify production state. Only registered when server starts with `--enable-write-tools`.

## Stacked on PR #137
This PR is based on `feat/new-read-tools`. After that PR merges to `main`, this branch will be rebased onto `main` and the target updated.

## Test plan
- [ ] All tests pass (`394 passed`)
- [ ] Write tool gating verified — all 7 tools in `write_tools`, none in `read_tools`
- [ ] Verify each write tool against a sandbox account