### PR TITLE
feat: add HTTP / SSE / streamable-http transport support

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,36 @@ To integrate the Docker container with MCP clients, you can use Docker as the co
 
 > **Note**: The Docker container uses stdio transport, making it compatible with MCP clients that expect standard input/output communication. Ensure you build the image first using `docker build -t pagerduty-mcp:latest .`
 
+## Transport modes
+
+The server supports three MCP transports, selected via the `--transport` flag:
+
+| Transport         | Use case                                                    | Default |
+|-------------------|-------------------------------------------------------------|---------|
+| `stdio`           | Local clients launched as a subprocess (Cursor, VS Code).   | ✅      |
+| `streamable-http` | Long-running remote/server deployments. MCP endpoint at `/mcp`. |     |
+| `sse`             | Legacy Server-Sent Events transport.                        |         |
+
+For HTTP-based transports, `--host` (default `127.0.0.1`) and `--port` (default `8000`) control the listen address.
+
+**Example: run as a remote streamable-HTTP server**
+
+```bash
+pagerduty-mcp --transport streamable-http --host 0.0.0.0 --port 8000
+# MCP endpoint: http://localhost:8000/mcp
+```
+
+**Docker:**
+
+```bash
+docker run -d -p 8000:8000 \
+  -e PAGERDUTY_USER_API_KEY="your-api-key-here" \
+  pagerduty-mcp:latest \
+  --transport streamable-http --host 0.0.0.0 --port 8000
+```
+
+The default remains `stdio` so existing local integrations are unaffected.
+
 ## Set up locally
 
 1.  **Clone the repository** 

--- a/pagerduty_mcp/server.py
+++ b/pagerduty_mcp/server.py
@@ -1,5 +1,6 @@
 import logging
 from collections.abc import Callable
+from enum import Enum
 
 import typer
 from mcp.server.fastmcp import FastMCP
@@ -8,6 +9,15 @@ from mcp.types import ToolAnnotations
 from pagerduty_mcp.tools import read_tools, write_tools
 from pagerduty_mcp.context import ContextResolver
 from pagerduty_mcp.context.application_context_strategy import ApplicationContextStrategy
+
+
+class Transport(str, Enum):
+    """MCP transport protocols supported by the server."""
+
+    stdio = "stdio"
+    sse = "sse"
+    streamable_http = "streamable-http"
+
 
 logging.basicConfig(level=logging.WARNING)
 
@@ -50,17 +60,28 @@ def add_write_tool(mcp_instance: FastMCP, tool: Callable) -> None:
 
 
 @app.command()
-def run(*, enable_write_tools: bool = False) -> None:
+def run(
+    *,
+    enable_write_tools: bool = False,
+    transport: Transport = Transport.stdio,
+    host: str = "127.0.0.1",
+    port: int = 8000,
+) -> None:
     """Run the MCP server with the specified configuration.
 
     Args:
         enable_write_tools: Flag to enable write tools
+        transport: Transport protocol to use (stdio, sse, or streamable-http)
+        host: Host to bind to for HTTP-based transports
+        port: Port to bind to for HTTP-based transports
     """
     ContextResolver.set_strategy(ApplicationContextStrategy())
 
     mcp = FastMCP(
         "PagerDuty MCP Server",
         instructions=MCP_SERVER_INSTRUCTIONS,
+        host=host,
+        port=port,
     )
     for tool in read_tools:
         add_read_only_tool(mcp, tool)
@@ -69,4 +90,4 @@ def run(*, enable_write_tools: bool = False) -> None:
         for tool in write_tools:
             add_write_tool(mcp, tool)
 
-    mcp.run()
+    mcp.run(transport=transport.value)


### PR DESCRIPTION

### Description

Adds --transport, --host, --port CLI flags so the server can be deployed as a long-running remote MCP server (in-cluster behind a gateway, etc.) in addition to the existing stdio mode. Closes #25.

Default transport remains stdio so existing local integrations are unaffected. FastMCP's own constructor and run() already accept these arguments — this change just exposes them through the typer CLI.


**Issue number:** #25

### Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only

### Checklist

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes are documented
- [x] Changes generate *no new warnings*
- [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

If this is a breaking change 👇

- [ ] I have documented the migration process
- [ ] I have implemented necessary warnings (if it can live side by side)

**Disclaimer:** We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.