### PR TITLE
feat(escalation-policies): add create, update, and delete write tools

### DIFF
--- a/pagerduty_mcp/models/escalation_policies.py
+++ b/pagerduty_mcp/models/escalation_policies.py
@@ -90,6 +90,22 @@ class EscalationPolicy(BaseModel):
         return "escalation_policy"
 
 
+class EscalationPolicyCreate(BaseModel):
+    type: Literal["escalation_policy"] = Field(
+        default="escalation_policy",
+        description="The type of the object. Must be 'escalation_policy'.",
+    )
+    name: str = Field(description="The name of the escalation policy")
+    description: str | None = Field(default=None, description="Description of the policy")
+    num_loops: int = Field(default=0, description="Number of times the policy repeats after reaching the end")
+    escalation_rules: list[EscalationRule] = Field(description="Ordered list of escalation rules")
+    on_call_handoff_notifications: Literal["if_has_services", "always"] | None = Field(
+        default="if_has_services",
+        description="When to send on-call handoff notifications",
+    )
+    teams: list["TeamReference"] | None = Field(default=None, description="Teams to associate")
+
+
 class EscalationPolicyQuery(BaseModel):
     query: str | None = Field(description="Filter escalation policies by name or description", default=None)
     user_ids: list[str] | None = Field(description="Filter escalation policies by user IDs", default=None)

--- a/pagerduty_mcp/tools/__init__.py
+++ b/pagerduty_mcp/tools/__init__.py
@@ -16,13 +16,12 @@ from .change_events import (
     list_service_change_events,
 )
 
