### PR TITLE
FDE-856 [FDE-359] Feat: v3 schedules unified tool

### DIFF
--- a/pagerduty_mcp/__main__.py
+++ b/pagerduty_mcp/__main__.py
@@ -1,5 +1,11 @@
+import sys
+
 from pagerduty_mcp.server import app
 
 if __name__ == "__main__":
-    print("Starting PagerDuty MCP Server. Use the --enable-write-tools flag to enable write tools.")
+    # STDIO transport reserves stdout for JSON-RPC; diagnostics must go to stderr.
+    print(
+        "Starting PagerDuty MCP Server. Use the --enable-write-tools flag to enable write tools.",
+        file=sys.stderr,
+    )
     app()

--- a/pagerduty_mcp/models/__init__.py
+++ b/pagerduty_mcp/models/__init__.py
@@ -14,10 +14,14 @@ from .oncalls import Oncall, OncallQuery
 from .references import IncidentReference, ScheduleReference, ServiceReference, TeamReference, UserReference
 from .schedules import (
     Schedule,
+    ScheduleDetail,
     ScheduleLayer,
     ScheduleLayerUser,
     ScheduleOverrideCreate,
     ScheduleQuery,
+    SchedulesListResponse,
+    ScheduleSummary,
+    SourceStatus,
 )
 from .schedules_v3 import ScheduleV3, ScheduleV3Create, ScheduleV3Update
 from .services import Service, ServiceCreate, ServiceQuery
