### PR TITLE
feat: add create_escalation_policy and update_escalation_policy tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,8 +402,10 @@ This section describes the tools provided by the PagerDuty MCP server. They are 
 | list_event_orchestrations | Event Orchestrations | Lists event orchestrations with optional filtering | ✅         |
 | update_event_orchestration_router | Event Orchestrations | Updates the router configuration for an event orchestration | ❌         |
 | append_event_orchestration_router_rule | Event Orchestrations | Adds a new routing rule to an event orchestration router | ❌         |
-| list_escalation_policies | Escalation Policy  | Lists escalation policies                           | ✅         |
+| create_escalation_policy | Escalation Policy  | Creates a new escalation policy                     | ❌         |
 | get_escalation_policy    | Escalation Policy  | Retrieves a specific escalation policy              | ✅         |
+| list_escalation_policies | Escalation Policy  | Lists escalation policies                           | ✅         |
+| update_escalation_policy | Escalation Policy  | Updates an existing escalation policy               | ❌         |
 | add_note_to_incident     | Incidents          | Adds note to an incident                            | ❌         |
 | add_responders           | Incidents          | Adds responders to an incident                      | ❌         |
 | create_incident          | Incidents          | Creates a new incident                              | ❌         |

--- a/pagerduty_mcp/models/__init__.py
+++ b/pagerduty_mcp/models/__init__.py
@@ -12,7 +12,7 @@ from .alert_grouping_settings import (
 from .alerts import Alert, AlertQuery
 from .base import MAX_RESULTS, ListResponseModel
 from .change_events import ChangeEvent, ChangeEventQuery
-from .escalation_policies import EscalationPolicy, EscalationPolicyCreate, EscalationPolicyQuery
+from .escalation_policies import EscalationPolicy, EscalationPolicyCreate, EscalationPolicyQuery, EscalationPolicyUpdate
 from .event_orchestrations import (
     EventOrchestration,
     EventOrchestrationCatchAll,
@@ -158,6 +158,7 @@ __all__ = [
     "ContentBasedIntelligentConfig",
     "EscalationPolicy",
     "EscalationPolicyCreate",
+    "EscalationPolicyUpdate",
     "EscalationPolicyQuery",
     "EventOrchestration",
     "EventOrchestrationCatchAll",

--- a/pagerduty_mcp/models/__init__.py
+++ b/pagerduty_mcp/models/__init__.py
@@ -12,7 +12,7 @@ from .alert_grouping_settings import (
 from .alerts import Alert, AlertQuery
 from .base import MAX_RESULTS, ListResponseModel
 from .change_events import ChangeEvent, ChangeEventQuery
-from .escalation_policies import EscalationPolicy, EscalationPolicyQuery
+from .escalation_policies import EscalationPolicy, EscalationPolicyCreate, EscalationPolicyQuery
 from .event_orchestrations import (
     EventOrchestration,
     EventOrchestrationCatchAll,
@@ -157,6 +157,7 @@ __all__ = [
     "ContentBasedConfig",
     "ContentBasedIntelligentConfig",
     "EscalationPolicy",
+    "EscalationPolicyCreate",
     "EscalationPolicyQuery",
     "EventOrchestration",
     "EventOrchestrationCatchAll",

--- a/pagerduty_mcp/models/escalation_policies.py
+++ b/pagerduty_mcp/models/escalation_policies.py
@@ -93,7 +93,27 @@ class EscalationPolicy(BaseModel):
 
 class EscalationPolicyCreate(BaseModel):
     escalation_policy: EscalationPolicy = Field(
-        description="The escalation policy to create or update"
+        description="The escalation policy to create. escalation_rules is required."
+    )
+
+
+class EscalationPolicyUpdate(BaseModel):
+    class _PartialEscalationPolicy(BaseModel):
+        name: str | None = Field(default=None, description="The name of the escalation policy")
+        description: str | None = Field(default=None, description="The description of the escalation policy")
+        escalation_rules: list[EscalationRule] | None = Field(
+            default=None, description="The ordered list of escalation rules for the policy"
+        )
+        num_loops: int | None = Field(default=None, description="The number of times the escalation policy will repeat")
+        on_call_handoff_notifications: Literal["if_has_services", "always"] | None = Field(
+            default=None, description="Determines how on call handoff notifications will be sent"
+        )
+        teams: list[TeamReference] | None = Field(
+            default=None, description="The teams associated with this escalation policy"
+        )
+
+    escalation_policy: _PartialEscalationPolicy = Field(
+        description="The fields to update on the escalation policy. Only provided fields are sent."
     )
 
 

--- a/pagerduty_mcp/models/escalation_policies.py
+++ b/pagerduty_mcp/models/escalation_policies.py
@@ -51,10 +51,11 @@ class EscalationPolicyReference(BaseModel):
 
 
 class EscalationPolicy(BaseModel):
-    id: str = Field(description="The ID of the escalation policy")
-    summary: str = Field(
+    id: str | None = Field(default=None, description="The ID of the escalation policy")
+    summary: str | None = Field(
+        default=None,
         description="A short-form, server-generated string that provides succinct information"
-        " about the escalation policy"
+        " about the escalation policy",
     )
     name: str = Field(description="The name of the escalation policy")
     description: str | None = Field(default=None, description="The description of the escalation policy")
@@ -88,6 +89,12 @@ class EscalationPolicy(BaseModel):
     @property
     def type(self) -> Literal["escalation_policy"]:
         return "escalation_policy"
+
+
+class EscalationPolicyCreate(BaseModel):
+    escalation_policy: EscalationPolicy = Field(
+        description="The escalation policy to create or update"
+    )
 
 
 class EscalationPolicyQuery(BaseModel):

--- a/pagerduty_mcp/tools/__init__.py
+++ b/pagerduty_mcp/tools/__init__.py
@@ -28,13 +28,11 @@ from .change_events import (
     list_service_change_events,
 )
 
-# Currently disabled to prevent issues with the escalation policies domain
 from .escalation_policies import (
-    # create_escalation_policy,
+    create_escalation_policy,
     get_escalation_policy,
-    # get_escalation_policy_on_call,
-    # get_escalation_policy_services,
     list_escalation_policies,
+    update_escalation_policy,
 )
 from .event_orchestrations import (
     append_event_orchestration_router_rule,
@@ -269,8 +267,9 @@ write_tools = [
     create_status_page_post_update,
     # Users
     create_user,
-    # Escalation Policies - currently disabled
-    # create_escalation_policy,
+    # Escalation Policies
+    create_escalation_policy,
+    update_escalation_policy,
     # Webhooks
     create_webhook_subscription,
     update_webhook_subscription,

--- a/pagerduty_mcp/tools/escalation_policies.py
+++ b/pagerduty_mcp/tools/escalation_policies.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from pagerduty_mcp.client import get_client
-from pagerduty_mcp.models import EscalationPolicy, ListResponseModel
+from pagerduty_mcp.models import EscalationPolicy, EscalationPolicyCreate, ListResponseModel
 from pagerduty_mcp.utils import paginate
 
 
@@ -50,4 +50,41 @@ def get_escalation_policy(policy_id: str) -> EscalationPolicy:
         Escalation policy details
     """
     response = get_client().rget(f"/escalation_policies/{policy_id}")
+    return EscalationPolicy.model_validate(response)
+
+
+def create_escalation_policy(escalation_policy_data: EscalationPolicyCreate) -> EscalationPolicy:
+    """Create a new escalation policy.
+
+    Args:
+        escalation_policy_data: The data for the new escalation policy. Do not include the ID
+            since it is auto-generated. Each escalation rule requires at least one target
+            with 'id' and 'type' (user_reference or schedule_reference).
+
+    Returns:
+        The created escalation policy
+    """
+    response = get_client().rpost("/escalation_policies", json=escalation_policy_data.model_dump(exclude_none=True))
+
+    if type(response) is dict and "escalation_policy" in response:
+        return EscalationPolicy.model_validate(response["escalation_policy"])
+
+    return EscalationPolicy.model_validate(response)
+
+
+def update_escalation_policy(policy_id: str, escalation_policy_data: EscalationPolicyCreate) -> EscalationPolicy:
+    """Update an existing escalation policy.
+
+    Args:
+        policy_id: The ID of the escalation policy to update
+        escalation_policy_data: The updated escalation policy data
+
+    Returns:
+        The updated escalation policy
+    """
+    response = get_client().rput(f"/escalation_policies/{policy_id}", json=escalation_policy_data.model_dump(exclude_none=True))
+
+    if type(response) is dict and "escalation_policy" in response:
+        return EscalationPolicy.model_validate(response["escalation_policy"])
+
     return EscalationPolicy.model_validate(response)

--- a/pagerduty_mcp/tools/escalation_policies.py
+++ b/pagerduty_mcp/tools/escalation_policies.py
@@ -64,7 +64,7 @@ def create_escalation_policy(escalation_policy_data: EscalationPolicyCreate) -> 
     Returns:
         The created escalation policy
     """
-    response = get_client().rpost("/escalation_policies", json=escalation_policy_data.model_dump(exclude_none=True))
+    response = get_client().rpost("/escalation_policies", json=escalation_policy_data.model_dump(exclude_unset=True))
 
     if type(response) is dict and "escalation_policy" in response:
         return EscalationPolicy.model_validate(response["escalation_policy"])
@@ -82,7 +82,7 @@ def update_escalation_policy(policy_id: str, escalation_policy_data: EscalationP
     Returns:
         The updated escalation policy
     """
-    response = get_client().rput(f"/escalation_policies/{policy_id}", json=escalation_policy_data.model_dump(exclude_none=True))
+    response = get_client().rput(f"/escalation_policies/{policy_id}", json=escalation_policy_data.model_dump(exclude_unset=True))
 
     if type(response) is dict and "escalation_policy" in response:
         return EscalationPolicy.model_validate(response["escalation_policy"])

--- a/pagerduty_mcp/tools/escalation_policies.py
+++ b/pagerduty_mcp/tools/escalation_policies.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from pagerduty_mcp.client import get_client
-from pagerduty_mcp.models import EscalationPolicy, EscalationPolicyCreate, ListResponseModel
+from pagerduty_mcp.models import EscalationPolicy, EscalationPolicyCreate, EscalationPolicyUpdate, ListResponseModel
 from pagerduty_mcp.utils import paginate
 
 
@@ -72,7 +72,7 @@ def create_escalation_policy(escalation_policy_data: EscalationPolicyCreate) -> 
     return EscalationPolicy.model_validate(response)
 
 
-def update_escalation_policy(policy_id: str, escalation_policy_data: EscalationPolicyCreate) -> EscalationPolicy:
+def update_escalation_policy(policy_id: str, escalation_policy_data: EscalationPolicyUpdate) -> EscalationPolicy:
     """Update an existing escalation policy.
 
     Args:

--- a/pagerduty_mcp_evals/test_cases/test_cases_builder.py
+++ b/pagerduty_mcp_evals/test_cases/test_cases_builder.py
@@ -16,6 +16,9 @@ from pagerduty_mcp_evals.test_cases.test_alert_grouping_settings import (
     ALERT_GROUPING_SETTINGS_COMPETENCY_TESTS,
 )
 from pagerduty_mcp_evals.test_cases.test_change_events import CHANGE_EVENTS_COMPETENCY_TESTS
+from pagerduty_mcp_evals.test_cases.test_escalation_policies import (
+    ESCALATION_POLICIES_COMPETENCY_TESTS,
+)
 from pagerduty_mcp_evals.test_cases.test_log_entries import LOG_ENTRY_COMPETENCY_TESTS
 from pagerduty_mcp_evals.test_cases.test_analytics import ANALYTICS_COMPETENCY_TESTS
 from pagerduty_mcp_evals.test_cases.test_business_services import BUSINESS_SERVICES_COMPETENCY_TESTS
@@ -32,6 +35,7 @@ test_mapping = {
     "alert-grouping-settings": ALERT_GROUPING_SETTINGS_COMPETENCY_TESTS,
     "change-events": CHANGE_EVENTS_COMPETENCY_TESTS,
     "log-entries": LOG_ENTRY_COMPETENCY_TESTS,
+    "escalation-policies": ESCALATION_POLICIES_COMPETENCY_TESTS,
     "schedules": SCHEDULES_COMPETENCY_TESTS,
     "schedules-v3": SCHEDULES_V3_COMPETENCY_TESTS,
     "services": SERVICES_COMPETENCY_TESTS,
@@ -48,6 +52,7 @@ test_mapping = {
         + ALERT_GROUPING_SETTINGS_COMPETENCY_TESTS
         + CHANGE_EVENTS_COMPETENCY_TESTS
         + LOG_ENTRY_COMPETENCY_TESTS
+        + ESCALATION_POLICIES_COMPETENCY_TESTS
         + SCHEDULES_COMPETENCY_TESTS
         + SERVICES_COMPETENCY_TESTS
         + ANALYTICS_COMPETENCY_TESTS

--- a/pagerduty_mcp_evals/test_cases/test_escalation_policies.py
+++ b/pagerduty_mcp_evals/test_cases/test_escalation_policies.py
@@ -1,0 +1,91 @@
+"""Tests for escalation policies-related competency questions."""
+
+from pagerduty_mcp_evals.test_cases.agent_competency_test import (
+    AgentCompetencyTest,
+    MockMCPToolInvocationResponse,
+    MockToolCall,
+)
+
+
+class EscalationPoliciesCompetencyTest(AgentCompetencyTest):
+    """Specialization of AgentCompetencyTest for escalation policies-related queries."""
+
+    def __init__(self, **kwargs) -> None:
+        mock_responses = [
+            MockMCPToolInvocationResponse(
+                tool_name="list_escalation_policies",
+                parameters=lambda params: True,
+                response={
+                    "response": [
+                        {"id": "EP123", "name": "Default EP", "summary": "Default escalation policy"},
+                        {"id": "EP456", "name": "Engineering EP", "summary": "Engineering escalation policy"},
+                    ]
+                },
+            ),
+            MockMCPToolInvocationResponse(
+                tool_name="get_escalation_policy",
+                parameters=lambda params: params.get("policy_id") == "EP123",
+                response={"id": "EP123", "name": "Default EP", "summary": "Default escalation policy"},
+            ),
+            MockMCPToolInvocationResponse(
+                tool_name="get_user_data",
+                parameters=lambda params: True,
+                response={"id": "USER123", "name": "Test User", "email": "user@example.com"},
+            ),
+        ]
+        super().__init__(mock_responses=mock_responses, **kwargs)
+
+
+ESCALATION_POLICIES_COMPETENCY_TESTS = [
+    EscalationPoliciesCompetencyTest(
+        query="Show me all escalation policies",
+        expected_tool_calls=[MockToolCall(name="list_escalation_policies", parameters={})],
+        description="Basic escalation policies listing",
+    ),
+    EscalationPoliciesCompetencyTest(
+        query="Get details for escalation policy EP123",
+        expected_tool_calls=[
+            MockToolCall(name="get_escalation_policy", parameters={"policy_id": "EP123"})
+        ],
+        description="Get specific escalation policy by ID",
+    ),
+    EscalationPoliciesCompetencyTest(
+        query="Create an escalation policy named 'On-Call Policy' with a 30 minute delay targeting user USER123",
+        expected_tool_calls=[
+            MockToolCall(
+                name="create_escalation_policy",
+                parameters={
+                    "escalation_policy_data": {
+                        "escalation_policy": {
+                            "name": "On-Call Policy",
+                            "escalation_rules": [
+                                {
+                                    "escalation_delay_in_minutes": 30,
+                                    "targets": [{"id": "USER123", "type": "user_reference"}],
+                                }
+                            ],
+                        }
+                    }
+                },
+            )
+        ],
+        description="Create escalation policy with one rule targeting a user",
+    ),
+    EscalationPoliciesCompetencyTest(
+        query="Update escalation policy EP123 to change its name to 'Updated Policy'",
+        expected_tool_calls=[
+            MockToolCall(
+                name="update_escalation_policy",
+                parameters={
+                    "policy_id": "EP123",
+                    "escalation_policy_data": {
+                        "escalation_policy": {
+                            "name": "Updated Policy",
+                        }
+                    },
+                },
+            )
+        ],
+        description="Update escalation policy name",
+    ),
+]

--- a/tests/test_escalation_policies.py
+++ b/tests/test_escalation_policies.py
@@ -4,13 +4,17 @@ from unittest.mock import MagicMock, patch
 from pagerduty_mcp.models.base import DEFAULT_PAGINATION_LIMIT, MAXIMUM_PAGINATION_LIMIT
 from pagerduty_mcp.models.escalation_policies import (
     EscalationPolicy,
+    EscalationPolicyCreate,
     EscalationPolicyQuery,
     EscalationRule,
     EscalationTarget,
 )
+from pagerduty_mcp.models.references import TeamReference
 from pagerduty_mcp.tools.escalation_policies import (
+    create_escalation_policy,
     get_escalation_policy,
     list_escalation_policies,
+    update_escalation_policy,
 )
 
 
@@ -387,6 +391,143 @@ class TestEscalationPolicyTools(unittest.TestCase):
         )
 
         self.assertEqual(policy.type, "escalation_policy")
+
+
+class TestEscalationPolicyWriteTools(unittest.TestCase):
+    """Test cases for escalation policy write tools."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.sample_escalation_rule = {
+            "id": "RULE123",
+            "escalation_delay_in_minutes": 30,
+            "targets": [{"id": "USER123", "type": "user_reference", "summary": "John Doe"}],
+            "escalation_rule_assignment_strategy": "assign_to_everyone",
+        }
+
+        cls.sample_escalation_policy_response = {
+            "id": "EP123",
+            "summary": "Engineering Escalation Policy",
+            "name": "Engineering Team Escalation",
+            "description": "Escalation policy for engineering incidents",
+            "escalation_rules": [cls.sample_escalation_rule],
+            "num_loops": 2,
+            "on_call_handoff_notifications": "if_has_services",
+            "teams": [{"id": "TEAM123", "summary": "Engineering Team", "type": "team_reference"}],
+        }
+
+        cls.mock_client = MagicMock()
+
+    def setUp(self):
+        self.mock_client.reset_mock()
+        self.mock_client.rpost.side_effect = None
+        self.mock_client.rput.side_effect = None
+
+    def _make_escalation_policy_create(self):
+        rule = EscalationRule(
+            escalation_delay_in_minutes=30,
+            targets=[EscalationTarget(id="USER123", type="user_reference", summary="John Doe")],
+        )
+        policy = EscalationPolicy(
+            name="Engineering Team Escalation",
+            description="Escalation policy for engineering incidents",
+            escalation_rules=[rule],
+            num_loops=2,
+            teams=[TeamReference(id="TEAM123", summary="Engineering Team")],
+        )
+        return EscalationPolicyCreate(escalation_policy=policy)
+
+    @patch("pagerduty_mcp.tools.escalation_policies.get_client")
+    def test_create_escalation_policy_wrapped_response(self, mock_get_client):
+        """Test successful escalation policy creation with wrapped response."""
+        mock_get_client.return_value = self.mock_client
+        self.mock_client.rpost.return_value = {"escalation_policy": self.sample_escalation_policy_response}
+
+        policy_create = self._make_escalation_policy_create()
+        result = create_escalation_policy(policy_create)
+
+        mock_get_client.assert_called_once()
+        self.mock_client.rpost.assert_called_once_with("/escalation_policies", json=policy_create.model_dump(exclude_none=True))
+        self.assertIsInstance(result, EscalationPolicy)
+        self.assertEqual(result.id, "EP123")
+        self.assertEqual(result.name, "Engineering Team Escalation")
+
+    @patch("pagerduty_mcp.tools.escalation_policies.get_client")
+    def test_create_escalation_policy_direct_response(self, mock_get_client):
+        """Test successful escalation policy creation with direct response."""
+        mock_get_client.return_value = self.mock_client
+        self.mock_client.rpost.return_value = self.sample_escalation_policy_response
+
+        policy_create = self._make_escalation_policy_create()
+        result = create_escalation_policy(policy_create)
+
+        mock_get_client.assert_called_once()
+        self.mock_client.rpost.assert_called_once_with("/escalation_policies", json=policy_create.model_dump(exclude_none=True))
+        self.assertIsInstance(result, EscalationPolicy)
+        self.assertEqual(result.id, "EP123")
+        self.assertEqual(result.name, "Engineering Team Escalation")
+
+    @patch("pagerduty_mcp.tools.escalation_policies.get_client")
+    def test_create_escalation_policy_client_error(self, mock_get_client):
+        """Test create_escalation_policy when client raises an exception."""
+        mock_get_client.return_value = self.mock_client
+        self.mock_client.rpost.side_effect = Exception("API Error")
+
+        policy_create = self._make_escalation_policy_create()
+
+        with self.assertRaises(Exception) as context:
+            create_escalation_policy(policy_create)
+
+        self.assertEqual(str(context.exception), "API Error")
+        mock_get_client.assert_called_once()
+
+    @patch("pagerduty_mcp.tools.escalation_policies.get_client")
+    def test_update_escalation_policy_wrapped_response(self, mock_get_client):
+        """Test successful escalation policy update with wrapped response."""
+        mock_get_client.return_value = self.mock_client
+        updated_policy = self.sample_escalation_policy_response.copy()
+        updated_policy["name"] = "Updated Escalation Policy"
+        self.mock_client.rput.return_value = {"escalation_policy": updated_policy}
+
+        policy_create = self._make_escalation_policy_create()
+        result = update_escalation_policy("EP123", policy_create)
+
+        mock_get_client.assert_called_once()
+        self.mock_client.rput.assert_called_once_with("/escalation_policies/EP123", json=policy_create.model_dump(exclude_none=True))
+        self.assertIsInstance(result, EscalationPolicy)
+        self.assertEqual(result.id, "EP123")
+        self.assertEqual(result.name, "Updated Escalation Policy")
+
+    @patch("pagerduty_mcp.tools.escalation_policies.get_client")
+    def test_update_escalation_policy_direct_response(self, mock_get_client):
+        """Test successful escalation policy update with direct response."""
+        mock_get_client.return_value = self.mock_client
+        updated_policy = self.sample_escalation_policy_response.copy()
+        updated_policy["name"] = "Updated Escalation Policy"
+        self.mock_client.rput.return_value = updated_policy
+
+        policy_create = self._make_escalation_policy_create()
+        result = update_escalation_policy("EP123", policy_create)
+
+        mock_get_client.assert_called_once()
+        self.mock_client.rput.assert_called_once_with("/escalation_policies/EP123", json=policy_create.model_dump(exclude_none=True))
+        self.assertIsInstance(result, EscalationPolicy)
+        self.assertEqual(result.id, "EP123")
+        self.assertEqual(result.name, "Updated Escalation Policy")
+
+    @patch("pagerduty_mcp.tools.escalation_policies.get_client")
+    def test_update_escalation_policy_client_error(self, mock_get_client):
+        """Test update_escalation_policy when client raises an exception."""
+        mock_get_client.return_value = self.mock_client
+        self.mock_client.rput.side_effect = Exception("API Error")
+
+        policy_create = self._make_escalation_policy_create()
+
+        with self.assertRaises(Exception) as context:
+            update_escalation_policy("EP123", policy_create)
+
+        self.assertEqual(str(context.exception), "API Error")
+        mock_get_client.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/tests/test_escalation_policies.py
+++ b/tests/test_escalation_policies.py
@@ -447,7 +447,7 @@ class TestEscalationPolicyWriteTools(unittest.TestCase):
         result = create_escalation_policy(policy_create)
 
         mock_get_client.assert_called_once()
-        self.mock_client.rpost.assert_called_once_with("/escalation_policies", json=policy_create.model_dump(exclude_none=True))
+        self.mock_client.rpost.assert_called_once_with("/escalation_policies", json=policy_create.model_dump(exclude_unset=True))
         self.assertIsInstance(result, EscalationPolicy)
         self.assertEqual(result.id, "EP123")
         self.assertEqual(result.name, "Engineering Team Escalation")
@@ -462,7 +462,7 @@ class TestEscalationPolicyWriteTools(unittest.TestCase):
         result = create_escalation_policy(policy_create)
 
         mock_get_client.assert_called_once()
-        self.mock_client.rpost.assert_called_once_with("/escalation_policies", json=policy_create.model_dump(exclude_none=True))
+        self.mock_client.rpost.assert_called_once_with("/escalation_policies", json=policy_create.model_dump(exclude_unset=True))
         self.assertIsInstance(result, EscalationPolicy)
         self.assertEqual(result.id, "EP123")
         self.assertEqual(result.name, "Engineering Team Escalation")
@@ -493,7 +493,7 @@ class TestEscalationPolicyWriteTools(unittest.TestCase):
         result = update_escalation_policy("EP123", policy_create)
 
         mock_get_client.assert_called_once()
-        self.mock_client.rput.assert_called_once_with("/escalation_policies/EP123", json=policy_create.model_dump(exclude_none=True))
+        self.mock_client.rput.assert_called_once_with("/escalation_policies/EP123", json=policy_create.model_dump(exclude_unset=True))
         self.assertIsInstance(result, EscalationPolicy)
         self.assertEqual(result.id, "EP123")
         self.assertEqual(result.name, "Updated Escalation Policy")
@@ -510,7 +510,7 @@ class TestEscalationPolicyWriteTools(unittest.TestCase):
         result = update_escalation_policy("EP123", policy_create)
 
         mock_get_client.assert_called_once()
-        self.mock_client.rput.assert_called_once_with("/escalation_policies/EP123", json=policy_create.model_dump(exclude_none=True))
+        self.mock_client.rput.assert_called_once_with("/escalation_policies/EP123", json=policy_create.model_dump(exclude_unset=True))
         self.assertIsInstance(result, EscalationPolicy)
         self.assertEqual(result.id, "EP123")
         self.assertEqual(result.name, "Updated Escalation Policy")

--- a/tests/test_escalation_policies.py
+++ b/tests/test_escalation_policies.py
@@ -6,6 +6,7 @@ from pagerduty_mcp.models.escalation_policies import (
     EscalationPolicy,
     EscalationPolicyCreate,
     EscalationPolicyQuery,
+    EscalationPolicyUpdate,
     EscalationRule,
     EscalationTarget,
 )
@@ -481,6 +482,10 @@ class TestEscalationPolicyWriteTools(unittest.TestCase):
         self.assertEqual(str(context.exception), "API Error")
         mock_get_client.assert_called_once()
 
+    def _make_escalation_policy_update(self, **kwargs):
+        """Helper: build an EscalationPolicyUpdate with only the given fields."""
+        return EscalationPolicyUpdate(escalation_policy=EscalationPolicyUpdate._PartialEscalationPolicy(**kwargs))
+
     @patch("pagerduty_mcp.tools.escalation_policies.get_client")
     def test_update_escalation_policy_wrapped_response(self, mock_get_client):
         """Test successful escalation policy update with wrapped response."""
@@ -489,11 +494,11 @@ class TestEscalationPolicyWriteTools(unittest.TestCase):
         updated_policy["name"] = "Updated Escalation Policy"
         self.mock_client.rput.return_value = {"escalation_policy": updated_policy}
 
-        policy_create = self._make_escalation_policy_create()
-        result = update_escalation_policy("EP123", policy_create)
+        policy_update = self._make_escalation_policy_update(name="Updated Escalation Policy")
+        result = update_escalation_policy("EP123", policy_update)
 
         mock_get_client.assert_called_once()
-        self.mock_client.rput.assert_called_once_with("/escalation_policies/EP123", json=policy_create.model_dump(exclude_unset=True))
+        self.mock_client.rput.assert_called_once_with("/escalation_policies/EP123", json=policy_update.model_dump(exclude_unset=True))
         self.assertIsInstance(result, EscalationPolicy)
         self.assertEqual(result.id, "EP123")
         self.assertEqual(result.name, "Updated Escalation Policy")
@@ -506,14 +511,31 @@ class TestEscalationPolicyWriteTools(unittest.TestCase):
         updated_policy["name"] = "Updated Escalation Policy"
         self.mock_client.rput.return_value = updated_policy
 
-        policy_create = self._make_escalation_policy_create()
-        result = update_escalation_policy("EP123", policy_create)
+        policy_update = self._make_escalation_policy_update(name="Updated Escalation Policy")
+        result = update_escalation_policy("EP123", policy_update)
 
         mock_get_client.assert_called_once()
-        self.mock_client.rput.assert_called_once_with("/escalation_policies/EP123", json=policy_create.model_dump(exclude_unset=True))
+        self.mock_client.rput.assert_called_once_with("/escalation_policies/EP123", json=policy_update.model_dump(exclude_unset=True))
         self.assertIsInstance(result, EscalationPolicy)
         self.assertEqual(result.id, "EP123")
         self.assertEqual(result.name, "Updated Escalation Policy")
+
+    @patch("pagerduty_mcp.tools.escalation_policies.get_client")
+    def test_update_escalation_policy_partial_name_only(self, mock_get_client):
+        """Test that update with name only does not send escalation_rules (no data loss)."""
+        mock_get_client.return_value = self.mock_client
+        updated_policy = self.sample_escalation_policy_response.copy()
+        updated_policy["name"] = "Renamed Policy"
+        self.mock_client.rput.return_value = {"escalation_policy": updated_policy}
+
+        policy_update = self._make_escalation_policy_update(name="Renamed Policy")
+        result = update_escalation_policy("EP123", policy_update)
+
+        call_json = self.mock_client.rput.call_args.kwargs["json"]
+        # escalation_rules must NOT be sent — would delete existing rules
+        self.assertNotIn("escalation_rules", call_json.get("escalation_policy", {}))
+        self.assertEqual(call_json["escalation_policy"]["name"], "Renamed Policy")
+        self.assertIsInstance(result, EscalationPolicy)
 
     @patch("pagerduty_mcp.tools.escalation_policies.get_client")
     def test_update_escalation_policy_client_error(self, mock_get_client):
@@ -521,10 +543,10 @@ class TestEscalationPolicyWriteTools(unittest.TestCase):
         mock_get_client.return_value = self.mock_client
         self.mock_client.rput.side_effect = Exception("API Error")
 
-        policy_create = self._make_escalation_policy_create()
+        policy_update = self._make_escalation_policy_update(name="Test")
 
         with self.assertRaises(Exception) as context:
-            update_escalation_policy("EP123", policy_create)
+            update_escalation_policy("EP123", policy_update)
 
         self.assertEqual(str(context.exception), "API Error")
         mock_get_client.assert_called_once()


### PR DESCRIPTION
## Summary

- Adds `create_escalation_policy` tool calling `POST /escalation_policies`
- Adds `update_escalation_policy` tool calling `PUT /escalation_policies/{id}`
- Both tools follow the existing create/update pattern used by `services` and `schedules`

## Motivation

The MCP server only had read-only access to escalation policies (`list_escalation_policies`, `get_escalation_policy`). This broke the on-call setup automation workflow since schedules and services already had create/update tools but escalation policies did not, forcing users back to the PagerDuty UI.

Closes #118

## Changes

- Added `EscalationPolicyCreate` model wrapping `EscalationPolicy` (same pattern as `ServiceCreate`)
- Made `id` and `summary` optional in `EscalationPolicy` (server-generated fields)
- Registered both tools in `write_tools` (require `--enable-write-tools` flag)
- Added 6 unit tests covering wrapped/direct API responses and error handling
- Added 4 eval competency test cases in `pagerduty_mcp_evals/test_cases/`

## Test plan

- [ ] `uv run pytest tests/test_escalation_policies.py -v` — all new tests pass
- [ ] Restart MCP server in VS Code and confirm tool count is 67
- [ ] Ask agent: "List my escalation policies" — read still works
- [ ] Ask agent: "Create an escalation policy named 'Test Policy' with a 30 minute delay targeting my user" — policy created successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)