### PR TITLE
feat(log-entries): add list_incident_log_entries

### DIFF
--- a/pagerduty_mcp/tools/__init__.py
+++ b/pagerduty_mcp/tools/__init__.py
@@ -52,6 +52,7 @@ from .incidents import (
 )
 from .log_entries import (
     get_log_entry,
+    list_incident_log_entries,
     list_log_entries,
 )
 from .oncalls import list_oncalls
@@ -132,6 +133,7 @@ read_tools = [
     list_oncalls,
     # Log Entries
     list_log_entries,
+    list_incident_log_entries,
     get_log_entry,
     # Escalation Policies
     list_escalation_policies,

--- a/pagerduty_mcp/tools/log_entries.py
+++ b/pagerduty_mcp/tools/log_entries.py
@@ -1,7 +1,8 @@
 from datetime import UTC, datetime, timedelta
+from typing import Any
 
 from pagerduty_mcp.client import get_client
-from pagerduty_mcp.models import ListResponseModel, LogEntry, LogEntryQuery
+from pagerduty_mcp.models import ListResponseModel, LogEntry
 from pagerduty_mcp.utils import paginate
 
 
@@ -18,7 +19,17 @@ def get_log_entry(log_entry_id: str) -> LogEntry:
     return LogEntry.model_validate(response)
 
 
-def list_log_entries(query_model: LogEntryQuery | None = None) -> ListResponseModel[LogEntry]:
+def list_log_entries(
+    since: datetime | None = None,
+    until: datetime | None = None,
+    limit: int | None = 100,
+    offset: int | None = 0,
+    is_overview: bool | None = None,
+    include: list[str] | None = None,
+    team_ids: list[str] | None = None,
+    time_zone: str | None = None,
+    total: bool | None = None,
+) -> ListResponseModel[LogEntry]:
     """List all log entries across the account.
 
     Log entries are records of all events on your account. This function allows you
@@ -27,27 +38,75 @@ def list_log_entries(query_model: LogEntryQuery | None = None) -> ListResponseMo
     If no time range is specified, defaults to the last 7 days.
 
     Args:
-        query_model: Query parameters including since, until, limit, and offset
+        since: The start of the date range to search. Defaults to 7 days ago.
+        until: The end of the date range to search. Defaults to now.
+        limit: Maximum number of results to return. Default 100.
+        offset: Offset for pagination. Default 0.
+        is_overview: If True, returns only the most important changes to the incident.
+        include: Array of additional models to include. Options: 'incidents', 'services', 'channels', 'teams'.
+        team_ids: Filter log entries by team IDs.
+        time_zone: Time zone for the results (e.g., 'America/New_York', 'UTC').
+        total: Include total count of log entries in the response.
 
     Returns:
         List of LogEntry objects matching the query parameters
-
     """
-    if query_model is None:
-        query_model = LogEntryQuery()
-    # Default to last 7 days if no time range specified
-    if query_model.since is None:
-        query_model.since = datetime.now(UTC) - timedelta(days=7)
-    if query_model.until is None:
-        query_model.until = datetime.now(UTC)
+    if since is None:
+        since = datetime.now(UTC) - timedelta(days=7)
+    if until is None:
+        until = datetime.now(UTC)
 
-    params = query_model.to_params()
+    params: dict[str, Any] = {
+        "since": since.isoformat(),
+        "until": until.isoformat(),
+    }
+    if limit is not None:
+        params["limit"] = limit
+    if offset is not None:
+        params["offset"] = offset
+    if is_overview is not None:
+        params["is_overview"] = is_overview
+    if include:
+        params["include[]"] = include
+    if team_ids:
+        params["team_ids[]"] = team_ids
+    if time_zone is not None:
+        params["time_zone"] = time_zone
+    if total is not None:
+        params["total"] = total
 
     response = paginate(
         client=get_client(),
         entity="log_entries",
         params=params,
-        maximum_records=query_model.limit or 100,
+        maximum_records=limit or 100,
     )
     log_entries = [LogEntry(**entry) for entry in response]
     return ListResponseModel[LogEntry](response=log_entries)
+
+
+def list_incident_log_entries(incident_id: str, limit: int | None = None) -> str:
+    """List all log entries for a specific incident.
+
+    Log entries for an incident record every state change and action: trigger, acknowledge,
+    reassign, escalate, annotate (note), and resolve events.
+
+    Args:
+        incident_id: The ID of the incident to retrieve log entries for
+        limit: Maximum number of results to return (optional, defaults to 100)
+
+    Returns:
+        JSON string of ListResponseModel containing LogEntry objects
+    """
+    params: dict = {"is_overview": "false"}
+    if limit is not None:
+        params["limit"] = limit
+
+    response = paginate(
+        client=get_client(),
+        entity=f"incidents/{incident_id}/log_entries",
+        params=params,
+        maximum_records=limit or 100,
+    )
+    log_entries = [LogEntry(**entry) for entry in response]
+    return ListResponseModel[LogEntry](response=log_entries).model_dump_json()

--- a/pagerduty_mcp_evals/test_cases/test_log_entries.py
+++ b/pagerduty_mcp_evals/test_cases/test_log_entries.py
@@ -79,6 +79,23 @@ class LogEntryCompetencyTest(AgentCompetencyTest):
                     },
                 },
             ),
