### PR TITLE
chore: bump version to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [Unreleased]
+## [1.0.0]
 
 ### Changed — ⚠️ Breaking Change
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pagerduty-mcp"
-version = "0.17.0"
+version = "1.0.0"
 description = "PagerDuty's official local MCP (Model Context Protocol) server which provides tools to interact with your PagerDuty account directly from your MCP-enabled client."
 readme = "README.md"
 requires-python = "~=3.12.0"


### PR DESCRIPTION
### Description

Promotes the `[Unreleased]` CHANGELOG section to `[1.0.0]` and bumps the package version `0.17.0` → `1.0.0` in `pyproject.toml`. This is the 1.0.0 release cut.

The 1.0.0 release contains a breaking change already merged to the branch: list tool function signatures were flattened — the single nested `query_model` parameter was replaced with individual typed parameters across `list_alert_grouping_settings`, `list_alerts_from_incident`, `list_change_events`, `list_service_change_events`, `list_event_orchestrations`, `list_incident_workflows`, `list_oncalls`, and `list_teams`. This removes `$ref` / `$defs` from the tool input schemas so all tools work with non-Claude MCP clients (GitHub Copilot CLI, Cursor, AWS Bedrock). See `CHANGELOG.md` for the full migration table.

**Issue number:** N/A

### Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only

### Checklist

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes are documented
- [x] Changes generate *no new warnings*
- [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

If this is a breaking change 👇

- [x] I have documented the migration process
- [ ] I have implemented necessary warnings (if it can live side by side)

**Disclaimer:** We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
