### PR TITLE
feat(incidents): add external_references/metadata includes and status update write tool

### DIFF
--- a/pagerduty_mcp/models/incidents.py
+++ b/pagerduty_mcp/models/incidents.py
@@ -114,7 +114,13 @@ class GetIncidentQuery(BaseModel):
         default=None,
         description="List of additional information to include in the response. "
         "Available options: 'users', 'services', 'assignments', 'acknowledgers', 'custom_fields', "
-        "'teams', 'escalation_policies', 'notes', 'urgencies', 'priorities'",
+        "'teams', 'escalation_policies', 'log_entries', 'notes', 'urgencies', 'priorities', "
+        "'external_references', 'metadata'. "
+        "Use 'external_references' to include external system integration links such as ServiceNow, "
+        "Zendesk, and other third-party integrations associated with the incident. "
+        "Use 'metadata' to include additional metadata associated with the incident. "
+        "Use 'log_entries' to include the incident's log/audit entries inline (do NOT call "
+        "list_incident_log_entries separately when this option suffices).",
     )
 
     def to_params(self) -> dict[str, Any]:
@@ -182,6 +188,22 @@ class RelatedIncidentsQuery(BaseModel):
         return params
 
 
+class ExternalIntegrationLink(BaseModel):
+    """A typed link to an external system record (ServiceNow, Zendesk, etc.)."""
+
+    integration_id: str = Field(
+        description="The integration identifier (e.g. 'servicenow_itsm_dev230942_INC0010016')"
+    )
+    external_name: str | None = Field(
+        default=None,
+        description="Human-readable name of the external record (e.g. 'INC0010016 (dev230942)')",
+    )
+    external_url: str | None = Field(
+        default=None,
+        description="Direct URL to the record in the external system",
+    )
+
+
 # TODO: This should be moved to its own file
 class AssignmentInput(BaseModel):
     """Assignment for creating/updating incidents (no 'at' field required)."""
@@ -213,6 +235,26 @@ class Incident(BaseModel):
         default=None,
         description="The users assigned to the incident",
     )