@@ -41,18 +45,22 @@ __all__ = [
     "Oncall",
     "OncallQuery",
     "Schedule",
+    "ScheduleDetail",
     "ScheduleLayer",
     "ScheduleLayerUser",
     "ScheduleOverrideCreate",
     "ScheduleQuery",
     "ScheduleReference",
+    "ScheduleSummary",
     "ScheduleV3",
     "ScheduleV3Create",
     "ScheduleV3Update",
+    "SchedulesListResponse",
     "Service",
     "ServiceCreate",
     "ServiceQuery",
     "ServiceReference",
+    "SourceStatus",
     "Team",
     "TeamCreateRequest",
     "TeamMemberAdd",

--- a/pagerduty_mcp/models/schedules.py
+++ b/pagerduty_mcp/models/schedules.py
@@ -1,10 +1,16 @@
 from datetime import datetime
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, Field, computed_field
 
-from pagerduty_mcp.models.base import DEFAULT_PAGINATION_LIMIT, MAXIMUM_PAGINATION_LIMIT
+from pagerduty_mcp.models.base import (
+    DEFAULT_PAGINATION_LIMIT,
+    MAX_RESULTS,
+    MAXIMUM_PAGINATION_LIMIT,
+    ListResponseModel,
+)
 from pagerduty_mcp.models.references import TeamReference, UserReference
+from pagerduty_mcp.models.schedules_v3 import ScheduleV3
 
 
 class ScheduleLayerUser(BaseModel):
@@ -35,6 +41,12 @@ class ScheduleLayer(BaseModel):
 
 
 class Schedule(BaseModel):
+    # Normalized discriminator shared with ScheduleV3 so both can live in a single
+    # discriminated union (ScheduleDetail) without collapsing their distinct shapes.
+    kind: Literal["layer_based"] = Field(
+        default="layer_based",
+        description="Identifies this as a classic layer-based (v2) schedule",
+    )
     id: str | None = Field(description="The ID of the schedule", default=None)
     summary: str = Field(
         description="A short-form, server-generated string that provides succinct information about the schedule"
@@ -99,3 +111,80 @@ class Override(BaseModel):
 
 class ScheduleOverrideCreate(BaseModel):
     overrides: list[Override] = Field(description="The list of overrides to create for the schedule")
+
+
+# A single schedule of either system. The "kind" discriminator lets callers (and the LLM)
+# tell a classic layer-based (v2) schedule from a next-gen shift-based (v3) one, and lets
+# downstream code build the correct escalation-policy target type.
+ScheduleDetail = Annotated[Schedule | ScheduleV3, Field(discriminator="kind")]
+
+
+class ScheduleSummary(BaseModel):
+    """A lightweight schedule entry returned by the unified list_schedules tool.
+
+    Both schedule systems are represented uniformly here; the "kind" field tells them apart.
+    Shift-based (v3) names are filled in by enrichment when available (see list_schedules).
+    """
+
+    id: str = Field(description="The ID of the schedule")
+    name: str | None = Field(
+        default=None,
+        description="The schedule name. May be null for a shift-based (v3) schedule when enrichment is disabled",
+    )
+    kind: Literal["layer_based", "shift_based"] = Field(
+        description="Which scheduling system this belongs to: classic layer-based (v2) or next-gen shift-based (v3)"
+    )
+    time_zone: str | None = Field(default=None, description="The time zone of the schedule")
+    html_url: str | None = Field(
+        default=None, description="The URL at which this schedule is accessible in the PagerDuty UI"
+    )
+    summary: str | None = Field(default=None, description="A short-form, server-generated summary of the schedule")
+
+
+class SourceStatus(BaseModel):
+    """Per-API outcome for one half of a unified schedules listing."""
+
+    api: Literal["v2", "v3"] = Field(description="Which schedules API this status refers to")
+    status: Literal["ok", "error"] = Field(description="Whether this source was retrieved successfully")
+    count: int = Field(default=0, description="Number of schedules returned from this source")
+    more: bool = Field(default=False, description="Whether this source has additional pages not included")
+    message: str | None = Field(default=None, description="Error detail (on failure) or an informational note")
+
+
+class SchedulesListResponse(ListResponseModel[ScheduleSummary]):
+    """Unified schedules list spanning BOTH the layer-based (v2) and shift-based (v3) systems.
+
+    `sources` and `degraded` exist so a partial failure can NEVER be mistaken for a complete
+    answer: if one system fails, the other's results are still returned but the response is
+    explicitly marked incomplete.
+    """
+
+    sources: list[SourceStatus] = Field(
+        default_factory=list, description="Per-API retrieval status for each scheduling system"
+    )
+    degraded: bool = Field(default=False, description="True if any source failed; the list is then INCOMPLETE")
+
+    @computed_field
+    @property
+    def response_summary(self) -> str:
+        count = len(self.response)
+        n_v2 = sum(s.count for s in self.sources if s.api == "v2" and s.status == "ok")
+        n_v3 = sum(s.count for s in self.sources if s.api == "v3" and s.status == "ok")
+        lines = [
+            "ListResponseModel<ScheduleSummary>:",
+            f"- Returned {count} schedule(s): {n_v2} layer-based (v2), {n_v3} shift-based (v3).",
+        ]
+        for source in self.sources:
+            label = "layer-based (v2)" if source.api == "v2" else "shift-based (v3)"
+            if source.status == "error":
+                lines.append(
+                    f"- WARNING: the {label} source FAILED — this list is INCOMPLETE."
+                    f" Do not tell the user these schedules do not exist. ({source.message})"
+                )
+            elif source.message:
+                lines.append(f"- Note ({label}): {source.message}")
+            elif source.more:
+                lines.append(f"- Note: more {label} schedules exist beyond the returned page.")
+        if count >= MAX_RESULTS:
+            lines.append("- WARNING: the number of records equals the response limit; there may be more not included.")
+        return "\n".join(lines)

--- a/pagerduty_mcp/models/schedules_v3.py
+++ b/pagerduty_mcp/models/schedules_v3.py
@@ -1,11 +1,17 @@
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
 
 class ScheduleV3(BaseModel):
-    """A PagerDuty v3 schedule (next-gen scheduling system)."""
+    """A PagerDuty v3 schedule (next-gen, shift-based scheduling system)."""
 
+    # Normalized discriminator shared with the v2 Schedule model so both can live in a
+    # single discriminated union (ScheduleDetail) without losing their distinct shapes.
+    kind: Literal["shift_based"] = Field(
+        default="shift_based",
+        description="Identifies this as a next-gen shift-based (v3) schedule",
+    )
     id: str | None = Field(default=None, description="The ID of the v3 schedule")
     name: str | None = Field(default=None, description="The name of the v3 schedule")
     description: str | None = Field(default=None, description="A description of the v3 schedule")
@@ -48,6 +54,4 @@ class ScheduleV3Update(BaseModel):
     teams: list[dict[str, Any]] | None = Field(
         default=None, description="Updated teams to associate with this schedule"
     )
-    rotations: list[dict[str, Any]] | None = Field(
-        default=None, description="Updated rotations for the v3 schedule"
-    )
+    rotations: list[dict[str, Any]] | None = Field(default=None, description="Updated rotations for the v3 schedule")

--- a/pagerduty_mcp/tools/__init__.py
+++ b/pagerduty_mcp/tools/__init__.py
@@ -15,16 +15,12 @@ from .incidents import (
 )
 from .oncalls import list_oncalls
 from .schedules import (
+    create_schedule,
     create_schedule_override,
     get_schedule,
     list_schedule_users,
     list_schedules,
-)
-from .schedules_v3 import (
-    create_schedule_v3,
-    get_schedule_v3,
-    list_schedules_v3,
-    update_schedule_v3,
+    update_schedule,
 )
 from .services import (
     create_service,
@@ -59,13 +55,10 @@ read_tools = [
     # Users
     get_user_data,
     list_users,
-    # Schedules (v2)
+    # Schedules (unified across layer-based v2 and shift-based v3)
     list_schedules,
     get_schedule,
     list_schedule_users,
-    # Schedules (v3)
-    list_schedules_v3,
-    get_schedule_v3,
     # On-calls
     list_oncalls,
     # Escalation Policies
@@ -88,11 +81,10 @@ write_tools = [
     delete_team,
     add_team_member,
     remove_team_member,
-    # Schedules (v2)
+    # Schedules (unified): create/update target shift-based (v3); overrides are layer-based (v2)
+    create_schedule,
+    update_schedule,
     create_schedule_override,
-    # Schedules (v3)
-    create_schedule_v3,
-    update_schedule_v3,
     # Escalation Policies - currently disabled
     # create_escalation_policy,
 ]

--- a/pagerduty_mcp/tools/schedules.py
+++ b/pagerduty_mcp/tools/schedules.py
@@ -1,43 +1,217 @@
+import logging
+from typing import Literal
+
+from pagerduty.errors import HttpError
+
 from pagerduty_mcp.client import get_client
 from pagerduty_mcp.models import (
     ListResponseModel,
     Schedule,
+    ScheduleDetail,
     ScheduleOverrideCreate,
     ScheduleQuery,
+    SchedulesListResponse,
+    ScheduleSummary,
+    ScheduleV3Create,
+    ScheduleV3Update,
+    SourceStatus,
     User,
+)
+from pagerduty_mcp.tools.schedules_v3 import (
+    _get_v3_schedules_page,
+    create_schedule_v3,
+    get_schedule_v3,
+    update_schedule_v3,
 )
 from pagerduty_mcp.utils import paginate
 
+logger = logging.getLogger(__name__)
 
-def list_schedules(query_model: ScheduleQuery) -> ListResponseModel[Schedule]:
-    """List schedules with optional filtering.
+# Shift-based (v3) names are absent from the v3 list endpoint, so we enrich via per-id GETs.
+# Bounded to avoid an N+1 blow-up on large accounts; names beyond the cap stay null.
+_V3_ENRICH_CAP = 50
 
-    Returns:
-        List of schedules matching the query parameters
-    """
-    response = paginate(
-        client=get_client(), entity="schedules", params=query_model.to_params()
+# The cross-namespace v2 GET returns a 400 whose message points at the v3 API. Matching the
+# specific message (not just the 400 status) means a genuine bad-request is never swallowed.
+_V3_REDIRECT_MARKERS = ("shift-based", "v3 schedules api", "/v3/schedules")
+
+
+def _v2_summary(raw: dict) -> ScheduleSummary:
+    return ScheduleSummary(
+        id=raw["id"],
+        name=raw.get("name"),
+        kind="layer_based",
+        time_zone=raw.get("time_zone"),
+        html_url=raw.get("html_url"),
+        summary=raw.get("summary"),
     )
-    schedules = [Schedule(**schedule) for schedule in response]
-    return ListResponseModel[Schedule](response=schedules)
 
 
-def get_schedule(schedule_id: str) -> Schedule:
-    """Get a specific schedule by ID.
+def _list_v3_summaries(query_model: ScheduleQuery, *, enrich: bool) -> tuple[list[ScheduleSummary], bool, int]:
+    """Return shift-based (v3) summaries, whether more pages exist, and how many names were left null.
+
+    v3 LIST only supports name `query` and `limit`, so other v2 filters are not forwarded.
+    """
+    raw_refs, more = _get_v3_schedules_page(query=query_model.query, limit=query_model.limit)
+
+    summaries: list[ScheduleSummary] = []
+    unenriched = 0
+    enriched = 0
+    for ref in raw_refs:
+        schedule_id = ref.get("id")
+        if not schedule_id:
+            continue
+        name = ref.get("name")
+        time_zone = ref.get("time_zone")
+        html_url = ref.get("html_url")
+
+        if name is None:
+            if enrich and enriched < _V3_ENRICH_CAP:
+                try:
+                    full = get_schedule_v3(schedule_id)
+                    name = full.name
+                    time_zone = time_zone or full.time_zone
+                    html_url = html_url or full.html_url
+                    enriched += 1
+                except Exception as exc:  # noqa: BLE001 - one enrichment miss must not drop the item or fail the list
+                    unenriched += 1
+                    logger.warning("v3 schedule %s name enrichment failed: %s", schedule_id, exc)
+            else:
+                unenriched += 1
+
+        summaries.append(
+            ScheduleSummary(
+                id=schedule_id,
+                name=name,
+                kind="shift_based",
+                time_zone=time_zone,
+                html_url=html_url,
+                summary=ref.get("summary"),
+            )
+        )
+    return summaries, more, unenriched
+
+
+def list_schedules(query_model: ScheduleQuery, *, enrich: bool = True) -> SchedulesListResponse:
+    """List ALL PagerDuty schedules across BOTH scheduling systems in a single call.
+
+    This returns classic layer-based (v2) schedules AND next-gen shift-based (v3) schedules
+    together. It is the complete, authoritative schedule list — there is no other list tool.
+    Each item's `kind` field ("layer_based" or "shift_based") says which system it belongs to.
+    If either source fails, `response_summary`/`sources` explicitly mark the list INCOMPLETE;
+    otherwise treat it as exhaustive. Never tell the user a schedule type is unsupported or missing.
 
     Args:
-        schedule_id: The ID of the schedule to retrieve
+        query_model: Filters (name query, team_ids, user_ids, limit). Shift-based (v3) schedules
+            are filtered by name `query` and `limit` only.
+        enrich: When True (default), fill in names for shift-based (v3) schedules (bounded to the
+            returned page, max 50). Set False to skip the extra lookups; v3 names may then be null.
 
     Returns:
-        Schedule details
+        The merged schedule summaries with per-source status and a `degraded` flag.
     """
-    response = get_client().rget(f"/schedules/{schedule_id}")
-    return Schedule.model_validate(response)
+    summaries: list[ScheduleSummary] = []
+    sources: list[SourceStatus] = []
+    degraded = False
+
+    # Each source is retrieved independently: one system failing must never hide the other,
+    # and must never be mistaken for "no schedules exist".
+    try:
+        v2_raw = paginate(client=get_client(), entity="schedules", params=query_model.to_params())
+        summaries.extend(_v2_summary(raw) for raw in v2_raw)
+        sources.append(SourceStatus(api="v2", status="ok", count=len(v2_raw)))
+    except Exception as exc:  # noqa: BLE001 - resilience: report the failure, keep the other source
+        degraded = True
+        sources.append(SourceStatus(api="v2", status="error", message=str(exc)))
+        logger.warning("Listing layer-based (v2) schedules failed: %s", exc)
+
+    try:
+        v3_summaries, v3_more, unenriched = _list_v3_summaries(query_model, enrich=enrich)
+        summaries.extend(v3_summaries)
+        note = f"{unenriched} shift-based name(s) not enriched (cap reached or enrich disabled)" if unenriched else None
+        sources.append(SourceStatus(api="v3", status="ok", count=len(v3_summaries), more=v3_more, message=note))
+    except Exception as exc:  # noqa: BLE001 - resilience: report the failure, keep the other source
+        degraded = True
+        sources.append(SourceStatus(api="v3", status="error", message=str(exc)))
+        logger.warning("Listing shift-based (v3) schedules failed: %s", exc)
+
+    return SchedulesListResponse(response=summaries, sources=sources, degraded=degraded)
 
 
-def create_schedule_override(
-    schedule_id: str, override_request: ScheduleOverrideCreate
-) -> dict | list:
+def _get_v2(schedule_id: str) -> Schedule:
+    return Schedule.model_validate(get_client().rget(f"/schedules/{schedule_id}"))
+
+
+def _is_v3_redirect(exc: HttpError) -> bool:
+    """True only for the specific 'this is a shift-based schedule, use v3' 400."""
+    resp = getattr(exc, "response", None)
+    if resp is None or getattr(resp, "status_code", None) != 400:
+        return False
+    try:
+        body = resp.json()
+        message = (body.get("error") or {}).get("message", "") if isinstance(body, dict) else ""
+    except Exception:  # noqa: BLE001 - fall back to the raw text
+        message = getattr(resp, "text", "") or ""
+    message = (message or "").lower()
+    return any(marker in message for marker in _V3_REDIRECT_MARKERS)
+
+
+def get_schedule(schedule_id: str, kind: Literal["layer_based", "shift_based"] | None = None) -> ScheduleDetail:
+    """Get a single schedule by ID — works for layer-based (v2) and shift-based (v3) schedules alike.
+
+    You normally do not need to know the kind in advance; this resolves it automatically.
+
+    Args:
+        schedule_id: The ID of the schedule to retrieve.
+        kind: Optional hint ("layer_based" or "shift_based", taken from a prior list result) to
+            skip an extra lookup. A wrong or omitted hint still resolves correctly.
+
+    Returns:
+        The schedule details (a layer-based Schedule or a shift-based ScheduleV3).
+    """
+    if kind == "shift_based":
+        return get_schedule_v3(schedule_id)
+    if kind == "layer_based":
+        return _get_v2(schedule_id)
+
+    # No hint: try the layer-based (v2) endpoint, and on its self-describing 400 fall back to v3.
+    try:
+        return _get_v2(schedule_id)
+    except HttpError as exc:
+        if _is_v3_redirect(exc):
+            return get_schedule_v3(schedule_id)
+        raise
+
+
+def create_schedule(schedule_data: ScheduleV3Create) -> ScheduleDetail:
+    """Create a new schedule. All new schedules use PagerDuty's next-gen shift-based (v3) system.
+
+    Args:
+        schedule_data: Name, time_zone, and rotations for the new shift-based schedule.
+
+    Returns:
+        The created schedule.
+    """
+    return create_schedule_v3(schedule_data)
+
+
+def update_schedule(schedule_id: str, schedule_data: ScheduleV3Update) -> ScheduleDetail:
+    """Update an existing shift-based (v3) schedule.
+
+    Classic layer-based (v2) schedules cannot be edited through this tool; attempting to update
+    one surfaces the PagerDuty API's guidance message rather than failing silently.
+
+    Args:
+        schedule_id: The ID of the shift-based (v3) schedule to update.
+        schedule_data: Fields to change (only provided fields are updated).
+
+    Returns:
+        The updated schedule.
+    """
+    return update_schedule_v3(schedule_id, schedule_data)
+
+
+def create_schedule_override(schedule_id: str, override_request: ScheduleOverrideCreate) -> dict | list:
     """Create an override for a schedule.
 
     Args:
@@ -51,8 +225,7 @@ def create_schedule_override(
         override.start = override.start.isoformat()
         override.end = override.end.isoformat()
 
-    return get_client().rpost(f"/schedules/{schedule_id}/overrides",
-                        json=override_request.model_dump())
+    return get_client().rpost(f"/schedules/{schedule_id}/overrides", json=override_request.model_dump())
 
 
 def list_schedule_users(schedule_id: str) -> ListResponseModel[User]:

--- a/pagerduty_mcp/tools/schedules_v3.py
+++ b/pagerduty_mcp/tools/schedules_v3.py
@@ -25,22 +25,38 @@ def _unwrap_schedule(response: Any) -> dict:
     return response
 
 
-def list_schedules_v3(
+def _extract_api_message(resp: Any) -> str:
+    """Pull the human-readable error message out of a v3 API error body."""
+    try:
+        body = resp.json()
+    except Exception:  # noqa: BLE001 - any parse failure falls back to raw text
+        return getattr(resp, "text", "") or "unknown error"
+    if isinstance(body, dict):
+        err = body.get("error")
+        if isinstance(err, dict):
+            return err.get("message") or err.get("code") or str(err)
+        if isinstance(err, str):
+            return err
+    return str(body)
+
+
+def _check_v3_response(resp: Any) -> None:
+    """Raise an informative error on a non-2xx v3 response.
+
+    We surface the API's own message (e.g. "This is a layer-based schedule. Use the v2
+    Schedules API to access it.") so the caller never gets an opaque failure or a silent no-op.
+    """
+    if getattr(resp, "ok", True):
+        return
+    status = getattr(resp, "status_code", "?")
+    raise RuntimeError(f"PagerDuty v3 Schedules API error (HTTP {status}): {_extract_api_message(resp)}")
+
+
+def _get_v3_schedules_page(
     query: str | None = None,
     limit: int | None = None,
-) -> ListResponseModel[ScheduleV3]:
-    """List v3 schedules with optional filtering.
-
-    Use this tool to list schedules created with PagerDuty's next-gen scheduling system (v3).
-    Classic (v2) schedules are listed with list_schedules.
-
-    Args:
-        query: Filter v3 schedules by name
-        limit: Max results to return
-
-    Returns:
-        List of v3 schedules
-    """
+) -> tuple[list[dict], bool]:
+    """Fetch one page of raw v3 schedule references and whether more pages exist."""
     params: dict[str, Any] = {}
     if query:
         params["query"] = query
@@ -49,17 +65,33 @@ def list_schedules_v3(
 
     client = get_client()
     resp = client.get(_v3_url(client, "/v3/schedules"), params=params)
-    resp.raise_for_status()
+    _check_v3_response(resp)
     data = resp.json()
 
     if isinstance(data, dict) and "schedules" in data:
-        raw_schedules = data["schedules"]
-    elif isinstance(data, list):
-        raw_schedules = data
-    else:
-        logger.warning("Unexpected response format from /v3/schedules: %s", type(data).__name__)
-        raw_schedules = []
+        return data["schedules"], bool(data.get("more"))
+    if isinstance(data, list):
+        return data, False
+    logger.warning("Unexpected response format from /v3/schedules: %s", type(data).__name__)
+    return [], False
 
+
+def list_schedules_v3(
+    query: str | None = None,
+    limit: int | None = None,
+) -> ListResponseModel[ScheduleV3]:
+    """List v3 (shift-based) schedules. Internal helper — not registered as an MCP tool.
+
+    The unified `list_schedules` tool calls this so the LLM sees a single schedule list.
+
+    Args:
+        query: Filter v3 schedules by name
+        limit: Max results to return
+
+    Returns:
+        List of v3 schedules
+    """
+    raw_schedules, _ = _get_v3_schedules_page(query=query, limit=limit)
     schedules = [ScheduleV3(**s) for s in raw_schedules]
     return ListResponseModel[ScheduleV3](response=schedules)
 
@@ -75,7 +107,7 @@ def get_schedule_v3(schedule_id: str) -> ScheduleV3:
     """
     client = get_client()
     resp = client.get(_v3_url(client, f"/v3/schedules/{schedule_id}"))
-    resp.raise_for_status()
+    _check_v3_response(resp)
     return ScheduleV3.model_validate(_unwrap_schedule(resp.json()))
 
 
@@ -93,7 +125,7 @@ def create_schedule_v3(schedule_data: ScheduleV3Create) -> ScheduleV3:
         _v3_url(client, "/v3/schedules"),
         json={"schedule": schedule_data.model_dump(exclude_none=True)},
     )
-    resp.raise_for_status()
+    _check_v3_response(resp)
     return ScheduleV3.model_validate(_unwrap_schedule(resp.json()))
 
 
@@ -112,5 +144,5 @@ def update_schedule_v3(schedule_id: str, schedule_data: ScheduleV3Update) -> Sch
         _v3_url(client, f"/v3/schedules/{schedule_id}"),
         json={"schedule": schedule_data.model_dump(exclude_none=True)},
     )
-    resp.raise_for_status()
+    _check_v3_response(resp)
     return ScheduleV3.model_validate(_unwrap_schedule(resp.json()))

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -1,0 +1,251 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from pagerduty.errors import HttpError
+
+from pagerduty_mcp.models import Schedule, ScheduleQuery, ScheduleV3, ScheduleV3Create, ScheduleV3Update
+from pagerduty_mcp.tools.schedules import (
+    create_schedule,
+    get_schedule,
+    list_schedules,
+    update_schedule,
+)
+from pagerduty_mcp.tools.schedules_v3 import _check_v3_response
+
+SCHED = "pagerduty_mcp.tools.schedules"
+
+
+def _http_error(status: int, message: str) -> HttpError:
+    """Build a pagerduty HttpError whose .response mimics the API error body."""
+    resp = MagicMock()
+    resp.status_code = status
+    resp.json.return_value = {"error": {"message": message}}
+    return HttpError(f"HTTP {status}", resp)
+
+
+def _v2_raw(schedule_id: str, name: str) -> dict:
+    return {"id": schedule_id, "name": name, "summary": name, "time_zone": "UTC"}
+
+
+class TestListSchedulesUnified(unittest.TestCase):
+    """The unified list must surface BOTH systems and never hide a partial failure."""
+
+    @patch(f"{SCHED}._get_v3_schedules_page")
+    @patch(f"{SCHED}.paginate")
+    @patch(f"{SCHED}.get_client")
+    def test_merges_v2_and_v3_tagged_by_kind(self, _client, mock_paginate, mock_v3_page):
+        mock_paginate.return_value = [_v2_raw("PKSA96L", "Primary")]
+        mock_v3_page.return_value = ([{"id": "PK4N098", "name": "Shift A", "time_zone": "UTC"}], False)
+
+        result = list_schedules(ScheduleQuery())
+
+        kinds = {s.id: s.kind for s in result.response}
+        self.assertEqual(kinds, {"PKSA96L": "layer_based", "PK4N098": "shift_based"})
+        self.assertFalse(result.degraded)
+        self.assertEqual({s.api: s.status for s in result.sources}, {"v2": "ok", "v3": "ok"})
+
+    @patch(f"{SCHED}.get_schedule_v3")
+    @patch(f"{SCHED}._get_v3_schedules_page")
+    @patch(f"{SCHED}.paginate")
+    @patch(f"{SCHED}.get_client")
+    def test_enriches_v3_null_names(self, _client, mock_paginate, mock_v3_page, mock_get_v3):
+        mock_paginate.return_value = []
+        mock_v3_page.return_value = ([{"id": "PK4N098", "name": None}], False)
+        mock_get_v3.return_value = ScheduleV3(id="PK4N098", name="Enriched", time_zone="UTC")
+
+        result = list_schedules(ScheduleQuery(), enrich=True)
+
+        self.assertEqual(result.response[0].name, "Enriched")
+        mock_get_v3.assert_called_once_with("PK4N098")
+
+    @patch(f"{SCHED}.get_schedule_v3")
+    @patch(f"{SCHED}._get_v3_schedules_page")
+    @patch(f"{SCHED}.paginate")
+    @patch(f"{SCHED}.get_client")
+    def test_enrich_false_skips_lookups_and_notes_it(self, _client, mock_paginate, mock_v3_page, mock_get_v3):
+        mock_paginate.return_value = []
+        mock_v3_page.return_value = ([{"id": "PK4N098", "name": None}], False)
+
+        result = list_schedules(ScheduleQuery(), enrich=False)
+
+        self.assertIsNone(result.response[0].name)
+        mock_get_v3.assert_not_called()
+        v3_source = next(s for s in result.sources if s.api == "v3")
+        self.assertIn("not enriched", v3_source.message or "")
+
+    @patch(f"{SCHED}.get_schedule_v3")
+    @patch(f"{SCHED}._get_v3_schedules_page")
+    @patch(f"{SCHED}.paginate")
+    @patch(f"{SCHED}.get_client")
+    @patch(f"{SCHED}._V3_ENRICH_CAP", 2)
+    def test_enrichment_is_bounded_by_cap(self, _client, mock_paginate, mock_v3_page, mock_get_v3):
+        mock_paginate.return_value = []
+        mock_v3_page.return_value = (
+            [{"id": f"P{i}", "name": None} for i in range(3)],
+            False,
+        )
+        mock_get_v3.side_effect = lambda sid: ScheduleV3(id=sid, name=f"name-{sid}")
+
+        result = list_schedules(ScheduleQuery(), enrich=True)
+
+        self.assertEqual(mock_get_v3.call_count, 2)  # capped at 2, not 3
+        v3_source = next(s for s in result.sources if s.api == "v3")
+        self.assertIn("1 shift-based", v3_source.message or "")  # 1 left un-enriched
+
+    @patch(f"{SCHED}._get_v3_schedules_page")
+    @patch(f"{SCHED}.paginate")
+    @patch(f"{SCHED}.get_client")
+    def test_v3_failure_keeps_v2_and_marks_incomplete(self, _client, mock_paginate, mock_v3_page):
+        mock_paginate.return_value = [_v2_raw("PKSA96L", "Primary")]
+        mock_v3_page.side_effect = RuntimeError("v3 down")
+
+        result = list_schedules(ScheduleQuery())
+
+        self.assertTrue(result.degraded)
+        self.assertIn("PKSA96L", [s.id for s in result.response])  # v2 retained
+        self.assertEqual(next(s for s in result.sources if s.api == "v3").status, "error")
+        self.assertIn("INCOMPLETE", result.response_summary)
+
+    @patch(f"{SCHED}._get_v3_schedules_page")
+    @patch(f"{SCHED}.paginate")
+    @patch(f"{SCHED}.get_client")
+    def test_v2_failure_keeps_v3_and_marks_incomplete(self, _client, mock_paginate, mock_v3_page):
+        mock_paginate.side_effect = RuntimeError("v2 down")
+        mock_v3_page.return_value = ([{"id": "PK4N098", "name": "Shift A"}], False)
+
+        result = list_schedules(ScheduleQuery())
+
+        self.assertTrue(result.degraded)
+        self.assertIn("PK4N098", [s.id for s in result.response])  # v3 retained
+        self.assertEqual(next(s for s in result.sources if s.api == "v2").status, "error")
+        self.assertIn("INCOMPLETE", result.response_summary)
+
+
+class TestGetScheduleRouting(unittest.TestCase):
+    """get_schedule resolves the kind itself; the hint is an optimization, never required."""
+
+    @patch(f"{SCHED}.get_schedule_v3")
+    def test_kind_hint_shift_based_goes_straight_to_v3(self, mock_get_v3):
+        mock_get_v3.return_value = ScheduleV3(id="PK4N098", name="Shift")
+        result = get_schedule("PK4N098", kind="shift_based")
+        self.assertIsInstance(result, ScheduleV3)
+        mock_get_v3.assert_called_once_with("PK4N098")
+
+    @patch(f"{SCHED}.get_client")
+    def test_kind_hint_layer_based_uses_v2(self, mock_get_client):
+        client = MagicMock()
+        client.rget.return_value = _v2_raw("PKSA96L", "Primary")
+        mock_get_client.return_value = client
+
+        result = get_schedule("PKSA96L", kind="layer_based")
+
+        self.assertIsInstance(result, Schedule)
+        client.rget.assert_called_once_with("/schedules/PKSA96L")
+
+    @patch(f"{SCHED}.get_client")
+    def test_no_hint_v2_success(self, mock_get_client):
+        client = MagicMock()
+        client.rget.return_value = _v2_raw("PKSA96L", "Primary")
+        mock_get_client.return_value = client
+
+        result = get_schedule("PKSA96L")
+
+        self.assertIsInstance(result, Schedule)
+        self.assertEqual(result.kind, "layer_based")
+
+    @patch(f"{SCHED}.get_schedule_v3")
+    @patch(f"{SCHED}.get_client")
+    def test_no_hint_falls_back_to_v3_on_specific_400(self, mock_get_client, mock_get_v3):
+        client = MagicMock()
+        client.rget.side_effect = _http_error(
+            400, "This is a shift-based schedule. Use the v3 Schedules API to access it."
+        )
+        mock_get_client.return_value = client
+        mock_get_v3.return_value = ScheduleV3(id="PK4N098", name="Shift")
+
+        result = get_schedule("PK4N098")
+
+        self.assertIsInstance(result, ScheduleV3)
+        mock_get_v3.assert_called_once_with("PK4N098")
+
+    @patch(f"{SCHED}.get_schedule_v3")
+    @patch(f"{SCHED}.get_client")
+    def test_no_hint_reraises_non_redirect_404(self, mock_get_client, mock_get_v3):
+        client = MagicMock()
+        client.rget.side_effect = _http_error(404, "Not Found")
+        mock_get_client.return_value = client
+
+        with self.assertRaises(HttpError):
+            get_schedule("MISSING")
+        mock_get_v3.assert_not_called()  # no error-swallowing
+
+    @patch(f"{SCHED}.get_schedule_v3")
+    @patch(f"{SCHED}.get_client")
+    def test_no_hint_reraises_generic_400(self, mock_get_client, mock_get_v3):
+        client = MagicMock()
+        client.rget.side_effect = _http_error(400, "Invalid query parameter")
+        mock_get_client.return_value = client
+
+        with self.assertRaises(HttpError):
+            get_schedule("PXXXX")
+        mock_get_v3.assert_not_called()
+
+
+class TestCreateUpdateRouting(unittest.TestCase):
+    """Create/update target shift-based (v3); a v2 id surfaces the API's guidance, never a no-op."""
+
+    @patch(f"{SCHED}.create_schedule_v3")
+    def test_create_routes_to_v3(self, mock_create_v3):
+        mock_create_v3.return_value = ScheduleV3(id="PK4N098", name="New")
+        data = ScheduleV3Create(name="New", time_zone="UTC")
+
+        result = create_schedule(data)
+
+        self.assertIsInstance(result, ScheduleV3)
+        mock_create_v3.assert_called_once_with(data)
+
+    @patch(f"{SCHED}.update_schedule_v3")
+    def test_update_routes_to_v3(self, mock_update_v3):
+        mock_update_v3.return_value = ScheduleV3(id="PK4N098", name="Renamed")
+        data = ScheduleV3Update(name="Renamed")
+
+        result = update_schedule("PK4N098", data)
+
+        self.assertIsInstance(result, ScheduleV3)
+        mock_update_v3.assert_called_once_with("PK4N098", data)
+
+    @patch(f"{SCHED}.update_schedule_v3")
+    def test_update_on_v2_id_surfaces_self_describing_error(self, mock_update_v3):
+        mock_update_v3.side_effect = RuntimeError(
+            "PagerDuty v3 Schedules API error (HTTP 400): "
+            "This is a layer-based schedule. Use the v2 Schedules API to access it."
+        )
+
+        with self.assertRaises(RuntimeError) as ctx:
+            update_schedule("PKSA96L", ScheduleV3Update(name="x"))
+        self.assertIn("layer-based", str(ctx.exception))
+
+
+class TestCheckV3Response(unittest.TestCase):
+    """The v3 error checker must surface the API's own message, not an opaque failure."""
+
+    def test_raises_with_api_message_on_layer_based_400(self):
+        resp = MagicMock()
+        resp.ok = False
+        resp.status_code = 400
+        resp.json.return_value = {
+            "error": {"message": "This is a layer-based schedule. Use the v2 Schedules API to access it."}
+        }
+        with self.assertRaises(RuntimeError) as ctx:
+            _check_v3_response(resp)
+        self.assertIn("HTTP 400", str(ctx.exception))
+        self.assertIn("layer-based", str(ctx.exception))
+
+    def test_noop_on_ok_response(self):
+        resp = MagicMock()
+        resp.ok = True
+        self.assertIsNone(_check_v3_response(resp))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Description

After reviewing the #124, my evaluations leans more towards a unified Schedules (v2+v3) tools, instead of separating them, with that intention this PR makes the MCP server expose both systems through a single, version-agnostic tool surface designed around how an LLM actually calls tools, and below it's the expand explanation...

**The UX problem it fixes.** The base branch added separate `*_v3` tools (`list_schedules_v3`, `get_schedule_v3`, …). With two list tools, an assistant asked to *"list all my schedules"* calls `list_schedules` (v2), returns only those, and presents them as complete — silently omitting every v3 schedule. An account whose newer schedules are all v3 sees a misleading (often near-empty) list and never learns they exist. The two endpoints return **disjoint** sets, so no single legacy tool can ever be correct. This is a tool-layout problem, not a prompting problem — it can't be fixed with docstrings alone.

**The approach — unify the surface, not the model.**

- **`list_schedules`** now fans out to **both** `/schedules` and `/v3/schedules`, merges, and tags every item with a `kind` discriminator (`layer_based` / `shift_based`). It is the single authoritative list, so the model can no longer return a partial answer. v3 list entries have no name, so names are enriched per-id (bounded to the returned page, cap 50, with an `enrich=False` opt-out).
- **A partial failure can never look complete.** The response carries per-source status (`sources: [{api, status, count, …}]`) and a `degraded` flag, and `response_summary` emits a loud `INCOMPLETE` warning if either system fails — so a transient v3 outage is never mistaken for *"no schedules exist"*.
- **`get_schedule`** resolves either system automatically: it tries v2 and falls back to v3 **only** on the specific self-describing `400` (*"…use the v3 Schedules API…"*), re-raising any other error so genuine failures aren't swallowed. An optional `kind` hint skips the extra round-trip.
- **`create_schedule` / `update_schedule`** target v3 (all new schedules are v3; there is no v2 create/update tool). Updating a v2 id surfaces the API's own guidance message rather than failing silently.
- **The four `*_v3` tools are removed from the LLM-facing tool set** and kept as internal helpers the unified tools call. This is intentional and non-breaking: they were introduced only on this unreleased FDE-359 branch, MCP tools are discovered dynamically (nothing pins to their names), and keeping a v3-only list tool would reintroduce the exact partial-view bug. No `version=` enum is exposed, for the same reason.

Models gain a `kind` discriminator on `Schedule` and `ScheduleV3`, plus `ScheduleSummary`, `ScheduleDetail` (discriminated union), `SourceStatus`, and `SchedulesListResponse`.

Also bundled: a small fix sending the server's startup notice to **stderr** (stdout is reserved for JSON-RPC framing; the stray line broke STDIO clients such as the MCP Inspector).

**Verification.** 32 unit tests pass (17 new + 15 existing v3): merge, name enrichment + cap, both partial-failure directions, `get` routing/fallback (incl. no-swallow on 404 and generic 400), create/update routing, and self-describing-400 surfacing. Verified live against a real account — `list_schedules` returns all 5 schedules (2 v2 + 3 v3 with names enriched) where the old `list_schedules` returned only 2.

**Issue number:** FDE-359 (Jira)

### Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only

### Checklist

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes are documented
- [x] Changes generate *no new warnings*
- [ ] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

If this is a breaking change 👇

- [ ] I have documented the migration process
- [ ] I have implemented necessary warnings (if it can live side by side)

**Disclaimer:** We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
