### PR TITLE
feat(services): add get_technical_service_dependencies

### DIFF
--- a/pagerduty_mcp/tools/__init__.py
+++ b/pagerduty_mcp/tools/__init__.py
@@ -66,6 +66,7 @@ from .schedules import (
 from .services import (
     create_service,
     get_service,
+    get_technical_service_dependencies,
     list_services,
     update_service,
 )
@@ -117,6 +118,7 @@ read_tools = [
     # Services
     list_services,
     get_service,
+    get_technical_service_dependencies,
     # Teams
     list_teams,
     get_team,

--- a/pagerduty_mcp/tools/services.py
+++ b/pagerduty_mcp/tools/services.py
@@ -1,20 +1,34 @@
+import json
+from typing import Any
+
 from pagerduty_mcp.client import get_client
-from pagerduty_mcp.models import ListResponseModel, Service, ServiceCreate, ServiceQuery
+from pagerduty_mcp.models import ListResponseModel, Service, ServiceCreate
 from pagerduty_mcp.utils import paginate
 
 
-def list_services(query_model: ServiceQuery | None = None) -> ListResponseModel[Service]:
+def list_services(
+    query: str | None = None,
+    teams_ids: list[str] | None = None,
+    limit: int | None = None,
+) -> ListResponseModel[Service]:
     """List all services.
 
     Args:
-        query_model: Optional filtering parameters
+        query: Filter by name
+        teams_ids: Filter by team IDs
+        limit: Max results to return
 
     Returns:
         List of services matching the query parameters
     """
-    if query_model is None:
-        query_model = ServiceQuery()
-    response = paginate(client=get_client(), entity="services", params=query_model.to_params())
+    params: dict[str, Any] = {}
+    if query:
+        params["query"] = query
+    if teams_ids:
+        params["team_ids[]"] = teams_ids
+    if limit:
+        params["limit"] = limit
+    response = paginate(client=get_client(), entity="services", params=params)
     services = [Service(**service) for service in response]
     return ListResponseModel[Service](response=services)
 
@@ -72,3 +86,19 @@ def update_service(service_id: str, service_data: ServiceCreate) -> Service:
         return Service.model_validate(response["service"])
 
     return Service.model_validate(response)
+
+
+def get_technical_service_dependencies(service_id: str) -> str:
+    """Get dependencies for a technical service.
+
+    Args:
+        service_id: The ID of the technical service
+
+    Returns:
+        JSON string with relationships list
+    """
+    client = get_client()
+    resp = client.get(f"/service_dependencies/technical_services/{service_id}")
+    resp.raise_for_status()
+    data = resp.json()
+    return json.dumps({"relationships": data.get("relationships", [])})

--- a/pagerduty_mcp/tools/services.py
+++ b/pagerduty_mcp/tools/services.py
@@ -28,7 +28,7 @@ def list_services(
         params["team_ids[]"] = teams_ids
     if limit:
         params["limit"] = limit
-    response = paginate(client=get_client(), entity="services", params=params)
+    response = paginate(client=get_client(), entity="services", params=params, maximum_records=limit or 1000)
     services = [Service(**service) for service in response]
     return ListResponseModel[Service](response=services)
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -8,6 +8,7 @@ from pagerduty_mcp.models.services import Service, ServiceCreate, ServiceQuery
 from pagerduty_mcp.tools.services import (
     create_service,
     get_service,
+    get_technical_service_dependencies,
     list_services,
     update_service,
 )
@@ -81,7 +82,7 @@ class TestServiceTools(unittest.TestCase):
 
         result = list_services()
 
-        mock_paginate.assert_called_once_with(client=self.mock_client, entity="services", params={"limit": DEFAULT_PAGINATION_LIMIT})
+        mock_paginate.assert_called_once_with(client=self.mock_client, entity="services", params={})
         self.assertEqual(len(result.response), 2)
 
     @patch("pagerduty_mcp.tools.services.paginate")
@@ -91,11 +92,10 @@ class TestServiceTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         mock_paginate.return_value = self.sample_services_list_response
 
-        query = ServiceQuery()
-        result = list_services(query)
+        result = list_services()
 
         # Verify paginate call
-        mock_paginate.assert_called_once_with(client=self.mock_client, entity="services", params=query.to_params())
+        mock_paginate.assert_called_once_with(client=self.mock_client, entity="services", params={})
 
         # Verify result
         self.assertEqual(len(result.response), 2)
@@ -113,11 +113,10 @@ class TestServiceTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         mock_paginate.return_value = [self.sample_services_list_response[0]]
 
-        query = ServiceQuery(query="Web")
-        result = list_services(query)
+        result = list_services(query="Web")
 
         # Verify paginate call
-        expected_params = {"query": "Web", "limit": DEFAULT_PAGINATION_LIMIT}
+        expected_params = {"query": "Web"}
         mock_paginate.assert_called_once_with(client=self.mock_client, entity="services", params=expected_params)
 
         # Verify result
@@ -131,11 +130,10 @@ class TestServiceTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         mock_paginate.return_value = [self.sample_services_list_response[1]]
 
-        query = ServiceQuery(teams_ids=["TEAM2"])
-        result = list_services(query)
+        result = list_services(teams_ids=["TEAM2"])
 
         # Verify paginate call
-        expected_params = {"team_ids[]": ["TEAM2"], "limit": DEFAULT_PAGINATION_LIMIT}
+        expected_params = {"team_ids[]": ["TEAM2"]}
         mock_paginate.assert_called_once_with(client=self.mock_client, entity="services", params=expected_params)
 
         # Verify result
@@ -149,8 +147,7 @@ class TestServiceTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         mock_paginate.return_value = self.sample_services_list_response
 
-        query = ServiceQuery(limit=50)
-        result = list_services(query)
+        result = list_services(limit=50)
 
         # Verify paginate call
         expected_params = {"limit": 50}
@@ -166,8 +163,7 @@ class TestServiceTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         mock_paginate.return_value = [self.sample_services_list_response[0]]
 
-        query = ServiceQuery(query="Web", teams_ids=["TEAM1"], limit=10)
-        result = list_services(query)
+        result = list_services(query="Web", teams_ids=["TEAM1"], limit=10)
 
         # Verify paginate call
         expected_params = {"query": "Web", "team_ids[]": ["TEAM1"], "limit": 10}
@@ -184,11 +180,10 @@ class TestServiceTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         mock_paginate.return_value = []
 
-        query = ServiceQuery(query="NonExistentService")
-        result = list_services(query)
+        result = list_services(query="NonExistentService")
 
         # Verify paginate call
-        expected_params = {"query": "NonExistentService", "limit": DEFAULT_PAGINATION_LIMIT}
+        expected_params = {"query": "NonExistentService"}
         mock_paginate.assert_called_once_with(client=self.mock_client, entity="services", params=expected_params)
 
         # Verify result
@@ -201,10 +196,8 @@ class TestServiceTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         mock_paginate.side_effect = Exception("Pagination Error")
 
-        query = ServiceQuery()
-
         with self.assertRaises(Exception) as context:
-            list_services(query)
+            list_services()
 
         self.assertEqual(str(context.exception), "Pagination Error")
 
@@ -227,6 +220,8 @@ class TestServiceTools(unittest.TestCase):
         self.assertEqual(result.description, "Main web application service")
         self.assertIsInstance(result.escalation_policy, EscalationPolicyReference)
         self.assertEqual(result.escalation_policy.id, "EP123")
+        self.assertIsNotNone(result.teams)
+        assert result.teams is not None
         self.assertEqual(len(result.teams), 2)
         self.assertIsInstance(result.teams[0], TeamReference)
         self.assertEqual(result.teams[0].id, "TEAM1")
@@ -450,6 +445,61 @@ class TestServiceTools(unittest.TestCase):
         )
 
         self.assertEqual(service.type, "service")
+
+
+
+class TestGetTechnicalServiceDependencies(unittest.TestCase):
+    @patch("pagerduty_mcp.tools.services.get_client")
+    def test_success(self, mock_get_client):
+        """Test successful retrieval of technical service dependencies."""
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "relationships": [
+                {
+                    "supporting_service": {"id": "S1", "type": "service"},
+                    "dependent_service": {"id": "S2", "type": "service"},
+                }
+            ]
+        }
+        mock_client.get.return_value = mock_response
+        mock_get_client.return_value = mock_client
+
+        result = get_technical_service_dependencies("S2")
+
+        mock_client.get.assert_called_once_with("/service_dependencies/technical_services/S2")
+        mock_response.raise_for_status.assert_called_once()
+        self.assertIn('"relationships"', result)
+
+    @patch("pagerduty_mcp.tools.services.get_client")
+    def test_empty_relationships(self, mock_get_client):
+        """Test that an empty relationships list is handled correctly."""
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"relationships": []}
+        mock_client.get.return_value = mock_response
+        mock_get_client.return_value = mock_client
+
+        result = get_technical_service_dependencies("S1")
+
+        mock_response.raise_for_status.assert_called_once()
+        self.assertIn("relationships", result)
+
+    @patch("pagerduty_mcp.tools.services.get_client")
+    def test_http_error_propagates(self, mock_get_client):
+        """Test that HTTP errors from raise_for_status propagate correctly."""
+        from unittest.mock import MagicMock
+
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = Exception("404 Not Found")
+        mock_client.get.return_value = mock_response
+        mock_get_client.return_value = mock_client
+
+        with self.assertRaises(Exception) as context:
+            get_technical_service_dependencies("INVALID")
+
+        self.assertIn("404", str(context.exception))
 
 
 if __name__ == "__main__":

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -82,7 +82,7 @@ class TestServiceTools(unittest.TestCase):
 
         result = list_services()
 
