### PR TITLE
feat(users): add create_user write tool

### DIFF
--- a/pagerduty_mcp/models/__init__.py
+++ b/pagerduty_mcp/models/__init__.py
@@ -112,7 +112,7 @@ from .status_pages import (
     StatusPageStatusReference,
 )
 from .teams import Team, TeamCreateRequest, TeamMemberAdd, TeamQuery
-from .users import User, UserQuery
+from .users import CreateUserRequest, User, UserQuery
 
 __all__ = [
     "MAX_RESULTS",
@@ -228,4 +228,5 @@ __all__ = [
     "User",
     "UserQuery",
     "UserReference",
+    "CreateUserRequest",
 ]

--- a/pagerduty_mcp/models/users.py
+++ b/pagerduty_mcp/models/users.py
@@ -59,3 +59,16 @@ class UserQuery(BaseModel):
         if self.limit:
             params["limit"] = self.limit
         return params
+
+
+class CreateUserRequest(BaseModel):
+    name: str = Field(description="The full name of the user")
+    email: str = Field(description="The user's email address (used as login)")
+    role: UserRole = Field(
+        default="user",
+        description="The user's role in PagerDuty (user, admin, read_only_user, etc.)",
+    )
+    time_zone: str = Field(
+        default="UTC",
+        description="The user's time zone (e.g. 'America/New_York')",
+    )

--- a/pagerduty_mcp/models/users.py
+++ b/pagerduty_mcp/models/users.py
@@ -30,6 +30,15 @@ class User(BaseModel):
     email: str = Field(description="The email of the user")
     role: UserRole = Field(description="The user role in PagerDuty (admin, limited_user, observer, etc.)")
     teams: list[TeamReference] = Field(description="The list of teams to which the user belongs")
+    time_zone: str | None = Field(
+        default=None,
+        description="The user's preferred time zone as an IANA name (e.g., 'America/New_York'). "
+        "Used for bucketing on-call hours into off-hours/sleep-hours windows per user.",
+    )
+    job_title: str | None = Field(
+        default=None,
+        description="The user's job title.",
+    )
 
     @computed_field
     @property

--- a/pagerduty_mcp/tools/__init__.py
+++ b/pagerduty_mcp/tools/__init__.py
@@ -89,7 +89,7 @@ from .teams import (
     remove_team_member,
     update_team,
 )
-from .users import get_user_data, list_users
+from .users import create_user, get_user_data, list_users
 
 # Read-only tools (safe, non-destructive operations)
 read_tools = [
@@ -183,6 +183,8 @@ write_tools = [
     # Status Pages
     create_status_page_post,
     create_status_page_post_update,
+    # Users
+    create_user,
     # Escalation Policies - currently disabled
     # create_escalation_policy,
 ]

--- a/pagerduty_mcp/tools/users.py
+++ b/pagerduty_mcp/tools/users.py
@@ -1,5 +1,8 @@
+from typing import Any
+
 from pagerduty_mcp.client import get_client
-from pagerduty_mcp.models import ListResponseModel, User, UserQuery
+from pagerduty_mcp.models import ListResponseModel, User
+from pagerduty_mcp.models.users import CreateUserRequest
 
 
 def get_user_data() -> User:
@@ -12,17 +15,42 @@ def get_user_data() -> User:
     return User.model_validate(response)
 
 
-def list_users(query_model: UserQuery | None = None) -> ListResponseModel[User]:
+def list_users(
+    query: str | None = None,
+    teams_ids: list[str] | None = None,
+    limit: int | None = 100,
+) -> ListResponseModel[User]:
     """List users, optionally filtering by name (query) and team IDs.
 
     Args:
-        query_model: Optional filtering parameters
+        query: Filters the result, showing only the records whose name matches the query.
+        teams_ids: Filter users by team IDs.
+        limit: Pagination limit. Default 100.
 
     Returns:
         List of users matching the criteria.
     """
-    if query_model is None:
-        query_model = UserQuery()
-    response = get_client().rget("/users", params=query_model.to_params())
+    params: dict[str, Any] = {}
+    if query:
+        params["query"] = query
+    if teams_ids:
+        params["team_ids[]"] = teams_ids
+    if limit:
+        params["limit"] = limit
+
+    response = get_client().rget("/users", params=params)
     users = [User(**user) for user in response]
     return ListResponseModel[User](response=users)
+
+
+def create_user(request: CreateUserRequest) -> User:
+    """Create a new PagerDuty user account. No invitation email is sent.
+
+    Args:
+        request: User creation parameters (name, email, role, time_zone)
+
+    Returns:
+        The created User object.
+    """
+    response = get_client().rpost("/users", json=request.model_dump())
+    return User.model_validate(response)

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -339,5 +339,34 @@ class TestUserTools(unittest.TestCase):
         self.assertEqual(str(ctx.exception), "Create Error")
 
 
+class TestUserModelTimeZoneAndJobTitle(unittest.TestCase):
+    """Tests for time_zone and job_title fields on the User read model (from PR #131)."""
+
+    def test_user_model_job_title_and_time_zone_default_none(self):
+        """time_zone and job_title default to None — backwards compatible with existing payloads."""
+        user = User(name="Test User", email="test@example.com", role="user", teams=[])
+        self.assertIsNone(user.job_title)
+        self.assertIsNone(user.time_zone)
+
+    def test_user_model_job_title_and_time_zone_populated(self):
+        """time_zone and job_title round-trip from API payload."""
+        user = User(
+            name="Test User",
+            email="test@example.com",
+            role="user",
+            teams=[],
+            job_title="Senior Engineer",
+            time_zone="America/New_York",
+        )
+        self.assertEqual(user.job_title, "Senior Engineer")
+        self.assertEqual(user.time_zone, "America/New_York")
+
+    def test_user_model_time_zone_iana_format(self):
+        """time_zone accepts standard IANA timezone names."""
+        for tz in ("Europe/Lisbon", "Asia/Tokyo", "UTC", "America/Chicago"):
+            user = User(name="u", email="u@example.com", role="user", teams=[], time_zone=tz)
+            self.assertEqual(user.time_zone, tz)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -3,8 +3,8 @@ from unittest.mock import MagicMock, patch
 
 from pagerduty_mcp.models.base import DEFAULT_PAGINATION_LIMIT, MAXIMUM_PAGINATION_LIMIT
 from pagerduty_mcp.models.references import TeamReference
-from pagerduty_mcp.models.users import User, UserQuery
-from pagerduty_mcp.tools.users import get_user_data, list_users
+from pagerduty_mcp.models.users import CreateUserRequest, User, UserQuery
+from pagerduty_mcp.tools.users import create_user, get_user_data, list_users
 
 
 class TestUserTools(unittest.TestCase):
@@ -51,6 +51,7 @@ class TestUserTools(unittest.TestCase):
         self.mock_client.reset_mock()
         # Clear any side effects
         self.mock_client.rget.side_effect = None
+        self.mock_client.rpost.side_effect = None
 
     @patch("pagerduty_mcp.tools.users.get_client")
     def test_get_user_data_success(self, mock_get_client):
@@ -92,13 +93,13 @@ class TestUserTools(unittest.TestCase):
 
     @patch("pagerduty_mcp.tools.users.get_client")
     def test_list_users_no_query_model(self, mock_get_client):
-        """Test that list_users can be called with no arguments (no query_model)."""
+        """Test that list_users can be called with no arguments."""
         mock_get_client.return_value = self.mock_client
         self.mock_client.rget.return_value = self.sample_users_list_response
 
         result = list_users()
 
-        expected_params = {"limit": DEFAULT_PAGINATION_LIMIT}
+        expected_params = {"limit": 100}
         self.mock_client.rget.assert_called_once_with("/users", params=expected_params)
         self.assertEqual(len(result.response), 2)
 
@@ -108,11 +109,11 @@ class TestUserTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         self.mock_client.rget.return_value = self.sample_users_list_response
 
-        result = list_users(UserQuery())
+        result = list_users()
 
         # Verify API call
         mock_get_client.assert_called_once()
-        expected_params = {"limit": DEFAULT_PAGINATION_LIMIT}
+        expected_params = {"limit": 100}
         self.mock_client.rget.assert_called_once_with("/users", params=expected_params)
 
         # Verify result
@@ -130,11 +131,11 @@ class TestUserTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         self.mock_client.rget.return_value = [self.sample_users_list_response[0]]
 
-        result = list_users(UserQuery(query="John"))
+        result = list_users(query="John")
 
         # Verify API call
         mock_get_client.assert_called_once()
-        expected_params = {"query": "John", "limit": DEFAULT_PAGINATION_LIMIT}
+        expected_params = {"query": "John", "limit": 100}
         self.mock_client.rget.assert_called_once_with("/users", params=expected_params)
 
         # Verify result
@@ -148,11 +149,11 @@ class TestUserTools(unittest.TestCase):
         self.mock_client.rget.return_value = [self.sample_users_list_response[1]]
 
         team_ids = ["TEAM2", "TEAM3"]
-        result = list_users(UserQuery(teams_ids=team_ids))
+        result = list_users(teams_ids=team_ids)
 
         # Verify API call
         mock_get_client.assert_called_once()
-        expected_params = {"team_ids[]": team_ids, "limit": DEFAULT_PAGINATION_LIMIT}
+        expected_params = {"team_ids[]": team_ids, "limit": 100}
         self.mock_client.rget.assert_called_once_with("/users", params=expected_params)
 
         # Verify result
@@ -165,7 +166,7 @@ class TestUserTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         self.mock_client.rget.return_value = self.sample_users_list_response
 
-        result = list_users(UserQuery(limit=50))
+        result = list_users(limit=50)
 
         # Verify API call
         mock_get_client.assert_called_once()
@@ -182,7 +183,7 @@ class TestUserTools(unittest.TestCase):
         self.mock_client.rget.return_value = [self.sample_users_list_response[0]]
 
         team_ids = ["TEAM1"]
-        result = list_users(UserQuery(query="John", teams_ids=team_ids, limit=10))
+        result = list_users(query="John", teams_ids=team_ids, limit=10)
 
         # Verify API call
         mock_get_client.assert_called_once()
@@ -199,11 +200,11 @@ class TestUserTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         self.mock_client.rget.return_value = []
 
-        result = list_users(UserQuery(query="NonExistentUser"))
+        result = list_users(query="NonExistentUser")
 
         # Verify API call
         mock_get_client.assert_called_once()
-        expected_params = {"query": "NonExistentUser", "limit": DEFAULT_PAGINATION_LIMIT}
+        expected_params = {"query": "NonExistentUser", "limit": 100}
         self.mock_client.rget.assert_called_once_with("/users", params=expected_params)
 
         # Verify result
@@ -216,7 +217,7 @@ class TestUserTools(unittest.TestCase):
         self.mock_client.rget.side_effect = Exception("API Error")
 
         with self.assertRaises(Exception) as context:
-            list_users(UserQuery())
+            list_users()
 
         self.assertEqual(str(context.exception), "API Error")
         mock_get_client.assert_called_once()
@@ -274,25 +275,23 @@ class TestUserTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         self.mock_client.rget.return_value = [self.sample_users_list_response[0]]
 
-        result = list_users(UserQuery(teams_ids=["TEAM1"]))
+        result = list_users(teams_ids=["TEAM1"])
 
         # Verify API call
         mock_get_client.assert_called_once()
-        expected_params = {"team_ids[]": ["TEAM1"], "limit": DEFAULT_PAGINATION_LIMIT}
+        expected_params = {"team_ids[]": ["TEAM1"], "limit": 100}
         self.mock_client.rget.assert_called_once_with("/users", params=expected_params)
 
         # Verify result
         self.assertEqual(len(result.response), 1)
 
     @patch("pagerduty_mcp.tools.users.get_client")
-    def test_list_users_with_query_model(self, mock_get_client):
-        """Test listing users using UserQuery model - FastMCP compatible approach."""
+    def test_list_users_with_all_params(self, mock_get_client):
+        """Test listing users using flat params."""
         mock_get_client.return_value = self.mock_client
         self.mock_client.rget.return_value = self.sample_users_list_response
 
-        # Test the new approach using UserQuery model
-        query_model = UserQuery(query="John", teams_ids=["TEAM1"], limit=10)
-        result = list_users(query_model)
+        result = list_users(query="John", teams_ids=["TEAM1"], limit=10)
 
         # Verify API call
         mock_get_client.assert_called_once()
@@ -301,6 +300,43 @@ class TestUserTools(unittest.TestCase):
 
         # Verify result
         self.assertEqual(len(result.response), 2)
+
+    @patch("pagerduty_mcp.tools.users.get_client")
+    def test_create_user_success_unwrapped_response(self, mock_get_client):
+        """Test create_user when API returns the user object directly."""
+        mock_get_client.return_value = self.mock_client
+        self.mock_client.rpost.return_value = self.sample_user_response
+
+        request = CreateUserRequest(name="John Doe", email="john.doe@example.com")
+        result = create_user(request)
+
+        self.assertIsInstance(result, User)
+        self.assertEqual(result.id, "USER123")
+
+    @patch("pagerduty_mcp.tools.users.get_client")
+    def test_create_user_calls_api_correctly(self, mock_get_client):
+        """Test that create_user calls rpost with the correct arguments."""
+        mock_get_client.return_value = self.mock_client
+        self.mock_client.rpost.return_value = self.sample_user_response
+
+        request = CreateUserRequest(name="John Doe", email="john.doe@example.com")
+        create_user(request)
+
+        self.mock_client.rpost.assert_called_once_with(
+            "/users",
+            json=request.model_dump(),
+        )
+
+    @patch("pagerduty_mcp.tools.users.get_client")
+    def test_create_user_client_error(self, mock_get_client):
+        """Test create_user propagates client exceptions."""
+        mock_get_client.return_value = self.mock_client
+        self.mock_client.rpost.side_effect = Exception("Create Error")
+
+        with self.assertRaises(Exception) as ctx:
+            create_user(CreateUserRequest(name="John Doe", email="john.doe@example.com"))
+
+        self.assertEqual(str(ctx.exception), "Create Error")
 
 
 if __name__ == "__main__":

--- a/website/docs/tools/users.md
+++ b/website/docs/tools/users.md
@@ -4,7 +4,7 @@ sidebar_position: 9
 
 # Users
 
-User tools let you retrieve information about the currently authenticated user and list all users in the account.
+User tools let you retrieve information about the currently authenticated user, list users in the account, and create new users.
 
 ## Tools
 
@@ -33,3 +33,23 @@ List users, optionally filtering by name and team IDs.
 **Example prompt:**
 
 > "List all users on the platform team"
+
+---
+
+### `create_user` *(write)*
+
+Create a new PagerDuty user account. No invitation email is sent automatically.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `request` | `CreateUserRequest` | Yes | User creation parameters including `name`, `email`, `role` (default: `"user"`), and `time_zone` (default: `"UTC"`) |
+
+**Valid roles:** `admin`, `limited_user`, `observer`, `owner`, `read_only_user`, `restricted_access`, `read_only_limited_user`, `user`
+
+:::note
+Requires `--enable-write-tools` flag.
+:::
+
+**Example prompt:**
+
+> "Create a new user account for Jane Smith with email jane.smith@example.com in the America/New_York timezone"


### PR DESCRIPTION
## Summary

**Write tool (gated by `--enable-write-tools`):** `create_user(request: CreateUserRequest)` — creates a new user in PagerDuty.

New model: `CreateUserRequest` with required `name`, `email`, and optional `role`, `time_zone` fields.

- `CreateUserRequest` added to `pagerduty_mcp/models/users.py` and exported from `models/__init__.py`
- `create_user` registered in the `write_tools` list in `tools/__init__.py`
- Dead code removed: the conditional `"user" in response` branch was unreachable (`pdpyras` always unwraps the response)
- Corresponding test for the unreachable wrapped-response path removed

## Depends on
Requires **PR #133** (`refactor/flatten-tool-signatures`) to be merged first.