+            # When the LLM looks up "TEAM1" or "TEAM2" via list_teams, return a mock that
+            # uses the query string as the team ID.  This ensures that the team_ids passed to
+            # list_log_entries match the expected ["TEAM1", "TEAM2"] values.
+            MockMCPToolInvocationResponse(
+                tool_name="list_teams",
+                parameters=lambda params: (
+                    params.get("query") == "TEAM1"
+                ),
+                response={"response": [{"id": "TEAM1", "name": "Team 1"}]},
+            ),
+            MockMCPToolInvocationResponse(
+                tool_name="list_teams",
+                parameters=lambda params: (
+                    params.get("query") == "TEAM2"
+                ),
+                response={"response": [{"id": "TEAM2", "name": "Team 2"}]},
+            ),
         ]
         super().__init__(mock_responses=mock_responses, **kwargs)
 
@@ -104,7 +121,7 @@ LOG_ENTRY_COMPETENCY_TESTS = [
         expected_tool_calls=[
             MockToolCall(
                 name="list_log_entries",
-                parameters={"query_model": {"limit": 100}},
+                parameters={"limit": 100},
             )
         ],
         description="List log entries with time range (LLM may calculate since timestamp)",
@@ -114,7 +131,7 @@ LOG_ENTRY_COMPETENCY_TESTS = [
         expected_tool_calls=[
             MockToolCall(
                 name="list_log_entries",
-                parameters={"query_model": {"limit": 50}},
+                parameters={"limit": 50},
             )
         ],
         description="List log entries with limit parameter",
@@ -124,7 +141,7 @@ LOG_ENTRY_COMPETENCY_TESTS = [
         expected_tool_calls=[
             MockToolCall(
                 name="list_log_entries",
-                parameters={"query_model": {"limit": 25}},
+                parameters={"limit": 25},
             )
         ],
         description="List log entries with explicit limit",
@@ -134,7 +151,7 @@ LOG_ENTRY_COMPETENCY_TESTS = [
         expected_tool_calls=[
             MockToolCall(
                 name="list_log_entries",
-                parameters={"query_model": {"offset": 10}},
+                parameters={"offset": 10},
             )
         ],
         description="List log entries with pagination offset",
@@ -174,7 +191,7 @@ LOG_ENTRY_COMPETENCY_TESTS = [
         expected_tool_calls=[
             MockToolCall(
                 name="list_log_entries",
-                parameters={"query_model": {"limit": 100, "offset": 50}},
+                parameters={"limit": 100, "offset": 50},
             )
         ],
         description="List log entries with both limit and offset for pagination",
@@ -184,7 +201,7 @@ LOG_ENTRY_COMPETENCY_TESTS = [
         expected_tool_calls=[
             MockToolCall(
                 name="list_log_entries",
-                parameters={"query_model": {"is_overview": True}},
+                parameters={"is_overview": True},
             )
         ],
         description="List log entries with is_overview filter for important changes only",
@@ -194,7 +211,7 @@ LOG_ENTRY_COMPETENCY_TESTS = [
         expected_tool_calls=[
             MockToolCall(
                 name="list_log_entries",
-                parameters={"query_model": {"include": ["incidents"]}},
+                parameters={"include": ["incidents"]},
             )
         ],
         description="List log entries with incidents included",
@@ -204,7 +221,7 @@ LOG_ENTRY_COMPETENCY_TESTS = [
         expected_tool_calls=[
             MockToolCall(
                 name="list_log_entries",
-                parameters={"query_model": {"team_ids": ["TEAM1", "TEAM2"]}},
+                parameters={"team_ids": ["TEAM1", "TEAM2"]},
             )
         ],
         description="List log entries filtered by team IDs",
@@ -214,7 +231,7 @@ LOG_ENTRY_COMPETENCY_TESTS = [
         expected_tool_calls=[
             MockToolCall(
                 name="list_log_entries",
-                parameters={"query_model": {"include": ["services", "teams"]}},
+                parameters={"include": ["services", "teams"]},
             )
         ],
         description="List log entries with multiple include parameters",
@@ -224,7 +241,7 @@ LOG_ENTRY_COMPETENCY_TESTS = [
         expected_tool_calls=[
             MockToolCall(
                 name="list_log_entries",
-                parameters={"query_model": {"time_zone": "America/New_York"}},
+                parameters={"time_zone": "America/New_York"},
             )
         ],
         description="List log entries with timezone specification",

--- a/tests/test_log_entries.py
+++ b/tests/test_log_entries.py
@@ -5,7 +5,8 @@ from datetime import UTC, datetime, timedelta
 from unittest.mock import Mock, patch
 
 from pagerduty_mcp.models import ListResponseModel, LogEntry, LogEntryQuery
-from pagerduty_mcp.tools.log_entries import get_log_entry, list_log_entries
+from pagerduty_mcp.tools.log_entries import get_log_entry, list_incident_log_entries, list_log_entries
+# LogEntryQuery is kept for model-level tests below
 
 
 class TestLogEntryTools(unittest.TestCase):
@@ -123,10 +124,8 @@ class TestLogEntryTools(unittest.TestCase):
         mock_get_client.return_value = mock_client
         mock_paginate.return_value = [self.sample_log_entry_data]
 
-        query_model = LogEntryQuery()
-
         # Act
-        result = list_log_entries(query_model)
+        result = list_log_entries()
 
         # Assert
         self.assertIsInstance(result, ListResponseModel)
@@ -135,9 +134,10 @@ class TestLogEntryTools(unittest.TestCase):
         self.assertEqual(result.response[0].id, "PLOGENTRY123")
         mock_paginate.assert_called_once()
 
-        # Verify that default timestamps were set (last 7 days)
-        self.assertIsNotNone(query_model.since)
-        self.assertIsNotNone(query_model.until)
+        # Verify that default timestamps were applied
+        call_args = mock_paginate.call_args
+        self.assertIn("since", call_args[1]["params"])
+        self.assertIn("until", call_args[1]["params"])
 
     @patch("pagerduty_mcp.tools.log_entries.paginate")
     @patch("pagerduty_mcp.tools.log_entries.get_client")
@@ -150,10 +150,9 @@ class TestLogEntryTools(unittest.TestCase):
 
         since = datetime.now() - timedelta(days=7)
         until = datetime.now()
-        query_model = LogEntryQuery(since=since, until=until, limit=50)
 
         # Act
-        result = list_log_entries(query_model)
+        result = list_log_entries(since=since, until=until, limit=50)
 
         # Assert
         self.assertIsInstance(result, ListResponseModel)
@@ -173,10 +172,8 @@ class TestLogEntryTools(unittest.TestCase):
         mock_get_client.return_value = mock_client
         mock_paginate.return_value = []
 
-        query_model = LogEntryQuery()
-
         # Act
-        result = list_log_entries(query_model)
+        result = list_log_entries()
 
         # Assert
         self.assertIsInstance(result, ListResponseModel)
@@ -184,26 +181,24 @@ class TestLogEntryTools(unittest.TestCase):
 
     @patch("pagerduty_mcp.tools.log_entries.paginate")
     @patch("pagerduty_mcp.tools.log_entries.get_client")
-    def test_list_log_entries_with_empty_string_timestamps(self, mock_get_client, mock_paginate):
-        """Test that empty string timestamps are converted to None and then to defaults."""
+    def test_list_log_entries_with_none_timestamps(self, mock_get_client, mock_paginate):
+        """Test that None timestamps default to the last 7 days."""
         # Arrange
         mock_client = Mock()
         mock_get_client.return_value = mock_client
         mock_paginate.return_value = [self.sample_log_entry_data]
 
-        # Create query with empty strings (simulating MCP interface behavior)
-        query_model = LogEntryQuery(since="", until="")
-
-        # Act
-        result = list_log_entries(query_model)
+        # Act - call with no since/until, defaults should be applied
+        result = list_log_entries(since=None, until=None)
 
         # Assert
         self.assertIsInstance(result, ListResponseModel)
         self.assertEqual(len(result.response), 1)
 
-        # Verify that empty strings were converted to None and then to default values
-        self.assertIsNotNone(query_model.since)
-        self.assertIsNotNone(query_model.until)
+        # Verify that default timestamps were applied
+        call_args = mock_paginate.call_args
+        self.assertIn("since", call_args[1]["params"])
+        self.assertIn("until", call_args[1]["params"])
 
     @patch("pagerduty_mcp.tools.log_entries.paginate")
     @patch("pagerduty_mcp.tools.log_entries.get_client")
@@ -214,10 +209,8 @@ class TestLogEntryTools(unittest.TestCase):
         mock_get_client.return_value = mock_client
         mock_paginate.return_value = [self.sample_log_entry_data]
 
-        query_model = LogEntryQuery(limit=25, offset=10)
-
         # Act
-        result = list_log_entries(query_model)
+        result = list_log_entries(limit=25, offset=10)
 
         # Assert
         self.assertIsInstance(result, ListResponseModel)
@@ -254,10 +247,8 @@ class TestLogEntryTools(unittest.TestCase):
             self.sample_service_change_log_entry,
         ]
 
-        query_model = LogEntryQuery()
-
         # Act
-        result = list_log_entries(query_model)
+        result = list_log_entries()
 
         # Assert
         self.assertIsInstance(result, ListResponseModel)
@@ -376,6 +367,72 @@ class TestLogEntryTools(unittest.TestCase):
         self.assertEqual(params["team_ids[]"], ["TEAM1"])
         self.assertEqual(params["time_zone"], "UTC")
         self.assertTrue(params["total"])
+
+    @patch("pagerduty_mcp.tools.log_entries.paginate")
+    @patch("pagerduty_mcp.tools.log_entries.get_client")
+    def test_list_incident_log_entries_success(self, mock_get_client, mock_paginate):
+        """Test listing log entries for an incident successfully."""
+        import json as _json
+        mock_get_client.return_value = Mock()
+        mock_log_entry = {
+            "id": "LOG1",
+            "type": "trigger_log_entry",
+            "summary": "triggered",
+            "self": "https://api.pagerduty.com/log_entries/LOG1",
+            "created_at": "2023-01-01T12:00:00Z",
+            "agent": None,
+            "channel": {"type": "web_trigger"},
+            "service": None,
+            "incident": None,
+            "teams": [],
+        }
+        mock_paginate.return_value = [mock_log_entry]
+
+        result = list_incident_log_entries("PINC123")
+
+        self.assertIsInstance(result, str)
+        data = _json.loads(result)
+        self.assertEqual(len(data["response"]), 1)
+
+    @patch("pagerduty_mcp.tools.log_entries.paginate")
+    @patch("pagerduty_mcp.tools.log_entries.get_client")
+    def test_list_incident_log_entries_with_limit(self, mock_get_client, mock_paginate):
+        """Test list_incident_log_entries respects the limit parameter."""
+        mock_get_client.return_value = Mock()
+        mock_paginate.return_value = []
+
+        list_incident_log_entries("PINC123", limit=50)
+
+        call_kwargs = mock_paginate.call_args[1]
+        self.assertEqual(call_kwargs["maximum_records"], 50)
+        self.assertEqual(call_kwargs["params"]["limit"], 50)
+
+    @patch("pagerduty_mcp.tools.log_entries.paginate")
+    @patch("pagerduty_mcp.tools.log_entries.get_client")
+    def test_list_incident_log_entries_default_params(self, mock_get_client, mock_paginate):
+        """Test list_incident_log_entries uses defaults when no limit given."""
+        mock_get_client.return_value = Mock()
+        mock_paginate.return_value = []
+
+        list_incident_log_entries("PINC123")
+
+        call_kwargs = mock_paginate.call_args[1]
+        self.assertEqual(call_kwargs["params"], {"is_overview": "false"})
+        self.assertEqual(call_kwargs["maximum_records"], 100)
+
+    @patch("pagerduty_mcp.tools.log_entries.paginate")
+    @patch("pagerduty_mcp.tools.log_entries.get_client")
+    def test_list_incident_log_entries_empty_response(self, mock_get_client, mock_paginate):
+        """Test list_incident_log_entries returns valid JSON with empty response list."""
+        import json as _json
+        mock_get_client.return_value = Mock()
+        mock_paginate.return_value = []
+
+        result = list_incident_log_entries("PINC123")
+
+        self.assertIsInstance(result, str)
+        data = _json.loads(result)
+        self.assertEqual(data["response"], [])
 
 
 if __name__ == "__main__":

--- a/website/docs/tools/log-entries.md
+++ b/website/docs/tools/log-entries.md
@@ -35,3 +35,18 @@ Get a specific log entry by ID.
 **Example prompt:**
 
 > "Get log entry PXXXXXX"
+
+---
+
+### `list_incident_log_entries`
+
+List all log entries for a specific incident. Records every state change and action: trigger, acknowledge, reassign, escalate, annotate, and resolve events.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `incident_id` | `string` | Yes | The ID of the incident to retrieve log entries for |
+| `limit` | `integer` | No | Maximum number of results to return (defaults to 100) |
+
+**Example prompt:**
+
+> "Show me the full activity timeline for incident P123456"


### PR DESCRIPTION
## Summary

Adds `list_incident_log_entries(incident_id, limit)` — fetches the log/audit timeline for a specific incident. Useful for post-incident review and understanding the sequence of events during an incident.

## Depends on
Requires **PR #133** (`refactor/flatten-tool-signatures`) to be merged first.