-        mock_paginate.assert_called_once_with(client=self.mock_client, entity="services", params={})
+        mock_paginate.assert_called_once_with(client=self.mock_client, entity="services", params={}, maximum_records=1000)
         self.assertEqual(len(result.response), 2)
 
     @patch("pagerduty_mcp.tools.services.paginate")
@@ -95,7 +95,7 @@ class TestServiceTools(unittest.TestCase):
         result = list_services()
 
         # Verify paginate call
-        mock_paginate.assert_called_once_with(client=self.mock_client, entity="services", params={})
+        mock_paginate.assert_called_once_with(client=self.mock_client, entity="services", params={}, maximum_records=1000)
 
         # Verify result
         self.assertEqual(len(result.response), 2)
@@ -117,7 +117,7 @@ class TestServiceTools(unittest.TestCase):
 
         # Verify paginate call
         expected_params = {"query": "Web"}
-        mock_paginate.assert_called_once_with(client=self.mock_client, entity="services", params=expected_params)
+        mock_paginate.assert_called_once_with(client=self.mock_client, entity="services", params=expected_params, maximum_records=1000)
 
         # Verify result
         self.assertEqual(len(result.response), 1)
@@ -134,7 +134,7 @@ class TestServiceTools(unittest.TestCase):
 
         # Verify paginate call
         expected_params = {"team_ids[]": ["TEAM2"]}