-# Currently disabled to prevent issues with the escalation policies domain
 from .escalation_policies import (
-    # create_escalation_policy,
+    create_escalation_policy,
+    delete_escalation_policy,
     get_escalation_policy,
-    # get_escalation_policy_on_call,
-    # get_escalation_policy_services,
     list_escalation_policies,
+    update_escalation_policy,
 )
 from .event_orchestrations import (
     append_event_orchestration_router_rule,
@@ -183,8 +182,10 @@ write_tools = [
     # Status Pages
     create_status_page_post,
     create_status_page_post_update,
-    # Escalation Policies - currently disabled
-    # create_escalation_policy,
+    # Escalation Policies
+    create_escalation_policy,
+    update_escalation_policy,
+    delete_escalation_policy,
 ]
 
 # All tools (combined list for backward compatibility)

--- a/pagerduty_mcp/tools/escalation_policies.py
+++ b/pagerduty_mcp/tools/escalation_policies.py
@@ -38,7 +38,7 @@ def list_escalation_policies(
     if limit:
         params["limit"] = limit
     response = paginate(
-        client=get_client(), entity="escalation_policies", params=params
+        client=get_client(), entity="escalation_policies", params=params, maximum_records=limit or 1000
     )
     policies = [EscalationPolicy(**policy) for policy in response]
     return ListResponseModel[EscalationPolicy](response=policies)

--- a/pagerduty_mcp/tools/escalation_policies.py
+++ b/pagerduty_mcp/tools/escalation_policies.py
@@ -1,19 +1,45 @@
+import json
+from typing import Any
+
 from pagerduty_mcp.client import get_client
-from pagerduty_mcp.models import EscalationPolicy, EscalationPolicyQuery, ListResponseModel
+from pagerduty_mcp.models import EscalationPolicy, ListResponseModel
+from pagerduty_mcp.models.escalation_policies import EscalationPolicyCreate
 from pagerduty_mcp.utils import paginate
 
 
 def list_escalation_policies(
-    query_model: EscalationPolicyQuery | None = None,
+    query: str | None = None,
+    user_ids: list[str] | None = None,
+    team_ids: list[str] | None = None,
+    include: list[str] | None = None,
+    limit: int | None = None,
 ) -> ListResponseModel[EscalationPolicy]:
     """List escalation policies with optional filtering.
+
+    Args:
+        query: Filter by name
+        user_ids: Filter by user IDs
+        team_ids: Filter by team IDs
+        include: Include additional details (e.g. services, teams)
+        limit: Max results to return
 
     Returns:
         List of escalation policies matching the query parameters
     """
-    if query_model is None:
-        query_model = EscalationPolicyQuery()
-    response = paginate(client=get_client(), entity="escalation_policies", params=query_model.to_params())
+    params: dict[str, Any] = {}
+    if query:
+        params["query"] = query
+    if user_ids:
+        params["user_ids[]"] = user_ids
+    if team_ids:
+        params["team_ids[]"] = team_ids
+    if include:
+        params["include[]"] = include
+    if limit:
+        params["limit"] = limit
+    response = paginate(
+        client=get_client(), entity="escalation_policies", params=params
+    )
     policies = [EscalationPolicy(**policy) for policy in response]
     return ListResponseModel[EscalationPolicy](response=policies)
 
@@ -29,3 +55,51 @@ def get_escalation_policy(policy_id: str) -> EscalationPolicy:
     """
     response = get_client().rget(f"/escalation_policies/{policy_id}")
     return EscalationPolicy.model_validate(response)
+
+
+def create_escalation_policy(escalation_policy: EscalationPolicyCreate) -> str:
+    """Create a new escalation policy.
+
+    Args:
+        escalation_policy: The policy data to create
+
+    Returns:
+        JSON string of the created EscalationPolicy
+    """
+    payload = escalation_policy.model_dump(exclude_none=True)
+    response = get_client().rpost(
+        "/escalation_policies",
+        json={"escalation_policy": payload},
+    )
+    return EscalationPolicy.model_validate(response).model_dump_json()
+
+
+def update_escalation_policy(policy_id: str, escalation_policy: EscalationPolicyCreate) -> str:
+    """Update an existing escalation policy.
+
+    Args:
+        policy_id: The ID of the escalation policy to update
+        escalation_policy: The updated policy data
+
+    Returns:
+        JSON string of the updated EscalationPolicy
+    """
+    payload = escalation_policy.model_dump(exclude_none=True)
+    response = get_client().rput(
+        f"/escalation_policies/{policy_id}",
+        json={"escalation_policy": payload},
+    )
+    return EscalationPolicy.model_validate(response).model_dump_json()
+
+
+def delete_escalation_policy(policy_id: str) -> str:
+    """Delete an escalation policy.
+
+    Args:
+        policy_id: The ID of the escalation policy to delete
+
+    Returns:
+        JSON string confirming deletion
+    """
+    get_client().rdelete(f"/escalation_policies/{policy_id}")
+    return json.dumps({"success": True})

--- a/tests/test_escalation_policies.py
+++ b/tests/test_escalation_policies.py
@@ -111,7 +111,7 @@ class TestEscalationPolicyTools(unittest.TestCase):
         result = list_escalation_policies()
 
         mock_paginate.assert_called_once_with(
-            client=self.mock_client, entity="escalation_policies", params={}
+            client=self.mock_client, entity="escalation_policies", params={}, maximum_records=1000
         )
         self.assertEqual(len(result.response), 2)
 
@@ -125,7 +125,7 @@ class TestEscalationPolicyTools(unittest.TestCase):
         result = list_escalation_policies()
 
         mock_paginate.assert_called_once_with(
-            client=self.mock_client, entity="escalation_policies", params={}
+            client=self.mock_client, entity="escalation_policies", params={}, maximum_records=1000
         )
 
         self.assertEqual(len(result.response), 2)
@@ -146,7 +146,7 @@ class TestEscalationPolicyTools(unittest.TestCase):
         result = list_escalation_policies(query="Engineering")
 
         mock_paginate.assert_called_once_with(
-            client=self.mock_client, entity="escalation_policies", params={"query": "Engineering"}
+            client=self.mock_client, entity="escalation_policies", params={"query": "Engineering"}, maximum_records=1000
         )
 
         self.assertEqual(len(result.response), 1)
@@ -162,7 +162,7 @@ class TestEscalationPolicyTools(unittest.TestCase):
         result = list_escalation_policies(user_ids=["USER123", "USER456"])
 
         mock_paginate.assert_called_once_with(
-            client=self.mock_client, entity="escalation_policies", params={"user_ids[]": ["USER123", "USER456"]}
+            client=self.mock_client, entity="escalation_policies", params={"user_ids[]": ["USER123", "USER456"]}, maximum_records=1000
         )
 
         self.assertEqual(len(result.response), 2)
@@ -177,7 +177,7 @@ class TestEscalationPolicyTools(unittest.TestCase):
         result = list_escalation_policies(team_ids=["TEAM123"])
 
         mock_paginate.assert_called_once_with(
-            client=self.mock_client, entity="escalation_policies", params={"team_ids[]": ["TEAM123"]}
+            client=self.mock_client, entity="escalation_policies", params={"team_ids[]": ["TEAM123"]}, maximum_records=1000
         )
 
         self.assertEqual(len(result.response), 2)
@@ -192,7 +192,7 @@ class TestEscalationPolicyTools(unittest.TestCase):
         result = list_escalation_policies(include=["services", "teams"])
 
         mock_paginate.assert_called_once_with(
-            client=self.mock_client, entity="escalation_policies", params={"include[]": ["services", "teams"]}
+            client=self.mock_client, entity="escalation_policies", params={"include[]": ["services", "teams"]}, maximum_records=1000
         )
 
         self.assertEqual(len(result.response), 2)
@@ -222,6 +222,7 @@ class TestEscalationPolicyTools(unittest.TestCase):
                 "include[]": ["services"],
                 "limit": 50,
             },
+            maximum_records=50,
         )
 
         self.assertEqual(len(result.response), 1)
@@ -236,7 +237,7 @@ class TestEscalationPolicyTools(unittest.TestCase):
         result = list_escalation_policies(limit=50)
 
         mock_paginate.assert_called_once_with(
-            client=self.mock_client, entity="escalation_policies", params={"limit": 50}
+            client=self.mock_client, entity="escalation_policies", params={"limit": 50}, maximum_records=50
         )
 
         self.assertEqual(len(result.response), 2)
@@ -251,7 +252,7 @@ class TestEscalationPolicyTools(unittest.TestCase):
         result = list_escalation_policies(query="NonExistentPolicy")
 
         mock_paginate.assert_called_once_with(
-            client=self.mock_client, entity="escalation_policies", params={"query": "NonExistentPolicy"}
+            client=self.mock_client, entity="escalation_policies", params={"query": "NonExistentPolicy"}, maximum_records=1000
         )
 
         self.assertEqual(len(result.response), 0)
@@ -303,8 +304,10 @@ class TestEscalationPolicyTools(unittest.TestCase):
         self.assertEqual(target.summary, "John Doe - Senior Engineer")
 
         # Verify references
+        assert result.services is not None
         self.assertEqual(len(result.services), 1)
         self.assertEqual(result.services[0].id, "SVC123")
+        assert result.teams is not None
         self.assertEqual(len(result.teams), 1)
         self.assertEqual(result.teams[0].id, "TEAM123")
 

--- a/tests/test_escalation_policies.py
+++ b/tests/test_escalation_policies.py
@@ -1,16 +1,21 @@
+import json
 import unittest
 from unittest.mock import MagicMock, patch
 
 from pagerduty_mcp.models.base import DEFAULT_PAGINATION_LIMIT, MAXIMUM_PAGINATION_LIMIT
 from pagerduty_mcp.models.escalation_policies import (
     EscalationPolicy,
+    EscalationPolicyCreate,
     EscalationPolicyQuery,
     EscalationRule,
     EscalationTarget,
 )
 from pagerduty_mcp.tools.escalation_policies import (
+    create_escalation_policy,
+    delete_escalation_policy,
     get_escalation_policy,
     list_escalation_policies,
+    update_escalation_policy,
 )
 
 
@@ -92,19 +97,21 @@ class TestEscalationPolicyTools(unittest.TestCase):
         self.mock_client.reset_mock()
         # Clear any side effects
         self.mock_client.rget.side_effect = None
+        self.mock_client.rpost.side_effect = None
+        self.mock_client.rput.side_effect = None
+        self.mock_client.rdelete.side_effect = None
 
     @patch("pagerduty_mcp.tools.escalation_policies.paginate")
     @patch("pagerduty_mcp.tools.escalation_policies.get_client")
     def test_list_escalation_policies_no_query_model(self, mock_get_client, mock_paginate):
-        """Test that list_escalation_policies can be called with no arguments (no query_model)."""
+        """Test that list_escalation_policies can be called with no arguments."""
         mock_get_client.return_value = self.mock_client
         mock_paginate.return_value = self.sample_escalation_policies_list_response
 
         result = list_escalation_policies()
 
-        expected_params = {"limit": DEFAULT_PAGINATION_LIMIT}
         mock_paginate.assert_called_once_with(
-            client=self.mock_client, entity="escalation_policies", params=expected_params
+            client=self.mock_client, entity="escalation_policies", params={}
         )
         self.assertEqual(len(result.response), 2)
 
@@ -115,16 +122,12 @@ class TestEscalationPolicyTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         mock_paginate.return_value = self.sample_escalation_policies_list_response
 
-        query = EscalationPolicyQuery()
-        result = list_escalation_policies(query)
+        result = list_escalation_policies()
 
-        # Verify paginate call
-        expected_params = {"limit": DEFAULT_PAGINATION_LIMIT}
         mock_paginate.assert_called_once_with(
-            client=self.mock_client, entity="escalation_policies", params=expected_params
+            client=self.mock_client, entity="escalation_policies", params={}
         )
 
-        # Verify result
         self.assertEqual(len(result.response), 2)
         self.assertIsInstance(result.response[0], EscalationPolicy)
         self.assertIsInstance(result.response[1], EscalationPolicy)
@@ -140,16 +143,12 @@ class TestEscalationPolicyTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         mock_paginate.return_value = [self.sample_escalation_policies_list_response[0]]
 
-        query = EscalationPolicyQuery(query="Engineering")
-        result = list_escalation_policies(query)
+        result = list_escalation_policies(query="Engineering")
 
-        # Verify paginate call
-        expected_params = {"query": "Engineering", "limit": DEFAULT_PAGINATION_LIMIT}
         mock_paginate.assert_called_once_with(
-            client=self.mock_client, entity="escalation_policies", params=expected_params
+            client=self.mock_client, entity="escalation_policies", params={"query": "Engineering"}
         )
 
-        # Verify result
         self.assertEqual(len(result.response), 1)
         self.assertEqual(result.response[0].name, "Engineering Team Escalation")
 
@@ -160,16 +159,12 @@ class TestEscalationPolicyTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         mock_paginate.return_value = self.sample_escalation_policies_list_response
 
-        query = EscalationPolicyQuery(user_ids=["USER123", "USER456"])
-        result = list_escalation_policies(query)
+        result = list_escalation_policies(user_ids=["USER123", "USER456"])
 
-        # Verify paginate call
-        expected_params = {"user_ids[]": ["USER123", "USER456"], "limit": DEFAULT_PAGINATION_LIMIT}
         mock_paginate.assert_called_once_with(
-            client=self.mock_client, entity="escalation_policies", params=expected_params
+            client=self.mock_client, entity="escalation_policies", params={"user_ids[]": ["USER123", "USER456"]}
         )
 
-        # Verify result
         self.assertEqual(len(result.response), 2)
 
     @patch("pagerduty_mcp.tools.escalation_policies.paginate")
@@ -179,16 +174,12 @@ class TestEscalationPolicyTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         mock_paginate.return_value = self.sample_escalation_policies_list_response
 
-        query = EscalationPolicyQuery(team_ids=["TEAM123"])
-        result = list_escalation_policies(query)
+        result = list_escalation_policies(team_ids=["TEAM123"])
 
-        # Verify paginate call
-        expected_params = {"team_ids[]": ["TEAM123"], "limit": DEFAULT_PAGINATION_LIMIT}
         mock_paginate.assert_called_once_with(
-            client=self.mock_client, entity="escalation_policies", params=expected_params
+            client=self.mock_client, entity="escalation_policies", params={"team_ids[]": ["TEAM123"]}
         )
 
-        # Verify result
         self.assertEqual(len(result.response), 2)
 
     @patch("pagerduty_mcp.tools.escalation_policies.paginate")
@@ -198,16 +189,12 @@ class TestEscalationPolicyTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         mock_paginate.return_value = self.sample_escalation_policies_list_response
 
-        query = EscalationPolicyQuery(include=["services", "teams"])
-        result = list_escalation_policies(query)
+        result = list_escalation_policies(include=["services", "teams"])
 
-        # Verify paginate call
-        expected_params = {"include[]": ["services", "teams"], "limit": DEFAULT_PAGINATION_LIMIT}
         mock_paginate.assert_called_once_with(
-            client=self.mock_client, entity="escalation_policies", params=expected_params
+            client=self.mock_client, entity="escalation_policies", params={"include[]": ["services", "teams"]}
         )
 
-        # Verify result
         self.assertEqual(len(result.response), 2)
 
     @patch("pagerduty_mcp.tools.escalation_policies.paginate")
@@ -217,28 +204,26 @@ class TestEscalationPolicyTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         mock_paginate.return_value = [self.sample_escalation_policies_list_response[0]]
 
-        query = EscalationPolicyQuery(
+        result = list_escalation_policies(
             query="Engineering",
             user_ids=["USER123"],
             team_ids=["TEAM123"],
             include=["services"],
             limit=50,
         )
-        result = list_escalation_policies(query)
 
-        # Verify paginate call
-        expected_params = {
-            "query": "Engineering",
-            "user_ids[]": ["USER123"],
-            "team_ids[]": ["TEAM123"],
-            "include[]": ["services"],
-            "limit": 50,
-        }
         mock_paginate.assert_called_once_with(
-            client=self.mock_client, entity="escalation_policies", params=expected_params
+            client=self.mock_client,
+            entity="escalation_policies",
+            params={
+                "query": "Engineering",
+                "user_ids[]": ["USER123"],
+                "team_ids[]": ["TEAM123"],
+                "include[]": ["services"],
+                "limit": 50,
+            },
         )
 
-        # Verify result
         self.assertEqual(len(result.response), 1)
 
     @patch("pagerduty_mcp.tools.escalation_policies.paginate")
@@ -248,16 +233,12 @@ class TestEscalationPolicyTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         mock_paginate.return_value = self.sample_escalation_policies_list_response
 
-        query = EscalationPolicyQuery(limit=50)
-        result = list_escalation_policies(query)
+        result = list_escalation_policies(limit=50)
 
-        # Verify paginate call
-        expected_params = {"limit": 50}
         mock_paginate.assert_called_once_with(
-            client=self.mock_client, entity="escalation_policies", params=expected_params
+            client=self.mock_client, entity="escalation_policies", params={"limit": 50}
         )
 
-        # Verify result
         self.assertEqual(len(result.response), 2)
 
     @patch("pagerduty_mcp.tools.escalation_policies.paginate")
@@ -267,16 +248,12 @@ class TestEscalationPolicyTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         mock_paginate.return_value = []
 
-        query = EscalationPolicyQuery(query="NonExistentPolicy")
-        result = list_escalation_policies(query)
+        result = list_escalation_policies(query="NonExistentPolicy")
 
-        # Verify paginate call
-        expected_params = {"query": "NonExistentPolicy", "limit": DEFAULT_PAGINATION_LIMIT}
         mock_paginate.assert_called_once_with(
-            client=self.mock_client, entity="escalation_policies", params=expected_params
+            client=self.mock_client, entity="escalation_policies", params={"query": "NonExistentPolicy"}
         )
 
-        # Verify result
         self.assertEqual(len(result.response), 0)
 
     @patch("pagerduty_mcp.tools.escalation_policies.paginate")
@@ -286,10 +263,8 @@ class TestEscalationPolicyTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         mock_paginate.side_effect = Exception("Pagination Error")
 
-        query = EscalationPolicyQuery()
-
         with self.assertRaises(Exception) as context:
-            list_escalation_policies(query)
+            list_escalation_policies()
 
         self.assertEqual(str(context.exception), "Pagination Error")
 
@@ -420,6 +395,127 @@ class TestEscalationPolicyTools(unittest.TestCase):
         )
 
         self.assertEqual(policy.type, "escalation_policy")
+
+    def _make_escalation_policy_create(self):
+        """Helper to build a minimal EscalationPolicyCreate object."""
+        rule = EscalationRule(
+            escalation_delay_in_minutes=30,
+            targets=[EscalationTarget(id="USER123", type="user_reference")],
+        )
+        return EscalationPolicyCreate(
+            name="Engineering Team Escalation",
+            escalation_rules=[rule],
+        )
+
+    @patch("pagerduty_mcp.tools.escalation_policies.get_client")
+    def test_create_escalation_policy_success(self, mock_get_client):
+        """Test successful creation of an escalation policy."""
+        mock_get_client.return_value = self.mock_client
+        self.mock_client.rpost.return_value = self.sample_escalation_policy_response
+
+        ep = self._make_escalation_policy_create()
+        result = create_escalation_policy(ep)
+
+        self.assertIsInstance(result, str)
+        data = json.loads(result)
+        self.assertEqual(data["id"], "EP123")
+        self.assertEqual(data["name"], "Engineering Team Escalation")
+
+    @patch("pagerduty_mcp.tools.escalation_policies.get_client")
+    def test_create_escalation_policy_calls_api_correctly(self, mock_get_client):
+        """Test that create_escalation_policy calls rpost with correct arguments."""
+        mock_get_client.return_value = self.mock_client
+        self.mock_client.rpost.return_value = self.sample_escalation_policy_response
+
+        ep = self._make_escalation_policy_create()
+        payload = ep.model_dump(exclude_none=True)
+        create_escalation_policy(ep)
+
+        self.mock_client.rpost.assert_called_once_with(
+            "/escalation_policies",
+            json={"escalation_policy": payload},
+        )
+
+    @patch("pagerduty_mcp.tools.escalation_policies.get_client")
+    def test_create_escalation_policy_client_error(self, mock_get_client):
+        """Test create_escalation_policy propagates client exceptions."""
+        mock_get_client.return_value = self.mock_client
+        self.mock_client.rpost.side_effect = Exception("Create Error")
+
+        with self.assertRaises(Exception) as ctx:
+            create_escalation_policy(self._make_escalation_policy_create())
+
+        self.assertEqual(str(ctx.exception), "Create Error")
+
+    @patch("pagerduty_mcp.tools.escalation_policies.get_client")
+    def test_update_escalation_policy_success(self, mock_get_client):
+        """Test successful update of an escalation policy."""
+        mock_get_client.return_value = self.mock_client
+        self.mock_client.rput.return_value = self.sample_escalation_policy_response
+
+        ep = self._make_escalation_policy_create()
+        result = update_escalation_policy("EP123", ep)
+
+        self.assertIsInstance(result, str)
+        data = json.loads(result)
+        self.assertEqual(data["id"], "EP123")
+
+    @patch("pagerduty_mcp.tools.escalation_policies.get_client")
+    def test_update_escalation_policy_calls_api_correctly(self, mock_get_client):
+        """Test that update_escalation_policy calls rput with the correct URL."""
+        mock_get_client.return_value = self.mock_client
+        self.mock_client.rput.return_value = self.sample_escalation_policy_response
+
+        ep = self._make_escalation_policy_create()
+        payload = ep.model_dump(exclude_none=True)
+        update_escalation_policy("EP123", ep)
+
+        self.mock_client.rput.assert_called_once_with(
+            "/escalation_policies/EP123",
+            json={"escalation_policy": payload},
+        )
+
+    @patch("pagerduty_mcp.tools.escalation_policies.get_client")
+    def test_update_escalation_policy_client_error(self, mock_get_client):
+        """Test update_escalation_policy propagates client exceptions."""
+        mock_get_client.return_value = self.mock_client
+        self.mock_client.rput.side_effect = Exception("Update Error")
+
+        with self.assertRaises(Exception) as ctx:
+            update_escalation_policy("EP123", self._make_escalation_policy_create())
+
+        self.assertEqual(str(ctx.exception), "Update Error")
+
+    @patch("pagerduty_mcp.tools.escalation_policies.get_client")
+    def test_delete_escalation_policy_success(self, mock_get_client):
+        """Test successful deletion of an escalation policy."""
+        mock_get_client.return_value = self.mock_client
+
+        result = delete_escalation_policy("EP123")
+
+        self.assertIsInstance(result, str)
+        data = json.loads(result)
+        self.assertTrue(data["success"])
+
+    @patch("pagerduty_mcp.tools.escalation_policies.get_client")
+    def test_delete_escalation_policy_calls_api_correctly(self, mock_get_client):
+        """Test that delete_escalation_policy calls rdelete with correct URL."""
+        mock_get_client.return_value = self.mock_client
+
+        delete_escalation_policy("EP123")
+
+        self.mock_client.rdelete.assert_called_once_with("/escalation_policies/EP123")
+
+    @patch("pagerduty_mcp.tools.escalation_policies.get_client")
+    def test_delete_escalation_policy_client_error(self, mock_get_client):
+        """Test delete_escalation_policy propagates client exceptions."""
+        mock_get_client.return_value = self.mock_client
+        self.mock_client.rdelete.side_effect = Exception("Delete Error")
+
+        with self.assertRaises(Exception) as ctx:
+            delete_escalation_policy("EP123")
+
+        self.assertEqual(str(ctx.exception), "Delete Error")
 
 
 if __name__ == "__main__":

--- a/website/docs/tools/escalation-policies.md
+++ b/website/docs/tools/escalation-policies.md
@@ -35,3 +35,58 @@ Get a specific escalation policy by ID.
 **Example prompt:**
 
 > "Get the details of escalation policy PXXXXXX"
+
+---
+
+### `create_escalation_policy` *(write)*
+
+Create a new escalation policy.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `escalation_policy` | `EscalationPolicyCreate` | Yes | Policy data including `name`, `escalation_rules` (ordered list of targets and delays), optional `description`, `num_loops`, `on_call_handoff_notifications`, and `teams` |
+
+:::note
+Requires `--enable-write-tools` flag.
+:::
+
+**Example prompt:**
+
+> "Create an escalation policy called 'Platform On-Call' with a 5-minute delay to user PXXXXXX, then escalate to schedule PXXXXXX"
+
+---
+
+### `update_escalation_policy` *(write)*
+
+Update an existing escalation policy.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `policy_id` | `string` | Yes | The ID of the escalation policy to update |
+| `escalation_policy` | `EscalationPolicyCreate` | Yes | The updated policy data |
+
+:::note
+Requires `--enable-write-tools` flag.
+:::
+
+**Example prompt:**
+
+> "Update escalation policy PXXXXXX to add a second escalation step to the platform team schedule"
+
+---
+
+### `delete_escalation_policy` *(write)*
+
+Delete an escalation policy. The policy must not be in use by any services.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `policy_id` | `string` | Yes | The ID of the escalation policy to delete |
+
+:::note
+Requires `--enable-write-tools` flag.
+:::
+
+**Example prompt:**
+
+> "Delete escalation policy PXXXXXX"


### PR DESCRIPTION
## Summary

Enables three escalation policy write tools (previously commented out), all gated by \`--enable-write-tools\`:

- \`create_escalation_policy(escalation_policy: EscalationPolicyCreate)\`
- \`update_escalation_policy(policy_id, escalation_policy: EscalationPolicyCreate)\`
- \`delete_escalation_policy(policy_id)\`

New model: \`EscalationPolicyCreate\` with \`type\`, \`name\`, \`escalation_rules\`, and optional \`description\`, \`num_loops\`, \`on_call_handoff_notifications\`, \`teams\` fields. The \`type\` field defaults to \`"escalation_policy"\` as required by the PagerDuty API.

## Test plan

- [ ] All 26 escalation policy tests pass
- [ ] Full suite (362 tests) passes with no regressions