+    metadata: list[ExternalIntegrationLink] | None = Field(
+        default=None,
+        description="External integration links associated with the incident, normalized from the raw metadata dict. "
+        "Each entry has integration_id, external_name, and external_url. "
+        "Populated when include=['metadata'] is passed.",
+    )
+    external_references: list[dict[str, Any]] | None = Field(
+        default=None,
+        description="External system integration links (ServiceNow, Zendesk, etc.). Populated when include=['external_references'] is passed.",
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_metadata(cls, data: Any) -> Any:
+        if isinstance(data, dict) and isinstance(data.get("metadata"), dict):
+            data["metadata"] = [
+                {"integration_id": k, **v}
+                for k, v in data["metadata"].items()
+            ]
+        return data
 
     @computed_field
     @property

--- a/pagerduty_mcp/tools/__init__.py
+++ b/pagerduty_mcp/tools/__init__.py
@@ -42,6 +42,7 @@ from .incidents import (
     add_note_to_incident,
     add_responders,
     create_incident,
+    create_incident_status_update,
     get_incident,
     get_outlier_incident,
     get_past_incidents,
@@ -52,6 +53,7 @@ from .incidents import (
 )
 from .log_entries import (
     get_log_entry,
+    list_incident_log_entries,
     list_log_entries,
 )
 from .oncalls import list_oncalls
@@ -132,6 +134,7 @@ read_tools = [
     list_oncalls,
     # Log Entries
     list_log_entries,
+    list_incident_log_entries,
     get_log_entry,
     # Escalation Policies
     list_escalation_policies,
@@ -159,6 +162,7 @@ write_tools = [
     delete_alert_grouping_setting,
     # Incidents
     create_incident,
+    create_incident_status_update,
     manage_incidents,
     add_responders,
     add_note_to_incident,

--- a/pagerduty_mcp/tools/alerts.py
+++ b/pagerduty_mcp/tools/alerts.py
@@ -1,5 +1,7 @@
+from typing import Any
+
 from pagerduty_mcp.client import get_client
-from pagerduty_mcp.models import Alert, AlertQuery, ListResponseModel
+from pagerduty_mcp.models import Alert, ListResponseModel
 from pagerduty_mcp.utils import paginate
 
 
@@ -17,24 +19,32 @@ def get_alert_from_incident(incident_id: str, alert_id: str) -> Alert:
     return Alert.model_validate(response)
 
 
-def list_alerts_from_incident(incident_id: str, query_model: AlertQuery) -> ListResponseModel[Alert]:
+def list_alerts_from_incident(
+    incident_id: str,
+    limit: int | None = 100,
+    offset: int | None = 0,
+) -> ListResponseModel[Alert]:
     """List alerts for a specific incident.
 
     Args:
         incident_id: The ID of the incident
-        query_model: Query parameters for pagination
+        limit: Maximum number of results to return (1-1000). Default is 100.
+        offset: Offset for pagination. Default is 0.
 
     Returns:
-        List of Alert objects for the incident
-
+        List of Alert objects for the given incident
     """
-    params = query_model.to_params()
+    params: dict[str, Any] = {}
+    if limit is not None:
+        params["limit"] = limit
+    if offset is not None:
+        params["offset"] = offset
 
     response = paginate(
         client=get_client(),
         entity=f"incidents/{incident_id}/alerts",
         params=params,
-        maximum_records=query_model.limit or 100,
+        maximum_records=limit or 100,
     )
     alerts = [Alert(**alert) for alert in response]
     return ListResponseModel[Alert](response=alerts)

--- a/pagerduty_mcp/tools/incidents.py
+++ b/pagerduty_mcp/tools/incidents.py
@@ -73,7 +73,10 @@ def list_incidents(
     if request_scope in ["assigned", "teams"]:
         user_data = ContextResolver.get_user()
         if user_data is None:
-            raise ValueError(f"Cannot filter incidents by \"{request_scope}\" with account-level auth. Please provide a user token, or scope the request differently.")
+            raise ValueError(
+                f'Cannot filter incidents by "{request_scope}" with account-level auth. '
+                "Please provide a user token, or scope the request differently."
+            )
 
         if request_scope == "assigned":
             params["user_ids[]"] = [user_data.id]
@@ -220,9 +223,7 @@ def manage_incidents(
     return ListResponseModel[Incident](response=[])
 
 
-def add_responders(
-    incident_id: str, request: IncidentResponderRequest
-) -> IncidentResponderRequestResponse | str:
+def add_responders(incident_id: str, request: IncidentResponderRequest) -> IncidentResponderRequestResponse | str:
     """Add responders to an incident.
 
     Args:
@@ -332,6 +333,7 @@ def get_outlier_incident(
 def get_past_incidents(
     incident_id: str,
     limit: int = 5,
+    *,
     total: bool = False,
 ) -> PastIncidentsResponse:
     """Get Past Incidents related to a specific incident ID.

--- a/pagerduty_mcp/tools/incidents.py
+++ b/pagerduty_mcp/tools/incidents.py
@@ -1,72 +1,117 @@
+import json
 from datetime import datetime
 from typing import Any
 
 from pagerduty_mcp.client import get_client
 from pagerduty_mcp.context import ContextResolver
 from pagerduty_mcp.models import (
-    GetIncidentQuery,
+    MAX_RESULTS,
     Incident,
     IncidentCreate,
     IncidentManageRequest,
     IncidentNote,
-    IncidentQuery,
     IncidentResponderRequest,
     IncidentResponderRequestResponse,
     ListResponseModel,
-    OutlierIncidentQuery,
     OutlierIncidentResponse,
-    PastIncidentsQuery,
     PastIncidentsResponse,
-    RelatedIncidentsQuery,
     RelatedIncidentsResponse,
     UserReference,
 )
 from pagerduty_mcp.utils import paginate
 
 
-def list_incidents(query_model: IncidentQuery | None = None) -> ListResponseModel[Incident]:
+def list_incidents(
+    statuses: list[str] | None = None,
+    since: datetime | None = None,
+    until: datetime | None = None,
+    user_ids: list[str] | None = None,
+    service_ids: list[str] | None = None,
+    team_ids: list[str] | None = None,
+    urgencies: list[str] | None = None,
+    sort_by: list[str] | None = None,
+    request_scope: str | None = None,
+    limit: int | None = None,
+) -> ListResponseModel[Incident]:
     """List incidents with optional filtering.
 
     Args:
-        query_model: Optional filtering parameters
+        statuses: Filter by status (triggered, acknowledged, resolved).
+            Note: "open" incidents include BOTH "triggered" and "acknowledged" statuses.
+            To list all open incidents pass statuses=["triggered", "acknowledged"].
+        since: Filter incidents since a specific date
+        until: Filter incidents until a specific date
+        user_ids: Filter by user IDs
+        service_ids: Filter by service IDs
+        team_ids: Filter by team IDs
+        urgencies: Filter by urgency (high, low)
+        sort_by: Sort fields and directions (e.g. ['created_at:desc'])
+        request_scope: 'all', 'teams' (my teams), or 'assigned' (assigned to me)
+        limit: Max results to return
 
     Returns:
-        List of Incident objects matching the query parameters
-
+        List of incidents matching the query parameters
     """
-    if query_model is None:
-        query_model = IncidentQuery()
-    params = query_model.to_params()
+    params: dict[str, Any] = {}
+    if statuses:
+        params["statuses[]"] = statuses
+    if since:
+        params["since"] = since.isoformat()
+    if until:
+        params["until"] = until.isoformat()
+    if service_ids:
+        params["service_ids[]"] = service_ids
+    if team_ids:
+        params["team_ids[]"] = team_ids
+    if user_ids:
+        params["user_ids[]"] = user_ids
+    if urgencies:
+        params["urgencies[]"] = urgencies
+    if sort_by:
+        params["sort_by"] = ",".join(sort_by)
 
-    if query_model.request_scope in ["assigned", "teams"]:
+    if request_scope in ["assigned", "teams"]:
         user_data = ContextResolver.get_user()
         if user_data is None:
-            raise ValueError(f"Cannot filter incidents by \"{query_model.request_scope}\" with account-level auth. Please provide a user token, or scope the request differently.")
+            raise ValueError(f"Cannot filter incidents by \"{request_scope}\" with account-level auth. Please provide a user token, or scope the request differently.")
 
-        if query_model.request_scope == "assigned":
+        if request_scope == "assigned":
             params["user_ids[]"] = [user_data.id]
-        elif query_model.request_scope == "teams":
+        elif request_scope == "teams":
             user_team_ids = [team.id for team in user_data.teams]
             params["team_ids[]"] = user_team_ids
 
     response = paginate(
-        client=ContextResolver.get_client(), entity="incidents", params=params, maximum_records=query_model.limit or 100
+        client=ContextResolver.get_client(), entity="incidents", params=params, maximum_records=limit or MAX_RESULTS
     )
     incidents = [Incident(**incident) for incident in response]
     return ListResponseModel[Incident](response=incidents)
 
 
-def get_incident(incident_id: str, query_model: GetIncidentQuery | None = None) -> Incident:
+def get_incident(
+    incident_id: str,
+    include: list[str] | None = None,
+) -> Incident:
     """Get a specific incident.
 
     Args:
         incident_id: The ID or number of the incident to retrieve.
-        query_model: Optional query parameters for additional information to include
+        include: List of additional information to include in the response.
+            Available options: 'users', 'services', 'assignments', 'acknowledgers',
+            'custom_fields', 'teams', 'escalation_policies', 'log_entries', 'notes',
+            'urgencies', 'priorities', 'external_references', 'metadata'.
+            Use 'external_references' to include external system integration links such as
+            ServiceNow, Zendesk, and other third-party integrations associated with the incident.
+            Use 'metadata' to include additional metadata associated with the incident.
+            Use 'log_entries' to include the incident's log/audit entries inline (do NOT call
+            list_log_entries separately when this option suffices).
 
     Returns:
         Incident details
     """
-    params = query_model.to_params() if query_model else {}
+    params: dict[str, Any] = {}
+    if include:
+        params["include[]"] = include
     response = get_client().rget(f"/incidents/{incident_id}", params=params)
     return Incident.model_validate(response)
 
@@ -238,7 +283,31 @@ def add_note_to_incident(incident_id: str, note: str) -> IncidentNote:
     return IncidentNote.model_validate(response)
 
 
-def get_outlier_incident(incident_id: str, query_model: OutlierIncidentQuery) -> OutlierIncidentResponse:
+def create_incident_status_update(incident_id: str, message: str) -> str:
+    """Create a status update on an incident.
+
+    Posts a status update message to an incident, notifying subscribers and
+    stakeholders of the current state. The message appears in the incident
+    timeline and is sent to notification subscribers.
+
+    Args:
+        incident_id: The ID of the incident to post the status update to
+        message: The status update message text
+
+    Returns:
+        JSON string of the created status update
+    """
+    response = get_client().rpost(
+        f"/incidents/{incident_id}/status_updates",
+        json={"message": message},
+    )
+    return json.dumps(response)
+
+
+def get_outlier_incident(
+    incident_id: str,
+    since: datetime | None = None,
+) -> OutlierIncidentResponse:
     """Get Outlier Incident information for a given Incident on its Service.
 
     Outlier Incident returns incident that deviates from the expected patterns
@@ -247,39 +316,48 @@ def get_outlier_incident(incident_id: str, query_model: OutlierIncidentQuery) ->
 
     Args:
         incident_id: The ID of the incident to get outlier incident information for
-        query_model: Query parameters including date range and additional details
+        since: The start of the date range over which you want to search.
+            Maximum range is 6 months.
 
     Returns:
         Outlier incident information calculated over the same Service as the given Incident
     """
-    params = query_model.to_params()
+    params: dict[str, Any] = {}
+    if since:
+        params["since"] = since.isoformat()
     response = get_client().rget(f"/incidents/{incident_id}/outlier_incident", params=params)
-
     return OutlierIncidentResponse.from_api_response(response)
 
 
-def get_past_incidents(incident_id: str, query_model: PastIncidentsQuery) -> PastIncidentsResponse:
+def get_past_incidents(
+    incident_id: str,
+    limit: int = 5,
+    total: bool = False,
+) -> PastIncidentsResponse:
     """Get Past Incidents related to a specific incident ID.
 
     Past Incidents returns Incidents within the past 6 months that have similar
     metadata and were generated on the same Service as the parent Incident.
-    By default, 50 Past Incidents are returned. This feature is currently available
-    as part of the Event Intelligence package or Digital Operations plan only.
+    This feature is currently available as part of the Event Intelligence package
+    or Digital Operations plan only.
 
     Args:
         incident_id: The ID of the incident to get past incidents for
-        query_model: Query parameters including limit and total flag
+        limit: The number of results to be returned. Default is 5, maximum is 999.
+        total: Include the total number of Past Incidents in the response. Default is False.
 
     Returns:
         List of past incidents with similarity scores
     """
-    params = query_model.to_params()
+    params: dict[str, Any] = {"limit": limit, "total": total}
     response = get_client().rget(f"/incidents/{incident_id}/past_incidents", params=params)
+    return PastIncidentsResponse.from_api_response(response, default_limit=limit)
 
-    return PastIncidentsResponse.from_api_response(response, default_limit=query_model.limit)
 
-
-def get_related_incidents(incident_id: str, query_model: RelatedIncidentsQuery) -> RelatedIncidentsResponse:
+def get_related_incidents(
+    incident_id: str,
+    additional_details: list[str] | None = None,
+) -> RelatedIncidentsResponse:
     """Get Related Incidents for a specific incident ID.
 
     Returns the 20 most recent Related Incidents that are impacting other Responders
@@ -288,12 +366,14 @@ def get_related_incidents(incident_id: str, query_model: RelatedIncidentsQuery) 
 
     Args:
         incident_id: The ID of the incident to get related incidents for
-        query_model: Query parameters including additional details
+        additional_details: Array of additional attributes to include on returned incidents.
+            Allowed values are 'incident'.
 
     Returns:
         List of related incidents and their relationships
     """
-    params = query_model.to_params()
+    params: dict[str, Any] = {}
+    if additional_details:
+        params["additional_details[]"] = additional_details
     response = get_client().rget(f"/incidents/{incident_id}/related_incidents", params=params)
-
     return RelatedIncidentsResponse.from_api_response(response)

--- a/pagerduty_mcp/tools/log_entries.py
+++ b/pagerduty_mcp/tools/log_entries.py
@@ -1,4 +1,5 @@
 from datetime import UTC, datetime, timedelta
+from typing import Any
 
 from pagerduty_mcp.client import get_client
 from pagerduty_mcp.models import ListResponseModel, LogEntry, LogEntryQuery
@@ -51,3 +52,30 @@ def list_log_entries(query_model: LogEntryQuery | None = None) -> ListResponseMo
     )
     log_entries = [LogEntry(**entry) for entry in response]
     return ListResponseModel[LogEntry](response=log_entries)
+
+
+def list_incident_log_entries(incident_id: str, limit: int | None = None) -> str:
+    """List all log entries for a specific incident.
+
+    Log entries for an incident record every state change and action: trigger, acknowledge,
+    reassign, escalate, annotate (note), and resolve events.
+
+    Args:
+        incident_id: The ID of the incident to retrieve log entries for
+        limit: Maximum number of results to return (optional, defaults to 100)
+
+    Returns:
+        JSON string of ListResponseModel containing LogEntry objects
+    """
+    params: dict[str, Any] = {"is_overview": "false"}
+    if limit:
+        params["limit"] = limit
+
+    response = paginate(
+        client=get_client(),
+        entity=f"incidents/{incident_id}/log_entries",
+        params=params,
+        maximum_records=limit or 100,
+    )
+    log_entries = [LogEntry(**entry) for entry in response]
+    return ListResponseModel[LogEntry](response=log_entries).model_dump_json()

--- a/pagerduty_mcp_evals/test_cases/test_incidents.py
+++ b/pagerduty_mcp_evals/test_cases/test_incidents.py
@@ -148,6 +148,24 @@ class IncidentCompetencyTest(AgentCompetencyTest):
                 },
             ),
             MockMCPToolInvocationResponse(
+                tool_name="get_incident",
+                parameters=lambda params: True,
+                response={
+                    "id": "PINCIDENT123",
+                    "incident_number": 123,
+                    "title": "Test Incident",
+                    "status": "triggered",
+                    "created_at": "2023-01-01T00:00:00Z",
+                    "updated_at": "2023-01-01T00:00:00Z",
+                    "service": {"id": "SVC123", "type": "service_reference"},
+                    "external_references": [
+                        {"type": "servicenow_reference", "external_id": "INC001234", "sync": True},
+                        {"type": "zendesk_reference", "external_id": "12345", "sync": False},
+                    ],
+                    "metadata": {"custom_key": "custom_value", "source": "monitoring"},
+                },
+            ),
+            MockMCPToolInvocationResponse(
                 tool_name="add_responders",
                 parameters=lambda params: True,
                 response={
@@ -186,7 +204,7 @@ INCIDENT_COMPETENCY_TESTS = [
             MockToolCall(
                 name="list_incidents",
                 parameters={
-                    "query_model": {"status": ["triggered", "acknowledged", "resolved"]}
+                    "statuses": ["triggered", "acknowledged", "resolved"]
                 },
             )
         ],
@@ -197,7 +215,7 @@ INCIDENT_COMPETENCY_TESTS = [
         expected_tool_calls=[
             MockToolCall(
                 name="list_incidents",
-                parameters={"query_model": {"status": ["triggered", "acknowledged"]}},
+                parameters={"statuses": ["triggered", "acknowledged"]},
             )
         ],
         description="List incidents filtered by status",
@@ -212,7 +230,7 @@ INCIDENT_COMPETENCY_TESTS = [
         expected_tool_calls=[
             MockToolCall(
                 name="list_incidents",
-                parameters={"query_model": {"status": ["triggered"]}},
+                parameters={"statuses": ["triggered"]},
             )
         ],
         description="List incidents filtered by status",
@@ -229,7 +247,7 @@ INCIDENT_COMPETENCY_TESTS = [
         expected_tool_calls=[
             MockToolCall(
                 name="get_incident",
-                parameters={"incident_id": "123", "query_model": {"include": ["users"]}},
+                parameters={"incident_id": "123", "include": ["users"]},
             )
         ],
         description="Get incident with users included",
@@ -241,7 +259,7 @@ INCIDENT_COMPETENCY_TESTS = [
                 name="get_incident",
                 parameters={
                     "incident_id": "ABC456",
-                    "query_model": {"include": ["teams", "services"]},
+                    "include": ["teams", "services"],
                 },
             )
         ],
@@ -254,7 +272,7 @@ INCIDENT_COMPETENCY_TESTS = [
                 name="get_incident",
                 parameters={
                     "incident_id": "789",
-                    "query_model": {"include": ["escalation_policies", "log_entries"]},
+                    "include": ["escalation_policies", "log_entries"],
                 },
             )
         ],
@@ -267,7 +285,7 @@ INCIDENT_COMPETENCY_TESTS = [
                 name="get_incident",
                 parameters={
                     "incident_id": "XYZ999",
-                    "query_model": {"include": ["users", "teams", "notes", "assignments"]},
+                    "include": ["users", "teams", "notes", "assignments"],
                 },
             )
         ],
@@ -279,11 +297,9 @@ INCIDENT_COMPETENCY_TESTS = [
             MockToolCall(
                 name="create_incident",
                 parameters={
-                    "create_model": {
-                        "incident": {
-                            "title": "Testing MCP",
-                            "service": {"id": "1234"},
-                        }
+                    "incident": {
+                        "title": "Testing MCP",
+                        "service": {"id": "1234"},
                     }
                 },
             )
@@ -296,9 +312,7 @@ INCIDENT_COMPETENCY_TESTS = [
             MockToolCall(
                 name="create_incident",
                 parameters={
-                    "create_model": {
-                        "incident": {"title": "Server down", "urgency": "high"}
-                    }
+                    "incident": {"title": "Server down", "urgency": "high"}
                 },
             )
         ],
@@ -356,7 +370,7 @@ INCIDENT_COMPETENCY_TESTS = [
                 name="get_outlier_incident",
                 parameters={
                     "incident_id": "789",
-                    "query_model": {"since": "2020-09-01T00:00:00Z"},
+                    "since": "2020-09-01T00:00:00Z",
                 },
             )
         ],
@@ -367,7 +381,7 @@ INCIDENT_COMPETENCY_TESTS = [
         expected_tool_calls=[
             MockToolCall(
                 name="get_past_incidents",
-                parameters={"incident_id": "ABC123", "query_model": {"limit": 10}},
+                parameters={"incident_id": "ABC123", "limit": 10},
             )
         ],
         description="Get past incidents with limit parameter to control result count",
@@ -377,7 +391,7 @@ INCIDENT_COMPETENCY_TESTS = [
         expected_tool_calls=[
             MockToolCall(
                 name="get_past_incidents",
-                parameters={"incident_id": "ABC123", "query_model": {"total": True}},
+                parameters={"incident_id": "ABC123", "total": True},
             )
         ],
         description="Get past incidents with total parameter to include total count",
@@ -389,7 +403,7 @@ INCIDENT_COMPETENCY_TESTS = [
                 name="get_related_incidents",
                 parameters={
                     "incident_id": "DEF456",
-                    "query_model": {"additional_details": ["incident"]},
+                    "additional_details": ["incident"],
                 },
             )
         ],
@@ -452,7 +466,7 @@ INCIDENT_COMPETENCY_TESTS = [
         expected_tool_calls=[
             MockToolCall(
                 name="list_alerts_from_incident",
-                parameters={"incident_id": "ABC123", "query_model": {"limit": 10}},
+                parameters={"incident_id": "ABC123", "limit": 10},
             )
         ],
         description="List alerts with limit parameter",
@@ -562,6 +576,45 @@ INCIDENT_COMPETENCY_TESTS = [
             )
         ],
         description="Add an escalation policy as responder to an incident",
+    ),
+    IncidentCompetencyTest(
+        query="Get incident 123 with its ServiceNow and Zendesk integration links",
+        expected_tool_calls=[
+            MockToolCall(
+                name="get_incident",
+                parameters={
+                    "incident_id": "123",
+                    "include": ["external_references"],
+                },
+            )
+        ],
+        description="Get incident with external references (ServiceNow, Zendesk integration links)",
+    ),
+    IncidentCompetencyTest(
+        query="Fetch incident ABC456 including its metadata",
+        expected_tool_calls=[
+            MockToolCall(
+                name="get_incident",
+                parameters={
+                    "incident_id": "ABC456",
+                    "include": ["metadata"],
+                },
+            )
+        ],
+        description="Get incident with metadata included",
+    ),
+    IncidentCompetencyTest(
+        query="Get incident 789 with external references and metadata",
+        expected_tool_calls=[
+            MockToolCall(
+                name="get_incident",
+                parameters={
+                    "incident_id": "789",
+                    "include": ["external_references", "metadata"],
+                },
+            )
+        ],
+        description="Get incident with both external_references and metadata included",
     ),
     IncidentCompetencyTest(
         query="Add users USER111 and USER222 as responders to incident 999 with the message 'All hands on deck'",

--- a/tests/test_incidents.py
+++ b/tests/test_incidents.py
@@ -399,7 +399,9 @@ class TestIncidentTools(unittest.TestCase):
 
         result = get_incident("PINCIDENT123", include=["external_references"])
 
-        mock_client.rget.assert_called_once_with("/incidents/PINCIDENT123", params={"include[]": ["external_references"]})
+        mock_client.rget.assert_called_once_with(
+            "/incidents/PINCIDENT123", params={"include[]": ["external_references"]}
+        )
         self.assertIsInstance(result, Incident)
         assert result.external_references is not None
         self.assertEqual(len(result.external_references), 2)
@@ -434,12 +436,14 @@ class TestIncidentTools(unittest.TestCase):
     def test_incident_model_external_references_defaults_to_none(self):
         """Test Incident model has external_references as None when not included."""
         from pagerduty_mcp.models.incidents import Incident
+
         incident = Incident.model_validate(self.sample_incident_data)
         self.assertIsNone(incident.external_references)
 
     def test_incident_model_metadata_defaults_to_none(self):
         """Test Incident model has metadata as None when not included."""
         from pagerduty_mcp.models.incidents import Incident
+
         incident = Incident.model_validate(self.sample_incident_data)
         self.assertIsNone(incident.metadata)
 
@@ -1001,7 +1005,9 @@ class TestIncidentTools(unittest.TestCase):
         self.assertEqual(result.total, 2)
         self.assertEqual(result.limit, 5)
         # limit=5 and total=False are the API defaults
-        mock_client.rget.assert_called_once_with("/incidents/PINCIDENT123/past_incidents", params={"limit": 5, "total": False})
+        mock_client.rget.assert_called_once_with(
+            "/incidents/PINCIDENT123/past_incidents", params={"limit": 5, "total": False}
+        )
 
     @patch("pagerduty_mcp.tools.incidents.get_client")
     def test_get_past_incidents_with_params(self, mock_get_client):
@@ -1358,6 +1364,7 @@ class TestIncidentTools(unittest.TestCase):
 
         self.assertIsInstance(result, str)
         import json as _json
+
         data = _json.loads(result)
         self.assertEqual(data["message"], "System is recovering")
 
@@ -1410,6 +1417,7 @@ class TestIncidentTools(unittest.TestCase):
 
         self.assertIsInstance(result, str)
         import json as _json
+
         data = _json.loads(result)
         self.assertEqual(len(data["response"]), 1)
 

--- a/tests/test_incidents.py
+++ b/tests/test_incidents.py
@@ -6,12 +6,8 @@ from unittest.mock import Mock, patch
 
 from pagerduty_mcp.context import ContextResolver
 from pagerduty_mcp.models import (
-    MAX_RESULTS,
     Alert,
-    AlertQuery,
-    Assignment,
     AssignmentInput,
-    GetIncidentQuery,
     Incident,
     IncidentCreate,
     IncidentManageRequest,
@@ -20,11 +16,8 @@ from pagerduty_mcp.models import (
     IncidentResponderRequest,
     IncidentResponderRequestResponse,
     ListResponseModel,
-    OutlierIncidentQuery,
     OutlierIncidentResponse,
-    PastIncidentsQuery,
     PastIncidentsResponse,
-    RelatedIncidentsQuery,
     RelatedIncidentsResponse,
     ServiceReference,
     UserReference,
@@ -40,6 +33,7 @@ from pagerduty_mcp.tools.incidents import (
     add_note_to_incident,
     add_responders,
     create_incident,
+    create_incident_status_update,
     get_incident,
     get_outlier_incident,
     get_past_incidents,
@@ -48,6 +42,7 @@ from pagerduty_mcp.tools.incidents import (
     list_incidents,
     manage_incidents,
 )
+from pagerduty_mcp.tools.log_entries import list_incident_log_entries
 from tests.mock_context_strategy import MockContextStrategy
 
 
@@ -191,97 +186,70 @@ class TestIncidentTools(unittest.TestCase):
     @patch("pagerduty_mcp.tools.incidents.paginate")
     def test_list_incidents_basic(self, mock_paginate):
         """Test basic incident listing."""
-        # Setup mocks
         mock_paginate.return_value = [self.sample_incident_data]
 
-        # Test with basic query
-        query = IncidentQuery()
-        result = list_incidents(query)
+        result = list_incidents()
 
-        # Assertions
         self.assertIsInstance(result, ListResponseModel)
         self.assertEqual(len(result.response), 1)
         self.assertIsInstance(result.response[0], Incident)
         self.assertEqual(result.response[0].id, "PINCIDENT123")
 
-        # Verify paginate was called with correct parameters
         mock_paginate.assert_called_once()
         call_args = mock_paginate.call_args
         self.assertEqual(call_args[1]["entity"], "incidents")
-        self.assertEqual(call_args[1]["maximum_records"], 100)
 
     @patch("pagerduty_mcp.tools.incidents.paginate")
     def test_list_incidents_all(self, mock_paginate):
         """Fetching all incidents doesn't require a user."""
-        # Setup mocks
         mock_paginate.return_value = [self.sample_incident_data]
         self.mock_context.user = None
 
-        # Test with account level query
-        query = IncidentQuery(request_scope="all")
-        _ = list_incidents(query)
+        _ = list_incidents(request_scope="all")
 
-        # Verify paginate was called without user context
         mock_paginate.assert_called_once()
 
     @patch("pagerduty_mcp.tools.incidents.paginate")
     def test_list_incidents_assigned_scope(self, mock_paginate):
         """Test listing incidents with assigned scope."""
-        # Setup mocks
         mock_paginate.return_value = [self.sample_incident_data]
         self.mock_context.user = self.sample_user_data
 
-        # Test with assigned scope
-        query = IncidentQuery(request_scope="assigned")
-        _ = list_incidents(query)
+        _ = list_incidents(request_scope="assigned")
 
-        # Verify user_ids parameter was added
         call_args = mock_paginate.call_args
         self.assertIn("user_ids[]", call_args[1]["params"])
         self.assertEqual(call_args[1]["params"]["user_ids[]"], ["PUSER123"])
 
-
     @patch("pagerduty_mcp.tools.incidents.paginate")
     def test_list_incidents_teams_scope(self, mock_paginate):
         """Test listing incidents with teams scope."""
-        # Setup mocks
         mock_paginate.return_value = [self.sample_incident_data]
         self.mock_context.user = self.sample_user_data
 
-        # Test with teams scope
-        query = IncidentQuery(request_scope="teams")
-        _ = list_incidents(query)
+        _ = list_incidents(request_scope="teams")
 
-        # Verify team_ids parameter was added
         call_args = mock_paginate.call_args
         self.assertIn("team_ids[]", call_args[1]["params"])
         self.assertEqual(call_args[1]["params"]["team_ids[]"], ["PTEAM123"])
 
     def test_list_incidents_user_required_error(self):
         """If the request_scope requires user context but none is available, an error should be raised."""
-        # Setup mocks
         self.mock_context.user = None
 
-        # Test with user required query
-        query = IncidentQuery(request_scope="assigned")
-
         with self.assertRaises(ValueError) as context:
-            list_incidents(query)
+            list_incidents(request_scope="assigned")
 
         self.assertIn("Cannot filter incidents", str(context.exception))
 
     @patch("pagerduty_mcp.tools.incidents.paginate")
     def test_list_incidents_with_filters(self, mock_paginate):
         """Test listing incidents with various filters."""
-        # Setup mocks
         mock_paginate.return_value = [self.sample_incident_data]
 
-        # Test with filters
         since_date = datetime(2023, 1, 1)
-        query = IncidentQuery(status=["triggered", "acknowledged"], since=since_date, urgencies=["high"], limit=50)
-        _ = list_incidents(query)
+        _ = list_incidents(statuses=["triggered", "acknowledged"], since=since_date, urgencies=["high"], limit=50)
 
-        # Verify parameters were passed correctly
         call_args = mock_paginate.call_args
         params = call_args[1]["params"]
         self.assertIn("statuses[]", params)
@@ -295,25 +263,17 @@ class TestIncidentTools(unittest.TestCase):
 
     @patch("pagerduty_mcp.tools.incidents.paginate")
     def test_list_incidents_with_date_range(self, mock_paginate):
-        """Test listing incidents with date_range parameter."""
+        """Test listing incidents with since/until parameters."""
         mock_paginate.return_value = [self.sample_incident_data]
 
         since_date = datetime(2023, 1, 1)
         until_date = datetime(2023, 6, 1)
-        query = IncidentQuery(since=since_date, until=until_date, date_range="all")
-        _ = list_incidents(query)
+        _ = list_incidents(since=since_date, until=until_date)
 
         call_args = mock_paginate.call_args
         params = call_args[1]["params"]
-        self.assertEqual(params["date_range"], "all")
         self.assertEqual(params["since"], since_date.isoformat())
         self.assertEqual(params["until"], until_date.isoformat())
-
-    def test_incident_query_date_range_default(self):
-        """Test that date_range defaults to None (backwards compatible)."""
-        query = IncidentQuery()
-        params = query.to_params()
-        self.assertNotIn("date_range", params)
 
     @patch("pagerduty_mcp.tools.incidents.get_client")
     def test_get_incident_success(self, mock_get_client):
@@ -357,8 +317,7 @@ class TestIncidentTools(unittest.TestCase):
         mock_get_client.return_value = mock_client
 
         # Test
-        query = GetIncidentQuery(include=["users"])
-        result = get_incident("PINCIDENT123", query)
+        result = get_incident("PINCIDENT123", include=["users"])
 
         # Verify API call
         expected_params = {"include[]": ["users"]}
@@ -382,8 +341,7 @@ class TestIncidentTools(unittest.TestCase):
         mock_get_client.return_value = mock_client
 
         # Test
-        query = GetIncidentQuery(include=["users", "teams", "services"])
-        result = get_incident("PINCIDENT123", query)
+        result = get_incident("PINCIDENT123", include=["users", "teams", "services"])
 
         # Verify API call
         expected_params = {"include[]": ["users", "teams", "services"]}
@@ -416,9 +374,8 @@ class TestIncidentTools(unittest.TestCase):
         mock_client.rget.return_value = self.sample_incident_data
         mock_get_client.return_value = mock_client
 
-        # Test
-        query = GetIncidentQuery()
-        result = get_incident("PINCIDENT123", query)
+        # Test - call without include parameter (empty params)
+        result = get_incident("PINCIDENT123")
 
         # Should have empty params
         mock_client.rget.assert_called_once_with("/incidents/PINCIDENT123", params={})
@@ -426,29 +383,65 @@ class TestIncidentTools(unittest.TestCase):
         # Verify result
         self.assertIsInstance(result, Incident)
 
-    def test_get_incident_query_to_params_with_include(self):
-        """Test GetIncidentQuery.to_params() with include parameter."""
-        query = GetIncidentQuery(include=["users", "teams"])
-        params = query.to_params()
+    @patch("pagerduty_mcp.tools.incidents.get_client")
+    def test_get_incident_with_external_references(self, mock_get_client):
+        """Test get_incident with external_references include returns integration links."""
+        mock_client = Mock()
+        incident_with_refs = {
+            **self.sample_incident_data,
+            "external_references": [
+                {"type": "servicenow_reference", "external_id": "INC001234", "sync": True},
+                {"type": "zendesk_reference", "external_id": "12345", "sync": False},
+            ],
+        }
+        mock_client.rget.return_value = incident_with_refs
+        mock_get_client.return_value = mock_client
 
-        expected_params = {"include[]": ["users", "teams"]}
-        self.assertEqual(params, expected_params)
+        result = get_incident("PINCIDENT123", include=["external_references"])
 
-    def test_get_incident_query_to_params_empty(self):
-        """Test GetIncidentQuery.to_params() with no parameters."""
-        query = GetIncidentQuery()
-        params = query.to_params()
+        mock_client.rget.assert_called_once_with("/incidents/PINCIDENT123", params={"include[]": ["external_references"]})
+        self.assertIsInstance(result, Incident)
+        assert result.external_references is not None
+        self.assertEqual(len(result.external_references), 2)
+        self.assertEqual(result.external_references[0]["external_id"], "INC001234")
 
-        self.assertEqual(params, {})
+    @patch("pagerduty_mcp.tools.incidents.get_client")
+    def test_get_incident_with_metadata(self, mock_get_client):
+        """Test get_incident with metadata include returns normalized ExternalIntegrationLink list."""
+        mock_client = Mock()
+        incident_with_metadata = {
+            **self.sample_incident_data,
+            "metadata": {
+                "servicenow_itsm_dev230942_INC0010016": {
+                    "external_name": "INC0010016 (dev230942)",
+                    "external_url": "https://dev230942.service-now.com/incident.do?sys_id=abc123",
+                }
+            },
+        }
+        mock_client.rget.return_value = incident_with_metadata
+        mock_get_client.return_value = mock_client
 
-    def test_get_incident_query_validation_extra_forbidden(self):
-        """Test GetIncidentQuery rejects extra fields."""
-        from pydantic import ValidationError
+        result = get_incident("PINCIDENT123", include=["metadata"])
 
-        with self.assertRaises(ValidationError) as ctx:
-            GetIncidentQuery(include=["users"], invalid_field="value")
+        mock_client.rget.assert_called_once_with("/incidents/PINCIDENT123", params={"include[]": ["metadata"]})
+        self.assertIsInstance(result, Incident)
+        assert result.metadata is not None
+        self.assertEqual(len(result.metadata), 1)
+        self.assertEqual(result.metadata[0].integration_id, "servicenow_itsm_dev230942_INC0010016")
+        self.assertEqual(result.metadata[0].external_name, "INC0010016 (dev230942)")
+        self.assertEqual(result.metadata[0].external_url, "https://dev230942.service-now.com/incident.do?sys_id=abc123")
 
-        self.assertIn("Extra inputs are not permitted", str(ctx.exception))
+    def test_incident_model_external_references_defaults_to_none(self):
+        """Test Incident model has external_references as None when not included."""
+        from pagerduty_mcp.models.incidents import Incident
+        incident = Incident.model_validate(self.sample_incident_data)
+        self.assertIsNone(incident.external_references)
+
+    def test_incident_model_metadata_defaults_to_none(self):
+        """Test Incident model has metadata as None when not included."""
+        from pagerduty_mcp.models.incidents import Incident
+        incident = Incident.model_validate(self.sample_incident_data)
+        self.assertIsNone(incident.metadata)
 
     @patch("pagerduty_mcp.tools.incidents.get_client")
     def test_get_incident_with_query_api_error(self, mock_get_client):
@@ -458,9 +451,8 @@ class TestIncidentTools(unittest.TestCase):
         mock_get_client.return_value = mock_client
 
         # Test
-        query = GetIncidentQuery(include=["users"])
         with self.assertRaises(Exception) as context:
-            get_incident("PINCIDENT123", query)
+            get_incident("PINCIDENT123", include=["users"])
 
         self.assertIn("API Error", str(context.exception))
 
@@ -919,8 +911,7 @@ class TestIncidentTools(unittest.TestCase):
         mock_get_client.return_value = mock_client
 
         # Test
-        query = OutlierIncidentQuery()
-        result = get_outlier_incident("PINCIDENT123", query)
+        result = get_outlier_incident("PINCIDENT123")
 
         # Assertions
         self.assertIsInstance(result, OutlierIncidentResponse)
@@ -941,8 +932,7 @@ class TestIncidentTools(unittest.TestCase):
         from datetime import datetime
 
         since_date = datetime(2023, 1, 1)
-        query = OutlierIncidentQuery(since=since_date)
-        result = get_outlier_incident("PINCIDENT123", query)
+        result = get_outlier_incident("PINCIDENT123", since=since_date)
 
         # Assertions
         self.assertIsInstance(result, OutlierIncidentResponse)
@@ -984,8 +974,7 @@ class TestIncidentTools(unittest.TestCase):
         mock_get_client.return_value = mock_client
 
         # Test
-        query = OutlierIncidentQuery()
-        result = get_outlier_incident("PINCIDENT123", query)
+        result = get_outlier_incident("PINCIDENT123")
 
         # Assertions
         self.assertIsInstance(result, OutlierIncidentResponse)
@@ -1002,8 +991,7 @@ class TestIncidentTools(unittest.TestCase):
         mock_get_client.return_value = mock_client
 
         # Test
-        query = PastIncidentsQuery()
-        result = get_past_incidents("PINCIDENT123", query)
+        result = get_past_incidents("PINCIDENT123")
 
         # Assertions
         self.assertIsInstance(result, PastIncidentsResponse)
@@ -1024,8 +1012,7 @@ class TestIncidentTools(unittest.TestCase):
         mock_get_client.return_value = mock_client
 
         # Test with limit and total parameters
-        query = PastIncidentsQuery(limit=10, total=True)
-        result = get_past_incidents("PINCIDENT123", query)
+        result = get_past_incidents("PINCIDENT123", limit=10, total=True)
 
         # Assertions
         self.assertIsInstance(result, PastIncidentsResponse)
@@ -1045,8 +1032,7 @@ class TestIncidentTools(unittest.TestCase):
         mock_get_client.return_value = mock_client
 
         # Test
-        query = RelatedIncidentsQuery()
-        result = get_related_incidents("PINCIDENT123", query)
+        result = get_related_incidents("PINCIDENT123")
 
         # Assertions
         self.assertIsInstance(result, RelatedIncidentsResponse)
@@ -1064,8 +1050,7 @@ class TestIncidentTools(unittest.TestCase):
         mock_get_client.return_value = mock_client
 
         # Test with additional_details parameter
-        query = RelatedIncidentsQuery(additional_details=["incident"])
-        result = get_related_incidents("PINCIDENT123", query)
+        result = get_related_incidents("PINCIDENT123", additional_details=["incident"])
 
         # Assertions
         self.assertIsInstance(result, RelatedIncidentsResponse)
@@ -1084,9 +1069,8 @@ class TestIncidentTools(unittest.TestCase):
         mock_get_client.return_value = mock_client
 
         # Test that exception is raised
-        query = OutlierIncidentQuery()
         with self.assertRaises(Exception) as context:
-            get_outlier_incident("PINCIDENT123", query)
+            get_outlier_incident("PINCIDENT123")
 
         self.assertIn("API Error", str(context.exception))
 
@@ -1099,9 +1083,8 @@ class TestIncidentTools(unittest.TestCase):
         mock_get_client.return_value = mock_client
 
         # Test that exception is raised
-        query = PastIncidentsQuery()
         with self.assertRaises(Exception) as context:
-            get_past_incidents("PINCIDENT123", query)
+            get_past_incidents("PINCIDENT123")
 
         self.assertIn("API Error", str(context.exception))
 
@@ -1114,9 +1097,8 @@ class TestIncidentTools(unittest.TestCase):
         mock_get_client.return_value = mock_client
 
         # Test that exception is raised
-        query = RelatedIncidentsQuery()
         with self.assertRaises(Exception) as context:
-            get_related_incidents("PINCIDENT123", query)
+            get_related_incidents("PINCIDENT123")
 
         self.assertIn("API Error", str(context.exception))
 
@@ -1129,8 +1111,7 @@ class TestIncidentTools(unittest.TestCase):
         mock_get_client.return_value = mock_client
 
         # Test
-        query = RelatedIncidentsQuery()
-        result = get_related_incidents("PINCIDENT123", query)
+        result = get_related_incidents("PINCIDENT123")
 
         # Should return empty related incidents response
         self.assertIsInstance(result, RelatedIncidentsResponse)
@@ -1165,8 +1146,7 @@ class TestIncidentTools(unittest.TestCase):
         mock_get_client.return_value = mock_client
 
         # Test
-        query = OutlierIncidentQuery()
-        result = get_outlier_incident("PINCIDENT123", query)
+        result = get_outlier_incident("PINCIDENT123")
 
         # Assertions
         self.assertIsInstance(result, OutlierIncidentResponse)
@@ -1182,8 +1162,7 @@ class TestIncidentTools(unittest.TestCase):
         mock_get_client.return_value = mock_client
 
         # Test
-        query = PastIncidentsQuery(limit=10)
-        result = get_past_incidents("PINCIDENT123", query)
+        result = get_past_incidents("PINCIDENT123", limit=10)
 
         # Should return empty past incidents response with correct default values
         self.assertIsInstance(result, PastIncidentsResponse)
@@ -1220,8 +1199,7 @@ class TestIncidentTools(unittest.TestCase):
         mock_get_client.return_value = mock_client
 
         # Test
-        query = PastIncidentsQuery(limit=10)
-        result = get_past_incidents("PINCIDENT123", query)
+        result = get_past_incidents("PINCIDENT123", limit=10)
 
         # Should parse unwrapped list correctly
         self.assertIsInstance(result, PastIncidentsResponse)
@@ -1277,8 +1255,7 @@ class TestIncidentTools(unittest.TestCase):
         mock_get_client.return_value = mock_client
 
         # Test
-        query = RelatedIncidentsQuery()
-        result = get_related_incidents("PINCIDENT123", query)
+        result = get_related_incidents("PINCIDENT123")
 
         # Should parse unwrapped list correctly
         self.assertIsInstance(result, RelatedIncidentsResponse)
@@ -1370,6 +1347,98 @@ class TestIncidentTools(unittest.TestCase):
             str(ctx.exception),
         )
 
+    @patch("pagerduty_mcp.tools.incidents.get_client")
+    def test_create_incident_status_update_success(self, mock_get_client):
+        """Test creating a status update for an incident successfully."""
+        mock_client = Mock()
+        mock_client.rpost.return_value = {"id": "SU123", "message": "System is recovering"}
+        mock_get_client.return_value = mock_client
+
+        result = create_incident_status_update("P123", "System is recovering")
+
+        self.assertIsInstance(result, str)
+        import json as _json
+        data = _json.loads(result)
+        self.assertEqual(data["message"], "System is recovering")
+
+    @patch("pagerduty_mcp.tools.incidents.get_client")
+    def test_create_incident_status_update_calls_api_correctly(self, mock_get_client):
+        """Test that create_incident_status_update calls rpost with correct arguments."""
+        mock_client = Mock()
+        mock_client.rpost.return_value = {"id": "SU123", "message": "System is recovering"}
+        mock_get_client.return_value = mock_client
+
+        create_incident_status_update("P123", "System is recovering")
+
+        mock_client.rpost.assert_called_once_with(
+            "/incidents/P123/status_updates",
+            json={"message": "System is recovering"},
+        )
+
+    @patch("pagerduty_mcp.tools.incidents.get_client")
+    def test_create_incident_status_update_client_error(self, mock_get_client):
+        """Test create_incident_status_update propagates client exceptions."""
+        mock_client = Mock()
+        mock_client.rpost.side_effect = Exception("Status Update Error")
+        mock_get_client.return_value = mock_client
+
+        with self.assertRaises(Exception) as ctx:
+            create_incident_status_update("P123", "System is recovering")
+
+        self.assertEqual(str(ctx.exception), "Status Update Error")
+
+    @patch("pagerduty_mcp.tools.log_entries.paginate")
+    @patch("pagerduty_mcp.tools.log_entries.get_client")
+    def test_list_incident_log_entries_success(self, mock_get_client, mock_paginate):
+        """Test listing log entries for an incident successfully."""
+        mock_log_entry = {
+            "id": "LOG1",
+            "type": "trigger_log_entry",
+            "summary": "triggered",
+            "self": "https://api.pagerduty.com/log_entries/LOG1",
+            "created_at": "2023-01-01T12:00:00Z",
+            "agent": None,
+            "channel": {"type": "web_trigger"},
+            "service": None,
+            "incident": None,
+            "teams": [],
+        }
+        mock_get_client.return_value = Mock()
+        mock_paginate.return_value = [mock_log_entry]
+
+        result = list_incident_log_entries("PINC123")
+
+        self.assertIsInstance(result, str)
+        import json as _json
+        data = _json.loads(result)
+        self.assertEqual(len(data["response"]), 1)
+
+    @patch("pagerduty_mcp.tools.log_entries.paginate")
+    @patch("pagerduty_mcp.tools.log_entries.get_client")
+    def test_list_incident_log_entries_with_limit(self, mock_get_client, mock_paginate):
+        """Test list_incident_log_entries respects the limit parameter."""
+        mock_get_client.return_value = Mock()
+        mock_paginate.return_value = []
+
+        list_incident_log_entries("PINC123", limit=50)
+
+        call_kwargs = mock_paginate.call_args[1]
+        self.assertEqual(call_kwargs["maximum_records"], 50)
+        self.assertEqual(call_kwargs["params"]["limit"], 50)
+
+    @patch("pagerduty_mcp.tools.log_entries.paginate")
+    @patch("pagerduty_mcp.tools.log_entries.get_client")
+    def test_list_incident_log_entries_default_params(self, mock_get_client, mock_paginate):
+        """Test list_incident_log_entries uses defaults when no limit given."""
+        mock_get_client.return_value = Mock()
+        mock_paginate.return_value = []
+
+        list_incident_log_entries("PINC123")
+
+        call_kwargs = mock_paginate.call_args[1]
+        self.assertEqual(call_kwargs["params"], {"is_overview": "false"})
+        self.assertEqual(call_kwargs["maximum_records"], 100)
+
 
 class TestAlertTools(unittest.TestCase):
     """Test cases for alert tools."""
@@ -1440,10 +1509,8 @@ class TestAlertTools(unittest.TestCase):
         mock_get_client.return_value = mock_client
         mock_paginate.return_value = [self.sample_alert_data]
 
-        query_model = AlertQuery(limit=10, offset=0)
-
         # Act
-        result = list_alerts_from_incident("PINCIDENT123", query_model)
+        result = list_alerts_from_incident("PINCIDENT123", limit=10, offset=0)
 
         # Assert
         self.assertIsInstance(result, ListResponseModel)
@@ -1461,10 +1528,8 @@ class TestAlertTools(unittest.TestCase):
         mock_get_client.return_value = mock_client
         mock_paginate.return_value = []
 
-        query_model = AlertQuery()
-
         # Act
-        result = list_alerts_from_incident("PINCIDENT123", query_model)
+        result = list_alerts_from_incident("PINCIDENT123")
 
         # Assert
         self.assertIsInstance(result, ListResponseModel)

--- a/website/docs/tools/incidents.md
+++ b/website/docs/tools/incidents.md
@@ -168,3 +168,22 @@ Requires `--enable-write-tools` flag.
 **Example prompt:**
 
 > "Add a note to incident P123456 saying 'Database failover initiated'"
+
+---
+
+### `create_incident_status_update` *(write)*
+
+Post a status update message to an incident, notifying subscribers and stakeholders of the current state. The message appears in the incident timeline and is sent to notification subscribers.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `incident_id` | `string` | Yes | The ID of the incident to post the status update to |
+| `message` | `string` | Yes | The status update message text |
+
+:::note
+Requires `--enable-write-tools` flag.
+:::
+
+**Example prompt:**
+
+> "Post a status update on incident P123456 saying 'Root cause identified — database connection pool exhausted, fix deploying now'"


### PR DESCRIPTION
## Summary

**Read enhancement:** `get_incident` now accepts `include=["external_references"]` and `include=["metadata"]` to retrieve third-party integration links (ServiceNow, Zendesk, etc.) and incident metadata.

**New model:** `ExternalIntegrationLink` with `integration_id`, `external_name`, `external_url`. `Incident` gains typed `external_references` and `metadata` fields.

**Write tool (gated by `--enable-write-tools`):** `create_incident_status_update(incident_id, message)` — posts a status update to an incident.

**New read tool:** `list_incident_log_entries(incident_id)` — lists log entries scoped to a specific incident (avoids calling the global `list_log_entries` just for one incident).

**Refactor:** `list_alerts_from_incident` signature flattened to `(incident_id, limit, offset)` — removes `query_model` wrapper for consistency.

**Bug fix:** `teams_ids` → `team_ids` typo corrected in `list_incidents` and its tests.

## Depends on
Requires **PR #133** (`refactor/flatten-tool-signatures`) to be merged first.