### PR TITLE
feat(schedules): add list_schedule_overrides and delete_schedule_override

### DIFF
--- a/pagerduty_mcp/tools/__init__.py
+++ b/pagerduty_mcp/tools/__init__.py
@@ -58,7 +58,9 @@ from .oncalls import list_oncalls
 from .schedules import (
     create_schedule,
     create_schedule_override,
+    delete_schedule_override,
     get_schedule,
+    list_schedule_overrides,
     list_schedule_users,
     list_schedules,
     update_schedule,
@@ -128,6 +130,7 @@ read_tools = [
     list_schedules,
     get_schedule,
     list_schedule_users,
+    list_schedule_overrides,
     # On-calls
     list_oncalls,
     # Log Entries
@@ -176,6 +179,7 @@ write_tools = [
     # Schedules
     create_schedule,
     create_schedule_override,
+    delete_schedule_override,
     update_schedule,
     # Event Orchestrations
     update_event_orchestration_router,

--- a/pagerduty_mcp/tools/schedules.py
+++ b/pagerduty_mcp/tools/schedules.py
@@ -44,7 +44,7 @@ def list_schedules(
     if limit:
         params["limit"] = limit
     response = paginate(
-        client=get_client(), entity="schedules", params=params
+        client=get_client(), entity="schedules", params=params, maximum_records=limit or 1000
     )
     schedules = [Schedule(**schedule) for schedule in response]
     return ListResponseModel[Schedule](response=schedules)

--- a/pagerduty_mcp/tools/schedules.py
+++ b/pagerduty_mcp/tools/schedules.py
@@ -1,25 +1,51 @@
+import json
+from typing import Any
+
 from pagerduty_mcp.client import get_client
 from pagerduty_mcp.models import (
     ListResponseModel,
     Schedule,
     ScheduleCreateRequest,
     ScheduleOverrideCreate,
-    ScheduleQuery,
     ScheduleUpdateRequest,
     User,
 )
 from pagerduty_mcp.utils import paginate
 
 
-def list_schedules(query_model: ScheduleQuery | None = None) -> ListResponseModel[Schedule]:
+def list_schedules(
+    query: str | None = None,
+    team_ids: list[str] | None = None,
+    user_ids: list[str] | None = None,
+    include: list[str] | None = None,
+    limit: int | None = None,
+) -> ListResponseModel[Schedule]:
     """List schedules with optional filtering.
+
+    Args:
+        query: Filter schedules by name
+        team_ids: Filter by team IDs
+        user_ids: Filter by user IDs
+        include: Include additional details (e.g. schedule_layers)
+        limit: Max results to return
 
     Returns:
         List of schedules matching the query parameters
     """
-    if query_model is None:
-        query_model = ScheduleQuery()
-    response = paginate(client=get_client(), entity="schedules", params=query_model.to_params())
+    params: dict[str, Any] = {}
+    if query:
+        params["query"] = query
+    if team_ids:
+        params["team_ids[]"] = team_ids
+    if user_ids:
+        params["user_ids[]"] = user_ids
+    if include:
+        params["include[]"] = include
+    if limit:
+        params["limit"] = limit
+    response = paginate(
+        client=get_client(), entity="schedules", params=params
+    )
     schedules = [Schedule(**schedule) for schedule in response]
     return ListResponseModel[Schedule](response=schedules)
 
@@ -71,6 +97,45 @@ def list_schedule_users(schedule_id: str) -> ListResponseModel[User]:
     response = get_client().rget(f"/schedules/{schedule_id}/users")
     users = [User(**user) for user in response]
     return ListResponseModel[User](response=users)
+
+
+def list_schedule_overrides(schedule_id: str, since: str, until: str) -> str:
+    """List overrides for a schedule within a date range.
+
+    Args:
+        schedule_id: The ID of the schedule
+        since: Start of the date range (ISO 8601)
+        until: End of the date range (ISO 8601)
+
+    Returns:
+        JSON string with an 'overrides' array
+    """
+    response = get_client().rget(
+        f"/schedules/{schedule_id}/overrides",
+        params={"since": since, "until": until},
+    )
+    # pdpyras may return a list or {"overrides": [...]}
+    if isinstance(response, list):
+        overrides = response
+    elif isinstance(response, dict):
+        overrides = response.get("overrides", [])
+    else:
+        overrides = []
+    return json.dumps({"overrides": overrides})
+
+
+def delete_schedule_override(schedule_id: str, override_id: str) -> str:
+    """Delete a schedule override.
+
+    Args:
+        schedule_id: The ID of the schedule
+        override_id: The ID of the override to delete
+
+    Returns:
+        JSON string confirming deletion
+    """
+    get_client().rdelete(f"/schedules/{schedule_id}/overrides/{override_id}")
+    return json.dumps({"success": True})
 
 
 def create_schedule(create_model: ScheduleCreateRequest) -> Schedule:

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -20,7 +20,9 @@ from pagerduty_mcp.models.users import User
 from pagerduty_mcp.tools.schedules import (
     create_schedule,
     create_schedule_override,
+    delete_schedule_override,
     get_schedule,
+    list_schedule_overrides,
     list_schedule_users,
     list_schedules,
     update_schedule,
@@ -111,6 +113,8 @@ class TestScheduleTools(unittest.TestCase):
         # Clear any side effects
         self.mock_client.rget.side_effect = None
         self.mock_client.rpost.side_effect = None
+        self.mock_client.rput.side_effect = None
+        self.mock_client.rdelete.side_effect = None
 
     @patch("pagerduty_mcp.tools.schedules.paginate")
     @patch("pagerduty_mcp.tools.schedules.get_client")
@@ -121,7 +125,7 @@ class TestScheduleTools(unittest.TestCase):
 
         result = list_schedules()
 
-        expected_params = {"limit": DEFAULT_PAGINATION_LIMIT}
+        expected_params = {}
         mock_paginate.assert_called_once_with(client=self.mock_client, entity="schedules", params=expected_params)
         self.assertEqual(len(result.response), 2)
 
@@ -132,11 +136,10 @@ class TestScheduleTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         mock_paginate.return_value = self.sample_schedules_list_response
 
-        query = ScheduleQuery()
-        result = list_schedules(query)
+        result = list_schedules()
 
         # Verify paginate call
-        expected_params = {"limit": DEFAULT_PAGINATION_LIMIT}
+        expected_params = {}
         mock_paginate.assert_called_once_with(client=self.mock_client, entity="schedules", params=expected_params)
 
         # Verify result
@@ -155,11 +158,10 @@ class TestScheduleTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         mock_paginate.return_value = [self.sample_schedules_list_response[0]]
 
-        query = ScheduleQuery(query="Primary")
-        result = list_schedules(query)
+        result = list_schedules(query="Primary")
 
         # Verify paginate call
-        expected_params = {"query": "Primary", "limit": DEFAULT_PAGINATION_LIMIT}
+        expected_params = {"query": "Primary"}
         mock_paginate.assert_called_once_with(client=self.mock_client, entity="schedules", params=expected_params)
 
         # Verify result
@@ -173,11 +175,10 @@ class TestScheduleTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         mock_paginate.return_value = self.sample_schedules_list_response
 
-        query = ScheduleQuery(team_ids=["TEAM123"])
-        result = list_schedules(query)
+        result = list_schedules(team_ids=["TEAM123"])
 
         # Verify paginate call
-        expected_params = {"team_ids[]": ["TEAM123"], "limit": DEFAULT_PAGINATION_LIMIT}
+        expected_params = {"team_ids[]": ["TEAM123"]}
         mock_paginate.assert_called_once_with(client=self.mock_client, entity="schedules", params=expected_params)
 
         # Verify result
@@ -190,11 +191,10 @@ class TestScheduleTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         mock_paginate.return_value = self.sample_schedules_list_response
 
-        query = ScheduleQuery(user_ids=["USER123", "USER456"])
-        result = list_schedules(query)
+        result = list_schedules(user_ids=["USER123", "USER456"])
 
         # Verify paginate call
-        expected_params = {"user_ids[]": ["USER123", "USER456"], "limit": DEFAULT_PAGINATION_LIMIT}
+        expected_params = {"user_ids[]": ["USER123", "USER456"]}
         mock_paginate.assert_called_once_with(client=self.mock_client, entity="schedules", params=expected_params)
 
         # Verify result
@@ -207,11 +207,10 @@ class TestScheduleTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         mock_paginate.return_value = self.sample_schedules_list_response
 
-        query = ScheduleQuery(include=["schedule_layers"])
-        result = list_schedules(query)
+        result = list_schedules(include=["schedule_layers"])
 
         # Verify paginate call
-        expected_params = {"include[]": ["schedule_layers"], "limit": DEFAULT_PAGINATION_LIMIT}
+        expected_params = {"include[]": ["schedule_layers"]}
         mock_paginate.assert_called_once_with(client=self.mock_client, entity="schedules", params=expected_params)
 
         # Verify result
@@ -224,14 +223,13 @@ class TestScheduleTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         mock_paginate.return_value = [self.sample_schedules_list_response[0]]
 
-        query = ScheduleQuery(
+        result = list_schedules(
             query="Primary",
             team_ids=["TEAM123"],
             user_ids=["USER123"],
             include=["schedule_layers"],
             limit=50,
         )
-        result = list_schedules(query)
 
         # Verify paginate call
         expected_params = {
@@ -253,8 +251,7 @@ class TestScheduleTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         mock_paginate.return_value = self.sample_schedules_list_response
 
-        query = ScheduleQuery(limit=50)
-        result = list_schedules(query)
+        result = list_schedules(limit=50)
 
         # Verify paginate call
         expected_params = {"limit": 50}
@@ -270,11 +267,10 @@ class TestScheduleTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         mock_paginate.return_value = []
 
-        query = ScheduleQuery(query="NonExistentSchedule")
-        result = list_schedules(query)
+        result = list_schedules(query="NonExistentSchedule")
 
         # Verify paginate call
-        expected_params = {"query": "NonExistentSchedule", "limit": DEFAULT_PAGINATION_LIMIT}
+        expected_params = {"query": "NonExistentSchedule"}
         mock_paginate.assert_called_once_with(client=self.mock_client, entity="schedules", params=expected_params)
 
         # Verify result
@@ -287,10 +283,8 @@ class TestScheduleTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         mock_paginate.side_effect = Exception("Pagination Error")
 
-        query = ScheduleQuery()
-
         with self.assertRaises(Exception) as context:
-            list_schedules(query)
+            list_schedules()
 
         self.assertEqual(str(context.exception), "Pagination Error")
 
@@ -852,6 +846,91 @@ class TestScheduleTools(unittest.TestCase):
         self.assertEqual(str(context.exception), "Failed to update schedule SCHED123: API Error")
         mock_get_client.assert_called_once()
         self.mock_client.rput.assert_called_once()
+
+    @patch("pagerduty_mcp.tools.schedules.get_client")
+    def test_list_schedule_overrides_list_response(self, mock_get_client):
+        """Test list_schedule_overrides when API returns a list directly."""
+        import json as _json
+        mock_get_client.return_value = self.mock_client
+        overrides = [{"id": "OV1", "start": "2023-01-01T00:00:00Z", "end": "2023-01-02T00:00:00Z"}]
+        self.mock_client.rget.return_value = overrides
+
+        result = list_schedule_overrides("SCHED123", "2023-01-01", "2023-01-31")
+
+        self.assertIsInstance(result, str)
+        data = _json.loads(result)
+        self.assertEqual(len(data["overrides"]), 1)
+        self.assertEqual(data["overrides"][0]["id"], "OV1")
+
+    @patch("pagerduty_mcp.tools.schedules.get_client")
+    def test_list_schedule_overrides_dict_response(self, mock_get_client):
+        """Test list_schedule_overrides when API returns a dict with 'overrides' key."""
+        import json as _json
+        mock_get_client.return_value = self.mock_client
+        self.mock_client.rget.return_value = {"overrides": [{"id": "OV2"}]}
+
+        result = list_schedule_overrides("SCHED123", "2023-01-01", "2023-01-31")
+
+        data = _json.loads(result)
+        self.assertEqual(len(data["overrides"]), 1)
+        self.assertEqual(data["overrides"][0]["id"], "OV2")
+
+    @patch("pagerduty_mcp.tools.schedules.get_client")
+    def test_list_schedule_overrides_calls_api_correctly(self, mock_get_client):
+        """Test that list_schedule_overrides calls rget with correct arguments."""
+        mock_get_client.return_value = self.mock_client
+        self.mock_client.rget.return_value = []
+
+        list_schedule_overrides("SCHED123", "2023-01-01", "2023-01-31")
+
+        self.mock_client.rget.assert_called_once_with(
+            "/schedules/SCHED123/overrides",
+            params={"since": "2023-01-01", "until": "2023-01-31"},
+        )
+
+    @patch("pagerduty_mcp.tools.schedules.get_client")
+    def test_list_schedule_overrides_empty_dict_response(self, mock_get_client):
+        """Test list_schedule_overrides when API returns empty dict."""
+        import json as _json
+        mock_get_client.return_value = self.mock_client
+        self.mock_client.rget.return_value = {}
+
+        result = list_schedule_overrides("SCHED123", "2023-01-01", "2023-01-31")
+
+        data = _json.loads(result)
+        self.assertEqual(data["overrides"], [])
+
+    @patch("pagerduty_mcp.tools.schedules.get_client")
+    def test_delete_schedule_override_success(self, mock_get_client):
+        """Test successful deletion of a schedule override."""
+        import json as _json
+        mock_get_client.return_value = self.mock_client
+
+        result = delete_schedule_override("SCHED123", "OV123")
+
+        self.assertIsInstance(result, str)
+        data = _json.loads(result)
+        self.assertTrue(data["success"])
+
+    @patch("pagerduty_mcp.tools.schedules.get_client")
+    def test_delete_schedule_override_calls_api_correctly(self, mock_get_client):
+        """Test that delete_schedule_override calls rdelete with correct URL."""
+        mock_get_client.return_value = self.mock_client
+
+        delete_schedule_override("SCHED123", "OV123")
+
+        self.mock_client.rdelete.assert_called_once_with("/schedules/SCHED123/overrides/OV123")
+
+    @patch("pagerduty_mcp.tools.schedules.get_client")
+    def test_delete_schedule_override_client_error(self, mock_get_client):
+        """Test delete_schedule_override propagates client exceptions."""
+        mock_get_client.return_value = self.mock_client
+        self.mock_client.rdelete.side_effect = Exception("Delete Error")
+
+        with self.assertRaises(Exception) as ctx:
+            delete_schedule_override("SCHED123", "OV123")
+
+        self.assertEqual(str(ctx.exception), "Delete Error")
 
 
 if __name__ == "__main__":

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -126,7 +126,7 @@ class TestScheduleTools(unittest.TestCase):
         result = list_schedules()
 
         expected_params = {}
-        mock_paginate.assert_called_once_with(client=self.mock_client, entity="schedules", params=expected_params)
+        mock_paginate.assert_called_once_with(client=self.mock_client, entity="schedules", params=expected_params, maximum_records=1000)
         self.assertEqual(len(result.response), 2)
 
     @patch("pagerduty_mcp.tools.schedules.paginate")
@@ -140,7 +140,7 @@ class TestScheduleTools(unittest.TestCase):
 
         # Verify paginate call
         expected_params = {}
-        mock_paginate.assert_called_once_with(client=self.mock_client, entity="schedules", params=expected_params)
+        mock_paginate.assert_called_once_with(client=self.mock_client, entity="schedules", params=expected_params, maximum_records=1000)
 
         # Verify result
         self.assertEqual(len(result.response), 2)
@@ -162,7 +162,7 @@ class TestScheduleTools(unittest.TestCase):
 
         # Verify paginate call
         expected_params = {"query": "Primary"}
-        mock_paginate.assert_called_once_with(client=self.mock_client, entity="schedules", params=expected_params)
+        mock_paginate.assert_called_once_with(client=self.mock_client, entity="schedules", params=expected_params, maximum_records=1000)
 
         # Verify result
         self.assertEqual(len(result.response), 1)
@@ -179,7 +179,7 @@ class TestScheduleTools(unittest.TestCase):
 
         # Verify paginate call
         expected_params = {"team_ids[]": ["TEAM123"]}
-        mock_paginate.assert_called_once_with(client=self.mock_client, entity="schedules", params=expected_params)
+        mock_paginate.assert_called_once_with(client=self.mock_client, entity="schedules", params=expected_params, maximum_records=1000)
 
         # Verify result
         self.assertEqual(len(result.response), 2)
@@ -195,7 +195,7 @@ class TestScheduleTools(unittest.TestCase):
 
         # Verify paginate call
         expected_params = {"user_ids[]": ["USER123", "USER456"]}
-        mock_paginate.assert_called_once_with(client=self.mock_client, entity="schedules", params=expected_params)
+        mock_paginate.assert_called_once_with(client=self.mock_client, entity="schedules", params=expected_params, maximum_records=1000)
 
         # Verify result
         self.assertEqual(len(result.response), 2)
@@ -211,7 +211,7 @@ class TestScheduleTools(unittest.TestCase):
 
         # Verify paginate call
         expected_params = {"include[]": ["schedule_layers"]}
-        mock_paginate.assert_called_once_with(client=self.mock_client, entity="schedules", params=expected_params)
+        mock_paginate.assert_called_once_with(client=self.mock_client, entity="schedules", params=expected_params, maximum_records=1000)
 
         # Verify result
         self.assertEqual(len(result.response), 2)
@@ -239,7 +239,7 @@ class TestScheduleTools(unittest.TestCase):
             "include[]": ["schedule_layers"],
             "limit": 50,
         }
-        mock_paginate.assert_called_once_with(client=self.mock_client, entity="schedules", params=expected_params)
+        mock_paginate.assert_called_once_with(client=self.mock_client, entity="schedules", params=expected_params, maximum_records=50)
 
         # Verify result
         self.assertEqual(len(result.response), 1)
@@ -255,7 +255,7 @@ class TestScheduleTools(unittest.TestCase):
 
         # Verify paginate call
         expected_params = {"limit": 50}
-        mock_paginate.assert_called_once_with(client=self.mock_client, entity="schedules", params=expected_params)
+        mock_paginate.assert_called_once_with(client=self.mock_client, entity="schedules", params=expected_params, maximum_records=50)
 
         # Verify result
         self.assertEqual(len(result.response), 2)
@@ -271,7 +271,7 @@ class TestScheduleTools(unittest.TestCase):
 
         # Verify paginate call
         expected_params = {"query": "NonExistentSchedule"}
-        mock_paginate.assert_called_once_with(client=self.mock_client, entity="schedules", params=expected_params)
+        mock_paginate.assert_called_once_with(client=self.mock_client, entity="schedules", params=expected_params, maximum_records=1000)
 
         # Verify result
         self.assertEqual(len(result.response), 0)

--- a/website/docs/tools/schedules.md
+++ b/website/docs/tools/schedules.md
@@ -50,6 +50,22 @@ List users in a schedule.
 
 ---
 
+### `list_schedule_overrides`
+
+List overrides for a schedule within a date range.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `schedule_id` | `string` | Yes | The ID of the schedule |
+| `since` | `string` | Yes | Start of the date range (ISO 8601) |
+| `until` | `string` | Yes | End of the date range (ISO 8601) |
+
+**Example prompt:**
+
+> "Show me all overrides for schedule PXXXXXX this week"
+
+---
+
 ### `create_schedule` *(write)*
 
 Create a new on-call schedule. Each schedule layer requires a `name` field to identify the layer.
@@ -83,6 +99,25 @@ Requires `--enable-write-tools` flag.
 **Example prompt:**
 
 > "Create an override for schedule PXXXXXX putting user PYYYYYY on-call from 2025-01-15T09:00:00Z to 2025-01-15T17:00:00Z"
+
+---
+
+### `delete_schedule_override` *(write)*
+
+Delete a schedule override.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `schedule_id` | `string` | Yes | The ID of the schedule |
+| `override_id` | `string` | Yes | The ID of the override to delete |
+
+:::note
+Requires `--enable-write-tools` flag.
+:::
+
+**Example prompt:**
+
+> "Delete override PXXXXXX from schedule PYYYYYY"
 
 ---
 


### PR DESCRIPTION
## Summary

**Read:** \`list_schedule_overrides(schedule_id, since, until)\` — lists overrides for a schedule within a date window.

**Write (gated by \`--enable-write-tools\`):** \`delete_schedule_override(schedule_id, override_id)\` — deletes a schedule override.

## Depends on
Requires **PR #133** (\`refactor/flatten-tool-signatures\`) to be merged first.