-        mock_paginate.assert_called_once_with(client=self.mock_client, entity="services", params=expected_params)
+        mock_paginate.assert_called_once_with(client=self.mock_client, entity="services", params=expected_params, maximum_records=1000)
 
         # Verify result
         self.assertEqual(len(result.response), 1)
@@ -151,7 +151,7 @@ class TestServiceTools(unittest.TestCase):
 
         # Verify paginate call
         expected_params = {"limit": 50}
-        mock_paginate.assert_called_once_with(client=self.mock_client, entity="services", params=expected_params)
+        mock_paginate.assert_called_once_with(client=self.mock_client, entity="services", params=expected_params, maximum_records=50)
 
         # Verify result
         self.assertEqual(len(result.response), 2)
@@ -167,7 +167,7 @@ class TestServiceTools(unittest.TestCase):
 
         # Verify paginate call
         expected_params = {"query": "Web", "team_ids[]": ["TEAM1"], "limit": 10}
-        mock_paginate.assert_called_once_with(client=self.mock_client, entity="services", params=expected_params)
+        mock_paginate.assert_called_once_with(client=self.mock_client, entity="services", params=expected_params, maximum_records=10)
 
         # Verify result
         self.assertEqual(len(result.response), 1)
@@ -184,7 +184,7 @@ class TestServiceTools(unittest.TestCase):
 
         # Verify paginate call
         expected_params = {"query": "NonExistentService"}
-        mock_paginate.assert_called_once_with(client=self.mock_client, entity="services", params=expected_params)
+        mock_paginate.assert_called_once_with(client=self.mock_client, entity="services", params=expected_params, maximum_records=1000)
 
         # Verify result
         self.assertEqual(len(result.response), 0)

--- a/website/docs/tools/services.md
+++ b/website/docs/tools/services.md
@@ -36,6 +36,20 @@ Get details for a specific service.
 
 ---
 
+### `get_technical_service_dependencies`
+
+Get the service dependencies for a technical service. Returns the `relationships` array showing which services this technical service depends on and which services depend on it.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `service_id` | `string` | Yes | The ID of the technical service |
+
+**Example prompt:**
+
+> "What services does the payment-gateway service depend on?"
+
+---
+
 ### `create_service` *(write)*
 
 Create a new service.


### PR DESCRIPTION
## Summary

Adds `get_technical_service_dependencies(service_id)` — returns the technical service dependency graph showing which services depend on or support a given service.

- Uses raw `client.get()` (not `rget()`) because the endpoint returns `{"relationships": [...]}` which does not follow the standard PD resource envelope
- Includes `raise_for_status()` before parsing the response body to propagate HTTP errors

## Depends on
Requires **PR #133** (`refactor/flatten-tool-signatures`) to be merged first.