### PR TITLE
feat: add HTTP / SSE / streamable-http transport support

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ The server supports three MCP transports, selected via the `--transport` flag:
 | `streamable-http` | Long-running remote/server deployments. MCP endpoint at `/mcp`. |     |
 | `sse`             | Legacy Server-Sent Events transport.                        |         |
 
-For HTTP-based transports, `--host` (default `127.0.0.1`) and `--port` (default `8000`) control the listen address. These can also be set via environment variables `MCP_HOST` and `MCP_PORT`.
+For HTTP-based transports, `--host` (default `127.0.0.1`) and `--port` (default `8000`) control the listen address. These can also be set via environment variables `MCP_HOST` and `MCP_PORT`. Note: `MCP_PORT` must always be a valid integer — the CLI parses its type at startup regardless of `--transport`; range validation (1–65535) only applies for HTTP transports.
 
 > ⚠️ **Security — HTTP transports have no built-in authentication.** When running `streamable-http` or `sse`, the MCP endpoint is exposed with **no authentication**, and every request uses the single `PAGERDUTY_USER_API_KEY` the server was started with. Any client that can reach the host/port can invoke tools — including write tools when `--enable-write-tools` is set — with that key's full PagerDuty privileges.
 > - The default bind address is `127.0.0.1` (loopback only) — keep it that way for local use.

--- a/README.md
+++ b/README.md
@@ -260,6 +260,36 @@ To integrate the Docker container with MCP clients, you can use Docker as the co
 
 > **Note**: The Docker container uses stdio transport, making it compatible with MCP clients that expect standard input/output communication. Ensure you build the image first using `docker build -t pagerduty-mcp:latest .`
 
+## Transport modes
+
+The server supports three MCP transports, selected via the `--transport` flag:
+
+| Transport         | Use case                                                    | Default |
+|-------------------|-------------------------------------------------------------|---------|
+| `stdio`           | Local clients launched as a subprocess (Cursor, VS Code).   | ✅      |
+| `streamable-http` | Long-running remote/server deployments. MCP endpoint at `/mcp`. |     |
+| `sse`             | Legacy Server-Sent Events transport.                        |         |
+
+For HTTP-based transports, `--host` (default `127.0.0.1`) and `--port` (default `8000`) control the listen address.
+
+**Example: run as a remote streamable-HTTP server**
+
+```bash
+pagerduty-mcp --transport streamable-http --host 0.0.0.0 --port 8000
+# MCP endpoint: http://localhost:8000/mcp
+```
+
+**Docker:**
+
+```bash
+docker run -d -p 8000:8000 \
+  -e PAGERDUTY_USER_API_KEY="your-api-key-here" \
+  pagerduty-mcp:latest \
+  --transport streamable-http --host 0.0.0.0 --port 8000
+```
+
+The default remains `stdio` so existing local integrations are unaffected.
+
 ## Set up locally
 
 1.  **Clone the repository** 

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ For HTTP-based transports, `--host` (default `127.0.0.1`) and `--port` (default 
 
 ```bash
 pagerduty-mcp --transport streamable-http --host 0.0.0.0 --port 8000
-# MCP endpoint: http://localhost:8000/mcp
+# MCP endpoint: http://<your-machine-ip>:8000/mcp
 # ⚠️ Only use --host 0.0.0.0 behind an authenticating proxy or on a trusted network.
 ```
 

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ The server supports three MCP transports, selected via the `--transport` flag:
 | `streamable-http` | Long-running remote/server deployments. MCP endpoint at `/mcp`. |     |
 | `sse`             | Legacy Server-Sent Events transport.                        |         |
 
-For HTTP-based transports, `--host` (default `127.0.0.1`) and `--port` (default `8000`) control the listen address.
+For HTTP-based transports, `--host` (default `127.0.0.1`) and `--port` (default `8000`) control the listen address. These can also be set via environment variables `MCP_HOST` and `MCP_PORT`.
 
 **Example: run as a remote streamable-HTTP server**
 
@@ -279,13 +279,21 @@ pagerduty-mcp --transport streamable-http --host 0.0.0.0 --port 8000
 # MCP endpoint: http://localhost:8000/mcp
 ```
 
+**Using environment variables:**
+
+```bash
+MCP_HOST=0.0.0.0 MCP_PORT=8000 pagerduty-mcp --transport streamable-http
+```
+
 **Docker:**
 
 ```bash
 docker run -d -p 8000:8000 \
   -e PAGERDUTY_USER_API_KEY="your-api-key-here" \
+  -e MCP_HOST=0.0.0.0 \
+  -e MCP_PORT=8000 \
   pagerduty-mcp:latest \
-  --transport streamable-http --host 0.0.0.0 --port 8000
+  --transport streamable-http
 ```
 
 The default remains `stdio` so existing local integrations are unaffected.

--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ pagerduty-mcp --transport streamable-http --host 0.0.0.0 --port 8000
 
 ```bash
 MCP_HOST=0.0.0.0 MCP_PORT=8000 pagerduty-mcp --transport streamable-http
+# ⚠️ Only use MCP_HOST=0.0.0.0 behind an authenticating proxy or on a trusted network.
 ```
 
 **Docker:**

--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ docker run -d -p 8000:8000 \
   -e MCP_PORT=8000 \
   pagerduty-mcp:latest \
   --transport streamable-http
+# ⚠️ Only use MCP_HOST=0.0.0.0 behind an authenticating proxy or on a trusted network.
 ```
 
 The default remains `stdio` so existing local integrations are unaffected.

--- a/README.md
+++ b/README.md
@@ -272,11 +272,16 @@ The server supports three MCP transports, selected via the `--transport` flag:
 
 For HTTP-based transports, `--host` (default `127.0.0.1`) and `--port` (default `8000`) control the listen address. These can also be set via environment variables `MCP_HOST` and `MCP_PORT`.
 
+> ⚠️ **Security — HTTP transports have no built-in authentication.** When running `streamable-http` or `sse`, the MCP endpoint is exposed with **no authentication**, and every request uses the single `PAGERDUTY_USER_API_KEY` the server was started with. Any client that can reach the host/port can invoke tools — including write tools when `--enable-write-tools` is set — with that key's full PagerDuty privileges.
+> - The default bind address is `127.0.0.1` (loopback only) — keep it that way for local use.
+> - Only bind to `0.0.0.0`/a routable address when the endpoint sits behind an authenticating reverse proxy / API gateway (e.g. oauth2-proxy, mTLS) or on a trusted network. Do not expose it directly to untrusted networks.
+
 **Example: run as a remote streamable-HTTP server**
 
 ```bash
 pagerduty-mcp --transport streamable-http --host 0.0.0.0 --port 8000
 # MCP endpoint: http://localhost:8000/mcp
+# ⚠️ Only use --host 0.0.0.0 behind an authenticating proxy or on a trusted network.
 ```
 
 **Using environment variables:**

--- a/pagerduty_mcp/__main__.py
+++ b/pagerduty_mcp/__main__.py
@@ -5,7 +5,6 @@ from pagerduty_mcp.server import app
 
 def main():
     """Main entry point for the pagerduty-mcp command."""
-    # STDIO transport reserves stdout for JSON-RPC; diagnostics must go to stderr.
     print(
         "Starting PagerDuty MCP Server. Use the --enable-write-tools flag to enable write tools.",
         file=sys.stderr,

--- a/pagerduty_mcp/server.py
+++ b/pagerduty_mcp/server.py
@@ -92,12 +92,15 @@ def run(
     fastmcp_kwargs: dict = {"instructions": MCP_SERVER_INSTRUCTIONS}
 
     if transport == Transport.stdio:
-        _http_env_vars = {k: v for k, v in {"MCP_HOST": host, "MCP_PORT": str(port)}.items()
-                         if v not in ("127.0.0.1", "8000")}
-        if _http_env_vars:
+        _ignored = []
+        if host != "127.0.0.1":
+            _ignored.append(f"--host {host!r}")
+        if port != 8000:
+            _ignored.append(f"--port {port}")
+        if _ignored:
             logging.getLogger(__name__).warning(
-                "Environment variable(s) %s have no effect when --transport stdio is used.",
-                ", ".join(_http_env_vars),
+                "%s have no effect when --transport stdio is used.",
+                " and ".join(_ignored),
             )
     else:
         if not (1 <= port <= 65535):

--- a/pagerduty_mcp/server.py
+++ b/pagerduty_mcp/server.py
@@ -149,17 +149,20 @@ def run(
         # operator handle network-level security (firewall, reverse proxy, etc.).
         if is_loopback:
             host_header = f"[{normalized_host}]" if is_ipv6 else normalized_host
-            # Deduplicate while preserving order (e.g. host='localhost' would otherwise
-            # produce duplicate entries since host_header == 'localhost').
-            allowed_hosts = list(dict.fromkeys([
+            candidates = [
                 f"{host_header}:{port}",
                 host_header,           # bare form — some clients omit port from Host header
                 f"localhost:{port}",
                 "localhost",
-            ]))
+            ]
+            # When binding to the 'localhost' hostname, clients may connect via the
+            # numeric loopback addresses (127.0.0.1 or [::1]) and send those as the
+            # Host header. Include both to avoid spurious 421 rejections.
+            if normalized_host.lower() == "localhost":
+                candidates.extend([f"127.0.0.1:{port}", "127.0.0.1", f"[::1]:{port}", "[::1]"])
             fastmcp_kwargs["transport_security"] = TransportSecuritySettings(
                 enable_dns_rebinding_protection=True,
-                allowed_hosts=allowed_hosts,
+                allowed_hosts=list(dict.fromkeys(candidates)),
             )
 
     mcp = FastMCP("PagerDuty MCP Server", **fastmcp_kwargs)

--- a/pagerduty_mcp/server.py
+++ b/pagerduty_mcp/server.py
@@ -117,6 +117,8 @@ def run(
         normalized_host = host.strip()
         if not normalized_host:
             raise typer.BadParameter("Host must not be empty", param_hint="--host")
+        if any(c.isspace() for c in normalized_host):
+            raise typer.BadParameter("Host must not contain whitespace", param_hint="--host")
         is_ipv6 = False
         try:
             addr = ipaddress.ip_address(normalized_host)

--- a/pagerduty_mcp/server.py
+++ b/pagerduty_mcp/server.py
@@ -97,7 +97,7 @@ def run(
 
     if transport == Transport.stdio:
         _ignored = []
-        if host != "127.0.0.1":
+        if host.strip() != "127.0.0.1":
             _ignored.append(f"host={host!r}")
         if port != 8000:
             _ignored.append(f"port={port}")

--- a/pagerduty_mcp/server.py
+++ b/pagerduty_mcp/server.py
@@ -24,6 +24,8 @@ class Transport(str, Enum):
 
 logging.basicConfig(level=logging.WARNING)
 
+logger = logging.getLogger(__name__)
+
 
 app = typer.Typer()
 
@@ -101,7 +103,7 @@ def run(
             _ignored.append(f"port={port}")
         if _ignored:
             verb = "have" if len(_ignored) > 1 else "has"
-            logging.getLogger(__name__).warning(
+            logger.warning(
                 "%s %s no effect when --transport stdio is used.",
                 " and ".join(_ignored),
                 verb,
@@ -111,7 +113,7 @@ def run(
             raise typer.BadParameter(f"Port must be between 1 and 65535, got {port}", param_hint="--port")
 
         if port < 1024:
-            logging.getLogger(__name__).warning(
+            logger.warning(
                 "Port %d is a privileged port — binding may fail on non-root processes.", port
             )
 
@@ -132,7 +134,7 @@ def run(
             is_loopback = normalized_host.lower() == "localhost"
 
         if not is_loopback:
-            logging.getLogger(__name__).warning(
+            logger.warning(
                 "HTTP transport '%s' bound to '%s' with no built-in authentication — "
                 "ensure this endpoint is protected by an authenticating proxy.",
                 transport.value,

--- a/pagerduty_mcp/server.py
+++ b/pagerduty_mcp/server.py
@@ -108,7 +108,7 @@ def run(
                 "Port %d is a privileged port — binding may fail on non-root processes.", port
             )
 
-        if any(c in host for c in ("\n", "\r", "\x00")):
+        if any(ord(c) < 0x20 for c in host):
             raise typer.BadParameter("Host must not contain control characters", param_hint="--host")
 
         normalized_host = host.strip()
@@ -127,18 +127,15 @@ def run(
 
         fastmcp_kwargs["host"] = normalized_host
         fastmcp_kwargs["port"] = port
-        # For loopback binds, restrict allowed Host headers to prevent DNS rebinding.
-        # For wildcard binds (0.0.0.0), clients connect via their own IP so no fixed
-        # allowlist is possible — the operator is responsible for network-level security.
-        allowed_hosts = (
-            [f"{normalized_host}:{port}", f"localhost:{port}", "localhost"]
-            if is_loopback
-            else []
-        )
-        fastmcp_kwargs["transport_security"] = TransportSecuritySettings(
-            enable_dns_rebinding_protection=True,
-            allowed_hosts=allowed_hosts,
-        )
+        # For loopback binds, enable DNS rebinding protection with an explicit Host
+        # allowlist. For wildcard binds (0.0.0.0), clients connect via their own IP
+        # so no fixed allowlist is possible — omit transport_security and let the
+        # operator handle network-level security (firewall, reverse proxy, etc.).
+        if is_loopback:
+            fastmcp_kwargs["transport_security"] = TransportSecuritySettings(
+                enable_dns_rebinding_protection=True,
+                allowed_hosts=[f"{normalized_host}:{port}", f"localhost:{port}", "localhost"],
+            )
 
     mcp = FastMCP("PagerDuty MCP Server", **fastmcp_kwargs)
     for tool in read_tools:

--- a/pagerduty_mcp/server.py
+++ b/pagerduty_mcp/server.py
@@ -94,9 +94,9 @@ def run(
     if transport == Transport.stdio:
         _ignored = []
         if host != "127.0.0.1":
-            _ignored.append(f"--host {host!r}")
+            _ignored.append(f"host={host!r}")
         if port != 8000:
-            _ignored.append(f"--port {port}")
+            _ignored.append(f"port={port}")
         if _ignored:
             logging.getLogger(__name__).warning(
                 "%s have no effect when --transport stdio is used.",
@@ -115,8 +115,11 @@ def run(
             raise typer.BadParameter("Host must not contain control characters", param_hint="--host")
 
         normalized_host = host.strip()
+        is_ipv6 = False
         try:
-            is_loopback = ipaddress.ip_address(normalized_host).is_loopback
+            addr = ipaddress.ip_address(normalized_host)
+            is_loopback = addr.is_loopback
+            is_ipv6 = addr.version == 6
         except ValueError:
             is_loopback = normalized_host.lower() == "localhost"
 
@@ -135,9 +138,15 @@ def run(
         # so no fixed allowlist is possible — omit transport_security and let the
         # operator handle network-level security (firewall, reverse proxy, etc.).
         if is_loopback:
+            host_header = f"[{normalized_host}]" if is_ipv6 else normalized_host
             fastmcp_kwargs["transport_security"] = TransportSecuritySettings(
                 enable_dns_rebinding_protection=True,
-                allowed_hosts=[f"{normalized_host}:{port}", f"localhost:{port}", "localhost"],
+                allowed_hosts=[
+                    f"{host_header}:{port}",
+                    host_header,           # bare form — clients may omit port for standard ports
+                    f"localhost:{port}",
+                    "localhost",
+                ],
             )
 
     mcp = FastMCP("PagerDuty MCP Server", **fastmcp_kwargs)

--- a/pagerduty_mcp/server.py
+++ b/pagerduty_mcp/server.py
@@ -80,7 +80,7 @@ def run(
     port: int = typer.Option(
         default=8000,
         envvar="MCP_PORT",
-        help="Port to bind to for HTTP-based transports",
+        help="Port to bind to for HTTP-based transports. Must be a valid integer even in stdio mode.",
     ),
 ) -> None:
     """Run the MCP server with the specified configuration.

--- a/pagerduty_mcp/server.py
+++ b/pagerduty_mcp/server.py
@@ -2,6 +2,7 @@ import ipaddress
 import logging
 from collections.abc import Callable
 from enum import Enum
+from typing import Any
 
 import typer
 from mcp.server.fastmcp import FastMCP
@@ -65,9 +66,20 @@ def add_write_tool(mcp_instance: FastMCP, tool: Callable) -> None:
 def run(
     *,
     enable_write_tools: bool = False,
-    transport: Transport = typer.Option(default=Transport.stdio, help="Transport protocol to use (stdio, sse, or streamable-http)"),
-    host: str = typer.Option(default="127.0.0.1", envvar="MCP_HOST", help="Host to bind to for HTTP-based transports"),
-    port: int = typer.Option(default=8000, envvar="MCP_PORT", help="Port to bind to for HTTP-based transports"),
+    transport: Transport = typer.Option(
+        default=Transport.stdio,
+        help="Transport protocol to use (stdio, sse, or streamable-http)",
+    ),
+    host: str = typer.Option(
+        default="127.0.0.1",
+        envvar="MCP_HOST",
+        help="Host to bind to for HTTP-based transports",
+    ),
+    port: int = typer.Option(
+        default=8000,
+        envvar="MCP_PORT",
+        help="Port to bind to for HTTP-based transports",
+    ),
 ) -> None:
     """Run the MCP server with the specified configuration.
 
@@ -79,7 +91,7 @@ def run(
     """
     ContextResolver.set_strategy(ApplicationContextStrategy())
 
-    fastmcp_kwargs: dict = {"instructions": MCP_SERVER_INSTRUCTIONS}
+    fastmcp_kwargs: dict[str, Any] = {"instructions": MCP_SERVER_INSTRUCTIONS}
 
     if transport == Transport.stdio:
         _ignored = []
@@ -135,14 +147,17 @@ def run(
         # operator handle network-level security (firewall, reverse proxy, etc.).
         if is_loopback:
             host_header = f"[{normalized_host}]" if is_ipv6 else normalized_host
+            # Deduplicate while preserving order (e.g. host='localhost' would otherwise
+            # produce duplicate entries since host_header == 'localhost').
+            allowed_hosts = list(dict.fromkeys([
+                f"{host_header}:{port}",
+                host_header,           # bare form — some clients omit port from Host header
+                f"localhost:{port}",
+                "localhost",
+            ]))
             fastmcp_kwargs["transport_security"] = TransportSecuritySettings(
                 enable_dns_rebinding_protection=True,
-                allowed_hosts=[
-                    f"{host_header}:{port}",
-                    host_header,           # bare form — some clients omit port from Host header
-                    f"localhost:{port}",
-                    "localhost",
-                ],
+                allowed_hosts=allowed_hosts,
             )
 
     mcp = FastMCP("PagerDuty MCP Server", **fastmcp_kwargs)

--- a/pagerduty_mcp/server.py
+++ b/pagerduty_mcp/server.py
@@ -117,7 +117,7 @@ def run(
                 "Port %d is a privileged port — binding may fail on non-root processes.", port
             )
 
-        if any(ord(c) < 0x20 for c in host):
+        if any(ord(c) < 0x20 or ord(c) == 0x7F for c in host):
             raise typer.BadParameter("Host must not contain control characters", param_hint="--host")
 
         normalized_host = host.strip()
@@ -131,6 +131,11 @@ def run(
             is_loopback = addr.is_loopback
             is_ipv6 = addr.version == 6
         except ValueError:
+            if ":" in normalized_host:
+                raise typer.BadParameter(
+                    "Host must not include a port — use --port to specify the port separately",
+                    param_hint="--host",
+                )
             is_loopback = normalized_host.lower() == "localhost"
 
         if not is_loopback:

--- a/pagerduty_mcp/server.py
+++ b/pagerduty_mcp/server.py
@@ -6,9 +6,9 @@ import typer
 from mcp.server.fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 
-from pagerduty_mcp.tools import read_tools, write_tools
 from pagerduty_mcp.context import ContextResolver
 from pagerduty_mcp.context.application_context_strategy import ApplicationContextStrategy
+from pagerduty_mcp.tools import read_tools, write_tools
 
 
 class Transport(str, Enum):

--- a/pagerduty_mcp/server.py
+++ b/pagerduty_mcp/server.py
@@ -88,13 +88,19 @@ def run(
     if not (1 <= port <= 65535):
         raise typer.BadParameter(f"Port must be between 1 and 65535, got {port}", param_hint="--port")
 
+    if port < 1024:
+        logging.getLogger(__name__).warning(
+            "Port %d is a privileged port — binding may fail on non-root processes.", port
+        )
+
     _loopback_addresses = {"127.0.0.1", "::1", "localhost"}
-    if transport != Transport.stdio and host not in _loopback_addresses:
+    normalized_host = host.strip().lower()
+    if transport != Transport.stdio and normalized_host not in _loopback_addresses:
         logging.getLogger(__name__).warning(
             "HTTP transport '%s' bound to '%s' with no built-in authentication — "
             "ensure this endpoint is protected by an authenticating proxy.",
             transport.value,
-            host,
+            normalized_host,
         )
 
     ContextResolver.set_strategy(ApplicationContextStrategy())

--- a/pagerduty_mcp/server.py
+++ b/pagerduty_mcp/server.py
@@ -85,6 +85,17 @@ def run(
         host: Host to bind to for HTTP-based transports (env: MCP_HOST)
         port: Port to bind to for HTTP-based transports (env: MCP_PORT)
     """
+    if not (1 <= port <= 65535):
+        raise typer.BadParameter(f"Port must be between 1 and 65535, got {port}", param_hint="--port")
+
+    if transport != Transport.stdio and host != "127.0.0.1":
+        logging.getLogger(__name__).warning(
+            "HTTP transport '%s' bound to '%s' with no built-in authentication — "
+            "ensure this endpoint is protected by an authenticating proxy.",
+            transport.value,
+            host,
+        )
+
     ContextResolver.set_strategy(ApplicationContextStrategy())
 
     mcp = FastMCP(

--- a/pagerduty_mcp/server.py
+++ b/pagerduty_mcp/server.py
@@ -127,9 +127,17 @@ def run(
 
         fastmcp_kwargs["host"] = normalized_host
         fastmcp_kwargs["port"] = port
+        # For loopback binds, restrict allowed Host headers to prevent DNS rebinding.
+        # For wildcard binds (0.0.0.0), clients connect via their own IP so no fixed
+        # allowlist is possible — the operator is responsible for network-level security.
+        allowed_hosts = (
+            [f"{normalized_host}:{port}", f"localhost:{port}", "localhost"]
+            if is_loopback
+            else []
+        )
         fastmcp_kwargs["transport_security"] = TransportSecuritySettings(
             enable_dns_rebinding_protection=True,
-            allowed_hosts=[f"{normalized_host}:{port}", "localhost"],
+            allowed_hosts=allowed_hosts,
         )
 
     mcp = FastMCP("PagerDuty MCP Server", **fastmcp_kwargs)

--- a/pagerduty_mcp/server.py
+++ b/pagerduty_mcp/server.py
@@ -85,32 +85,33 @@ def run(
         host: Host to bind to for HTTP-based transports (env: MCP_HOST)
         port: Port to bind to for HTTP-based transports (env: MCP_PORT)
     """
-    if not (1 <= port <= 65535):
-        raise typer.BadParameter(f"Port must be between 1 and 65535, got {port}", param_hint="--port")
-
-    if port < 1024:
-        logging.getLogger(__name__).warning(
-            "Port %d is a privileged port — binding may fail on non-root processes.", port
-        )
-
-    _loopback_addresses = {"127.0.0.1", "::1", "localhost"}
-    normalized_host = host.strip().lower().replace("\n", "").replace("\r", "")
-    if transport != Transport.stdio and normalized_host not in _loopback_addresses:
-        logging.getLogger(__name__).warning(
-            "HTTP transport '%s' bound to '%s' with no built-in authentication — "
-            "ensure this endpoint is protected by an authenticating proxy.",
-            transport.value,
-            normalized_host,
-        )
-
     ContextResolver.set_strategy(ApplicationContextStrategy())
 
-    mcp = FastMCP(
-        "PagerDuty MCP Server",
-        instructions=MCP_SERVER_INSTRUCTIONS,
-        host=normalized_host,
-        port=port,
-    )
+    fastmcp_kwargs: dict = {"instructions": MCP_SERVER_INSTRUCTIONS}
+
+    if transport != Transport.stdio:
+        if not (1 <= port <= 65535):
+            raise typer.BadParameter(f"Port must be between 1 and 65535, got {port}", param_hint="--port")
+
+        if port < 1024:
+            logging.getLogger(__name__).warning(
+                "Port %d is a privileged port — binding may fail on non-root processes.", port
+            )
+
+        _loopback_addresses = {"127.0.0.1", "::1", "localhost"}
+        normalized_host = host.strip().lower().replace("\n", "").replace("\r", "")
+        if normalized_host not in _loopback_addresses:
+            logging.getLogger(__name__).warning(
+                "HTTP transport '%s' bound to '%s' with no built-in authentication — "
+                "ensure this endpoint is protected by an authenticating proxy.",
+                transport.value,
+                normalized_host,
+            )
+
+        fastmcp_kwargs["host"] = normalized_host
+        fastmcp_kwargs["port"] = port
+
+    mcp = FastMCP("PagerDuty MCP Server", **fastmcp_kwargs)
     for tool in read_tools:
         add_read_only_tool(mcp, tool)
 

--- a/pagerduty_mcp/server.py
+++ b/pagerduty_mcp/server.py
@@ -149,9 +149,9 @@ def run(
         fastmcp_kwargs["host"] = normalized_host
         fastmcp_kwargs["port"] = port
         # For loopback binds, enable DNS rebinding protection with an explicit Host
-        # allowlist. For wildcard binds (0.0.0.0), clients connect via their own IP
-        # so no fixed allowlist is possible — omit transport_security and let the
-        # operator handle network-level security (firewall, reverse proxy, etc.).
+        # allowlist. For any non-loopback bind (e.g. 0.0.0.0, 192.168.1.1), clients
+        # connect via their own IP so no fixed allowlist is possible — omit
+        # transport_security and let the operator handle network-level security.
         if is_loopback:
             host_header = f"[{normalized_host}]" if is_ipv6 else normalized_host
             candidates = [

--- a/pagerduty_mcp/server.py
+++ b/pagerduty_mcp/server.py
@@ -74,16 +74,16 @@ def run(
     *,
     enable_write_tools: bool = False,
     transport: Transport = Transport.stdio,
-    host: str = "127.0.0.1",
-    port: int = 8000,
+    host: str = typer.Option(default="127.0.0.1", envvar="MCP_HOST", help="Host to bind to for HTTP-based transports"),
+    port: int = typer.Option(default=8000, envvar="MCP_PORT", help="Port to bind to for HTTP-based transports"),
 ) -> None:
     """Run the MCP server with the specified configuration.
 
     Args:
         enable_write_tools: Flag to enable write tools
         transport: Transport protocol to use (stdio, sse, or streamable-http)
-        host: Host to bind to for HTTP-based transports
-        port: Port to bind to for HTTP-based transports
+        host: Host to bind to for HTTP-based transports (env: MCP_HOST)
+        port: Port to bind to for HTTP-based transports (env: MCP_PORT)
     """
     ContextResolver.set_strategy(ApplicationContextStrategy())
 

--- a/pagerduty_mcp/server.py
+++ b/pagerduty_mcp/server.py
@@ -73,7 +73,7 @@ for _tool in write_tools:
 def run(
     *,
     enable_write_tools: bool = False,
-    transport: Transport = Transport.stdio,
+    transport: Transport = typer.Option(default=Transport.stdio, help="Transport protocol to use (stdio, sse, or streamable-http)"),
     host: str = typer.Option(default="127.0.0.1", envvar="MCP_HOST", help="Host to bind to for HTTP-based transports"),
     port: int = typer.Option(default=8000, envvar="MCP_PORT", help="Port to bind to for HTTP-based transports"),
 ) -> None:

--- a/pagerduty_mcp/server.py
+++ b/pagerduty_mcp/server.py
@@ -1,9 +1,11 @@
+import ipaddress
 import logging
 from collections.abc import Callable
 from enum import Enum
 
 import typer
 from mcp.server.fastmcp import FastMCP
+from mcp.server.transport_security import TransportSecuritySettings
 from mcp.types import ToolAnnotations
 
 from pagerduty_mcp.context import ContextResolver
@@ -89,7 +91,15 @@ def run(
 
     fastmcp_kwargs: dict = {"instructions": MCP_SERVER_INSTRUCTIONS}
 
-    if transport != Transport.stdio:
+    if transport == Transport.stdio:
+        _http_env_vars = {k: v for k, v in {"MCP_HOST": host, "MCP_PORT": str(port)}.items()
+                         if v not in ("127.0.0.1", "8000")}
+        if _http_env_vars:
+            logging.getLogger(__name__).warning(
+                "Environment variable(s) %s have no effect when --transport stdio is used.",
+                ", ".join(_http_env_vars),
+            )
+    else:
         if not (1 <= port <= 65535):
             raise typer.BadParameter(f"Port must be between 1 and 65535, got {port}", param_hint="--port")
 
@@ -98,12 +108,16 @@ def run(
                 "Port %d is a privileged port — binding may fail on non-root processes.", port
             )
 
-        if "\n" in host or "\r" in host:
-            raise typer.BadParameter("Host must not contain newline characters", param_hint="--host")
+        if any(c in host for c in ("\n", "\r", "\x00")):
+            raise typer.BadParameter("Host must not contain control characters", param_hint="--host")
 
-        _loopback_addresses = {"127.0.0.1", "::1", "localhost"}
         normalized_host = host.strip()
-        if normalized_host.lower() not in _loopback_addresses:
+        try:
+            is_loopback = ipaddress.ip_address(normalized_host).is_loopback
+        except ValueError:
+            is_loopback = normalized_host.lower() == "localhost"
+
+        if not is_loopback:
             logging.getLogger(__name__).warning(
                 "HTTP transport '%s' bound to '%s' with no built-in authentication — "
                 "ensure this endpoint is protected by an authenticating proxy.",
@@ -113,6 +127,10 @@ def run(
 
         fastmcp_kwargs["host"] = normalized_host
         fastmcp_kwargs["port"] = port
+        fastmcp_kwargs["transport_security"] = TransportSecuritySettings(
+            enable_dns_rebinding_protection=True,
+            allowed_hosts=[f"{normalized_host}:{port}", "localhost"],
+        )
 
     mcp = FastMCP("PagerDuty MCP Server", **fastmcp_kwargs)
     for tool in read_tools:

--- a/pagerduty_mcp/server.py
+++ b/pagerduty_mcp/server.py
@@ -98,9 +98,12 @@ def run(
                 "Port %d is a privileged port — binding may fail on non-root processes.", port
             )
 
+        if "\n" in host or "\r" in host:
+            raise typer.BadParameter("Host must not contain newline characters", param_hint="--host")
+
         _loopback_addresses = {"127.0.0.1", "::1", "localhost"}
-        normalized_host = host.strip().lower().replace("\n", "").replace("\r", "")
-        if normalized_host not in _loopback_addresses:
+        normalized_host = host.strip()
+        if normalized_host.lower() not in _loopback_addresses:
             logging.getLogger(__name__).warning(
                 "HTTP transport '%s' bound to '%s' with no built-in authentication — "
                 "ensure this endpoint is protected by an authenticating proxy.",

--- a/pagerduty_mcp/server.py
+++ b/pagerduty_mcp/server.py
@@ -88,7 +88,8 @@ def run(
     if not (1 <= port <= 65535):
         raise typer.BadParameter(f"Port must be between 1 and 65535, got {port}", param_hint="--port")
 
-    if transport != Transport.stdio and host != "127.0.0.1":
+    _loopback_addresses = {"127.0.0.1", "::1", "localhost"}
+    if transport != Transport.stdio and host not in _loopback_addresses:
         logging.getLogger(__name__).warning(
             "HTTP transport '%s' bound to '%s' with no built-in authentication — "
             "ensure this endpoint is protected by an authenticating proxy.",

--- a/pagerduty_mcp/server.py
+++ b/pagerduty_mcp/server.py
@@ -1,5 +1,6 @@
 import logging
 from collections.abc import Callable
+from enum import Enum
 
 import typer
 from mcp.server.fastmcp import FastMCP
@@ -8,6 +9,15 @@ from mcp.types import ToolAnnotations
 from pagerduty_mcp.tools import read_tools, write_tools
 from pagerduty_mcp.context import ContextResolver
 from pagerduty_mcp.context.application_context_strategy import ApplicationContextStrategy
+
+
+class Transport(str, Enum):
+    """MCP transport protocols supported by the server."""
+
+    stdio = "stdio"
+    sse = "sse"
+    streamable_http = "streamable-http"
+
 
 logging.basicConfig(level=logging.WARNING)
 
@@ -60,17 +70,28 @@ for _tool in write_tools:
 
 
 @app.command()
-def run(*, enable_write_tools: bool = False) -> None:
+def run(
+    *,
+    enable_write_tools: bool = False,
+    transport: Transport = Transport.stdio,
+    host: str = "127.0.0.1",
+    port: int = 8000,
+) -> None:
     """Run the MCP server with the specified configuration.
 
     Args:
         enable_write_tools: Flag to enable write tools
+        transport: Transport protocol to use (stdio, sse, or streamable-http)
+        host: Host to bind to for HTTP-based transports
+        port: Port to bind to for HTTP-based transports
     """
     ContextResolver.set_strategy(ApplicationContextStrategy())
 
     mcp = FastMCP(
         "PagerDuty MCP Server",
         instructions=MCP_SERVER_INSTRUCTIONS,
+        host=host,
+        port=port,
     )
     for tool in read_tools:
         add_read_only_tool(mcp, tool)
@@ -79,4 +100,4 @@ def run(*, enable_write_tools: bool = False) -> None:
         for tool in write_tools:
             add_write_tool(mcp, tool)
 
-    mcp.run()
+    mcp.run(transport=transport.value)

--- a/pagerduty_mcp/server.py
+++ b/pagerduty_mcp/server.py
@@ -125,6 +125,9 @@ def run(
             raise typer.BadParameter("Host must not be empty", param_hint="--host")
         if any(c.isspace() for c in normalized_host):
             raise typer.BadParameter("Host must not contain whitespace", param_hint="--host")
+        # Accept bracketed IPv6 notation (e.g. [::1]) commonly copied from URLs.
+        if normalized_host.startswith("[") and normalized_host.endswith("]"):
+            normalized_host = normalized_host[1:-1]
         is_ipv6 = False
         try:
             addr = ipaddress.ip_address(normalized_host)

--- a/pagerduty_mcp/server.py
+++ b/pagerduty_mcp/server.py
@@ -94,7 +94,7 @@ def run(
         )
 
     _loopback_addresses = {"127.0.0.1", "::1", "localhost"}
-    normalized_host = host.strip().lower()
+    normalized_host = host.strip().lower().replace("\n", "").replace("\r", "")
     if transport != Transport.stdio and normalized_host not in _loopback_addresses:
         logging.getLogger(__name__).warning(
             "HTTP transport '%s' bound to '%s' with no built-in authentication — "
@@ -108,7 +108,7 @@ def run(
     mcp = FastMCP(
         "PagerDuty MCP Server",
         instructions=MCP_SERVER_INSTRUCTIONS,
-        host=host,
+        host=normalized_host,
         port=port,
     )
     for tool in read_tools:

--- a/pagerduty_mcp/server.py
+++ b/pagerduty_mcp/server.py
@@ -61,14 +61,6 @@ def add_write_tool(mcp_instance: FastMCP, tool: Callable) -> None:
     )
 
 
-mcp = FastMCP(
-    "PagerDuty MCP Server",
-    instructions=MCP_SERVER_INSTRUCTIONS,
-)
-for _tool in read_tools:
-    add_read_only_tool(mcp, _tool)
-
-
 @app.command()
 def run(
     *,

--- a/pagerduty_mcp/server.py
+++ b/pagerduty_mcp/server.py
@@ -67,8 +67,6 @@ mcp = FastMCP(
 )
 for _tool in read_tools:
     add_read_only_tool(mcp, _tool)
-for _tool in write_tools:
-    add_write_tool(mcp, _tool)
 
 
 @app.command()
@@ -98,9 +96,11 @@ def run(
         if port != 8000:
             _ignored.append(f"port={port}")
         if _ignored:
+            verb = "have" if len(_ignored) > 1 else "has"
             logging.getLogger(__name__).warning(
-                "%s have no effect when --transport stdio is used.",
+                "%s %s no effect when --transport stdio is used.",
                 " and ".join(_ignored),
+                verb,
             )
     else:
         if not (1 <= port <= 65535):
@@ -115,6 +115,8 @@ def run(
             raise typer.BadParameter("Host must not contain control characters", param_hint="--host")
 
         normalized_host = host.strip()
+        if not normalized_host:
+            raise typer.BadParameter("Host must not be empty", param_hint="--host")
         is_ipv6 = False
         try:
             addr = ipaddress.ip_address(normalized_host)
@@ -143,7 +145,7 @@ def run(
                 enable_dns_rebinding_protection=True,
                 allowed_hosts=[
                     f"{host_header}:{port}",
-                    host_header,           # bare form — clients may omit port for standard ports
+                    host_header,           # bare form — some clients omit port from Host header
                     f"localhost:{port}",
                     "localhost",
                 ],

--- a/tests/test_schema_compliance.py
+++ b/tests/test_schema_compliance.py
@@ -9,9 +9,14 @@ class TestSchemaCompliance(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        from pagerduty_mcp.server import mcp
+        from mcp.server.fastmcp import FastMCP
+        from pagerduty_mcp.server import MCP_SERVER_INSTRUCTIONS, add_read_only_tool
+        from pagerduty_mcp.tools import read_tools
 
-        cls.tools = asyncio.run(mcp.list_tools())
+        _mcp = FastMCP("PagerDuty MCP Server", instructions=MCP_SERVER_INSTRUCTIONS)
+        for _tool in read_tools:
+            add_read_only_tool(_mcp, _tool)
+        cls.tools = asyncio.run(_mcp.list_tools())
 
     def test_total_schema_size_below_threshold(self):
         """Total tool schema JSON should be <150K chars to avoid context bloat."""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,4 +1,3 @@
-import logging
 import unittest
 import unittest.mock
 from unittest.mock import MagicMock, patch
@@ -160,13 +159,13 @@ class TestServerRun(unittest.TestCase):
         self.assertTrue(any("privileged port" in m for m in cm.output))
 
     def test_write_tools_not_registered_by_default(self):
-        result, mock_fastmcp, mock_mcp = self._invoke()
+        result, _, mock_mcp = self._invoke()
         self.assertEqual(result.exit_code, 0, result.output)
         # Only read_tools should be registered — count must equal len(read_tools)
         self.assertEqual(mock_mcp.add_tool.call_count, len(read_tools))
 
     def test_write_tools_registered_when_flag_set(self):
-        result, mock_fastmcp, mock_mcp = self._invoke(["--enable-write-tools"])
+        result, _, mock_mcp = self._invoke(["--enable-write-tools"])
         self.assertEqual(result.exit_code, 0, result.output)
         self.assertEqual(mock_mcp.add_tool.call_count, len(read_tools) + len(write_tools))
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -186,6 +186,10 @@ class TestServerRun(unittest.TestCase):
                 result, _, _ = self._invoke(["--transport", "streamable-http", "--host", bad_host])
                 self.assertNotEqual(result.exit_code, 0, f"Expected failure for host={bad_host!r}")
 
+    def test_empty_host_after_strip_fails(self):
+        result, _, _ = self._invoke(["--transport", "streamable-http", "--host", "   "])
+        self.assertNotEqual(result.exit_code, 0)
+
     def test_no_warning_for_loopback_variants(self):
         for loopback in ["127.0.0.1", "::1", "localhost", "LOCALHOST", "  127.0.0.1  ", "127.0.0.2"]:
             with self.subTest(host=loopback):
@@ -198,6 +202,18 @@ class TestServerRun(unittest.TestCase):
             result, _, _ = self._invoke(env={"MCP_HOST": "0.0.0.0"})
         self.assertEqual(result.exit_code, 0, result.output)
         self.assertTrue(any("no effect" in m for m in cm.output))
+
+    def test_stdio_warning_grammar_singular(self):
+        with self.assertLogs("pagerduty_mcp.server", level="WARNING") as cm:
+            result, _, _ = self._invoke(env={"MCP_HOST": "0.0.0.0"})
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertTrue(any(" has no effect" in m for m in cm.output))
+
+    def test_stdio_warning_grammar_plural(self):
+        with self.assertLogs("pagerduty_mcp.server", level="WARNING") as cm:
+            result, _, _ = self._invoke(env={"MCP_HOST": "0.0.0.0", "MCP_PORT": "9000"})
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertTrue(any(" have no effect" in m for m in cm.output))
 
     def test_warning_emitted_for_non_loopback_http(self):
         with self.assertLogs("pagerduty_mcp.server", level="WARNING") as cm:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -112,6 +112,31 @@ class TestServerRun(unittest.TestCase):
         result, _, _ = self._invoke(["--transport", "invalid"])
         self.assertNotEqual(result.exit_code, 0)
 
+    def test_port_zero_fails(self):
+        result, _, _ = self._invoke(["--port", "0"])
+        self.assertNotEqual(result.exit_code, 0)
+
+    def test_port_out_of_range_fails(self):
+        result, _, _ = self._invoke(["--port", "99999"])
+        self.assertNotEqual(result.exit_code, 0)
+
+    def test_no_warning_for_loopback_variants(self):
+        for loopback in ["127.0.0.1", "::1", "localhost"]:
+            with self.subTest(host=loopback), patch("pagerduty_mcp.server.logging") as mock_logging:
+                mock_logger = MagicMock()
+                mock_logging.getLogger.return_value = mock_logger
+                result, _, _ = self._invoke(["--transport", "streamable-http", "--host", loopback])
+                self.assertEqual(result.exit_code, 0, result.output)
+                mock_logger.warning.assert_not_called()
+
+    def test_warning_emitted_for_non_loopback_http(self):
+        with patch("pagerduty_mcp.server.logging") as mock_logging:
+            mock_logger = MagicMock()
+            mock_logging.getLogger.return_value = mock_logger
+            result, _, _ = self._invoke(["--transport", "streamable-http", "--host", "0.0.0.0"])
+            self.assertEqual(result.exit_code, 0, result.output)
+            mock_logger.warning.assert_called_once()
+
     def test_write_tools_not_registered_by_default(self):
         result, mock_fastmcp, mock_mcp = self._invoke()
         self.assertEqual(result.exit_code, 0, result.output)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,128 @@
+import unittest
+import unittest.mock
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from pagerduty_mcp.server import Transport, app
+from pagerduty_mcp.tools import read_tools, write_tools
+
+
+class TestTransportEnum(unittest.TestCase):
+    """Test cases for the Transport enum."""
+
+    def test_transport_values(self):
+        self.assertEqual(Transport.stdio.value, "stdio")
+        self.assertEqual(Transport.sse.value, "sse")
+        self.assertEqual(Transport.streamable_http.value, "streamable-http")
+
+    def test_transport_is_str(self):
+        self.assertIsInstance(Transport.stdio, str)
+        self.assertIsInstance(Transport.streamable_http, str)
+
+    def test_transport_default_is_stdio(self):
+        self.assertEqual(Transport.stdio, Transport("stdio"))
+
+
+class TestServerRun(unittest.TestCase):
+    """Test cases for the run() CLI command."""
+
+    def setUp(self):
+        self.runner = CliRunner()
+
+    def _invoke(self, args=None, env=None):
+        """Helper: invoke app with mocked FastMCP and ApplicationContextStrategy."""
+        args = args or []
+        with patch("pagerduty_mcp.server.FastMCP") as mock_fastmcp, \
+             patch("pagerduty_mcp.server.ApplicationContextStrategy"), \
+             patch("pagerduty_mcp.server.ContextResolver"):
+            mock_mcp = MagicMock()
+            mock_fastmcp.return_value = mock_mcp
+            result = self.runner.invoke(app, args, env=env)
+            return result, mock_fastmcp, mock_mcp
+
+    def test_default_transport_is_stdio(self):
+        result, _, mock_mcp = self._invoke()
+        self.assertEqual(result.exit_code, 0, result.output)
+        mock_mcp.run.assert_called_once_with(transport="stdio")
+
+    def test_streamable_http_transport(self):
+        result, _, mock_mcp = self._invoke(["--transport", "streamable-http"])
+        self.assertEqual(result.exit_code, 0, result.output)
+        mock_mcp.run.assert_called_once_with(transport="streamable-http")
+
+    def test_sse_transport(self):
+        result, _, mock_mcp = self._invoke(["--transport", "sse"])
+        self.assertEqual(result.exit_code, 0, result.output)
+        mock_mcp.run.assert_called_once_with(transport="sse")
+
+    def test_default_host_and_port(self):
+        result, mock_fastmcp, _ = self._invoke()
+        self.assertEqual(result.exit_code, 0, result.output)
+        mock_fastmcp.assert_called_once_with(
+            "PagerDuty MCP Server",
+            instructions=unittest.mock.ANY,
+            host="127.0.0.1",
+            port=8000,
+        )
+
+    def test_custom_host_and_port_via_cli(self):
+        result, mock_fastmcp, _ = self._invoke(["--host", "0.0.0.0", "--port", "9000"])
+        self.assertEqual(result.exit_code, 0, result.output)
+        mock_fastmcp.assert_called_once_with(
+            "PagerDuty MCP Server",
+            instructions=unittest.mock.ANY,
+            host="0.0.0.0",
+            port=9000,
+        )
+
+    def test_host_from_env_var(self):
+        result, mock_fastmcp, _ = self._invoke(env={"MCP_HOST": "0.0.0.0"})
+        self.assertEqual(result.exit_code, 0, result.output)
+        mock_fastmcp.assert_called_once_with(
+            "PagerDuty MCP Server",
+            instructions=unittest.mock.ANY,
+            host="0.0.0.0",
+            port=8000,
+        )
+
+    def test_port_from_env_var(self):
+        result, mock_fastmcp, _ = self._invoke(env={"MCP_PORT": "9000"})
+        self.assertEqual(result.exit_code, 0, result.output)
+        mock_fastmcp.assert_called_once_with(
+            "PagerDuty MCP Server",
+            instructions=unittest.mock.ANY,
+            host="127.0.0.1",
+            port=9000,
+        )
+
+    def test_cli_flag_overrides_env_var(self):
+        result, mock_fastmcp, _ = self._invoke(
+            ["--host", "192.168.1.1"], env={"MCP_HOST": "0.0.0.0"}
+        )
+        self.assertEqual(result.exit_code, 0, result.output)
+        mock_fastmcp.assert_called_once_with(
+            "PagerDuty MCP Server",
+            instructions=unittest.mock.ANY,
+            host="192.168.1.1",
+            port=8000,
+        )
+
+    def test_invalid_transport_fails(self):
+        result, _, _ = self._invoke(["--transport", "invalid"])
+        self.assertNotEqual(result.exit_code, 0)
+
+    def test_write_tools_not_registered_by_default(self):
+        result, mock_fastmcp, mock_mcp = self._invoke()
+        self.assertEqual(result.exit_code, 0, result.output)
+        # Only read_tools should be registered — count must equal len(read_tools)
+        self.assertEqual(mock_mcp.add_tool.call_count, len(read_tools))
+
+    def test_write_tools_registered_when_flag_set(self):
+        result, mock_fastmcp, mock_mcp = self._invoke(["--enable-write-tools"])
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(mock_mcp.add_tool.call_count, len(read_tools) + len(write_tools))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -85,7 +85,6 @@ class TestServerRun(unittest.TestCase):
             instructions=unittest.mock.ANY,
             host="0.0.0.0",
             port=9000,
-            transport_security=unittest.mock.ANY,
         )
 
     def test_host_from_env_var(self):
@@ -98,7 +97,6 @@ class TestServerRun(unittest.TestCase):
             instructions=unittest.mock.ANY,
             host="0.0.0.0",
             port=8000,
-            transport_security=unittest.mock.ANY,
         )
 
     def test_port_from_env_var(self):
@@ -125,7 +123,6 @@ class TestServerRun(unittest.TestCase):
             instructions=unittest.mock.ANY,
             host="192.168.1.1",
             port=8000,
-            transport_security=unittest.mock.ANY,
         )
 
     def test_dns_rebinding_protection_enabled_for_http(self):
@@ -147,15 +144,13 @@ class TestServerRun(unittest.TestCase):
         self.assertIsInstance(ts, TransportSecuritySettings)
         self.assertIn("127.0.0.1:9000", ts.allowed_hosts)
 
-    def test_dns_rebinding_wildcard_bind_has_empty_allowed_hosts(self):
-        from mcp.server.transport_security import TransportSecuritySettings
+    def test_dns_rebinding_wildcard_bind_omits_transport_security(self):
         result, mock_fastmcp, _ = self._invoke(
             ["--transport", "streamable-http", "--host", "0.0.0.0", "--port", "9000"]
         )
         self.assertEqual(result.exit_code, 0, result.output)
-        ts = mock_fastmcp.call_args.kwargs.get("transport_security")
-        self.assertIsInstance(ts, TransportSecuritySettings)
-        self.assertEqual(ts.allowed_hosts, [])
+        call_kwargs = mock_fastmcp.call_args.kwargs
+        self.assertNotIn("transport_security", call_kwargs)
 
     def test_invalid_transport_fails(self):
         result, _, _ = self._invoke(["--transport", "invalid"])
@@ -174,7 +169,7 @@ class TestServerRun(unittest.TestCase):
         self.assertEqual(result.exit_code, 0, result.output)
 
     def test_host_with_control_characters_fails(self):
-        for bad_host in ["bad\nhost", "bad\rhost", "bad\x00host"]:
+        for bad_host in ["bad\nhost", "bad\rhost", "bad\x00host", "bad\thost"]:
             with self.subTest(host=bad_host):
                 result, _, _ = self._invoke(["--transport", "streamable-http", "--host", bad_host])
                 self.assertNotEqual(result.exit_code, 0, f"Expected failure for host={bad_host!r}")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -203,6 +203,16 @@ class TestServerRun(unittest.TestCase):
         result, _, _ = self._invoke(["--transport", "streamable-http", "--host", "127.0.0.1:8000"])
         self.assertNotEqual(result.exit_code, 0)
 
+    def test_bracketed_ipv6_host_is_accepted(self):
+        result, _, _ = self._invoke(["--transport", "streamable-http", "--host", "[::1]"])
+        self.assertEqual(result.exit_code, 0, result.output)
+
+    def test_invalid_mcp_port_env_var_fails_in_all_modes(self):
+        # MCP_PORT must be a valid integer — Typer validates at CLI startup
+        # regardless of --transport, so MCP_PORT=abc always fails.
+        result, _, _ = self._invoke(env={"MCP_PORT": "abc"})
+        self.assertNotEqual(result.exit_code, 0)
+
     def test_empty_host_after_strip_fails(self):
         result, _, _ = self._invoke(["--transport", "streamable-http", "--host", "   "])
         self.assertNotEqual(result.exit_code, 0)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -194,10 +194,14 @@ class TestServerRun(unittest.TestCase):
         self.assertEqual(result.exit_code, 0, result.output)
 
     def test_host_with_control_characters_fails(self):
-        for bad_host in ["bad\nhost", "bad\rhost", "bad\x00host", "bad\thost"]:
+        for bad_host in ["bad\nhost", "bad\rhost", "bad\x00host", "bad\thost", "bad\x7fhost"]:
             with self.subTest(host=bad_host):
                 result, _, _ = self._invoke(["--transport", "streamable-http", "--host", bad_host])
                 self.assertNotEqual(result.exit_code, 0, f"Expected failure for host={bad_host!r}")
+
+    def test_host_with_embedded_port_fails(self):
+        result, _, _ = self._invoke(["--transport", "streamable-http", "--host", "127.0.0.1:8000"])
+        self.assertNotEqual(result.exit_code, 0)
 
     def test_empty_host_after_strip_fails(self):
         result, _, _ = self._invoke(["--transport", "streamable-http", "--host", "   "])

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -177,9 +177,9 @@ class TestServerRun(unittest.TestCase):
     def test_no_warning_for_loopback_variants(self):
         for loopback in ["127.0.0.1", "::1", "localhost", "LOCALHOST", "  127.0.0.1  ", "127.0.0.2"]:
             with self.subTest(host=loopback):
-                result, _, _ = self._invoke(["--transport", "streamable-http", "--host", loopback])
+                with self.assertNoLogs("pagerduty_mcp.server", level="WARNING"):
+                    result, _, _ = self._invoke(["--transport", "streamable-http", "--host", loopback])
                 self.assertEqual(result.exit_code, 0, result.output)
-                self.assertNotIn("no built-in authentication", result.output)
 
     def test_warning_emitted_when_http_env_vars_set_in_stdio_mode(self):
         with self.assertLogs("pagerduty_mcp.server", level="WARNING") as cm:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -190,6 +190,10 @@ class TestServerRun(unittest.TestCase):
         result, _, _ = self._invoke(["--transport", "streamable-http", "--host", "   "])
         self.assertNotEqual(result.exit_code, 0)
 
+    def test_host_with_embedded_space_fails(self):
+        result, _, _ = self._invoke(["--transport", "streamable-http", "--host", "bad host"])
+        self.assertNotEqual(result.exit_code, 0)
+
     def test_no_warning_for_loopback_variants(self):
         for loopback in ["127.0.0.1", "::1", "localhost", "LOCALHOST", "  127.0.0.1  ", "127.0.0.2"]:
             with self.subTest(host=loopback):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -143,6 +143,18 @@ class TestServerRun(unittest.TestCase):
         ts = mock_fastmcp.call_args.kwargs.get("transport_security")
         self.assertIsInstance(ts, TransportSecuritySettings)
         self.assertIn("127.0.0.1:9000", ts.allowed_hosts)
+        self.assertIn("127.0.0.1", ts.allowed_hosts)  # bare form for standard-port clients
+
+    def test_dns_rebinding_ipv6_loopback_uses_brackets(self):
+        from mcp.server.transport_security import TransportSecuritySettings
+        result, mock_fastmcp, _ = self._invoke(
+            ["--transport", "streamable-http", "--host", "::1", "--port", "9000"]
+        )
+        self.assertEqual(result.exit_code, 0, result.output)
+        ts = mock_fastmcp.call_args.kwargs.get("transport_security")
+        self.assertIsInstance(ts, TransportSecuritySettings)
+        self.assertIn("[::1]:9000", ts.allowed_hosts)   # RFC 3986 bracket form
+        self.assertIn("[::1]", ts.allowed_hosts)         # bare bracket form
 
     def test_dns_rebinding_wildcard_bind_omits_transport_security(self):
         result, mock_fastmcp, _ = self._invoke(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -137,7 +137,17 @@ class TestServerRun(unittest.TestCase):
         self.assertIsInstance(ts, TransportSecuritySettings)
         self.assertTrue(ts.enable_dns_rebinding_protection)
 
-    def test_dns_rebinding_allowed_hosts_includes_bind_address(self):
+    def test_dns_rebinding_loopback_restricts_allowed_hosts(self):
+        from mcp.server.transport_security import TransportSecuritySettings
+        result, mock_fastmcp, _ = self._invoke(
+            ["--transport", "streamable-http", "--host", "127.0.0.1", "--port", "9000"]
+        )
+        self.assertEqual(result.exit_code, 0, result.output)
+        ts = mock_fastmcp.call_args.kwargs.get("transport_security")
+        self.assertIsInstance(ts, TransportSecuritySettings)
+        self.assertIn("127.0.0.1:9000", ts.allowed_hosts)
+
+    def test_dns_rebinding_wildcard_bind_has_empty_allowed_hosts(self):
         from mcp.server.transport_security import TransportSecuritySettings
         result, mock_fastmcp, _ = self._invoke(
             ["--transport", "streamable-http", "--host", "0.0.0.0", "--port", "9000"]
@@ -145,7 +155,7 @@ class TestServerRun(unittest.TestCase):
         self.assertEqual(result.exit_code, 0, result.output)
         ts = mock_fastmcp.call_args.kwargs.get("transport_security")
         self.assertIsInstance(ts, TransportSecuritySettings)
-        self.assertIn("0.0.0.0:9000", ts.allowed_hosts)
+        self.assertEqual(ts.allowed_hosts, [])
 
     def test_invalid_transport_fails(self):
         result, _, _ = self._invoke(["--transport", "invalid"])

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -64,6 +64,7 @@ class TestServerRun(unittest.TestCase):
             instructions=unittest.mock.ANY,
             host="127.0.0.1",
             port=8000,
+            transport_security=unittest.mock.ANY,
         )
 
     def test_stdio_does_not_pass_host_or_port_to_fastmcp(self):
@@ -84,6 +85,7 @@ class TestServerRun(unittest.TestCase):
             instructions=unittest.mock.ANY,
             host="0.0.0.0",
             port=9000,
+            transport_security=unittest.mock.ANY,
         )
 
     def test_host_from_env_var(self):
@@ -96,6 +98,7 @@ class TestServerRun(unittest.TestCase):
             instructions=unittest.mock.ANY,
             host="0.0.0.0",
             port=8000,
+            transport_security=unittest.mock.ANY,
         )
 
     def test_port_from_env_var(self):
@@ -108,6 +111,7 @@ class TestServerRun(unittest.TestCase):
             instructions=unittest.mock.ANY,
             host="127.0.0.1",
             port=9000,
+            transport_security=unittest.mock.ANY,
         )
 
     def test_cli_flag_overrides_env_var(self):
@@ -121,7 +125,27 @@ class TestServerRun(unittest.TestCase):
             instructions=unittest.mock.ANY,
             host="192.168.1.1",
             port=8000,
+            transport_security=unittest.mock.ANY,
         )
+
+    def test_dns_rebinding_protection_enabled_for_http(self):
+        from mcp.server.transport_security import TransportSecuritySettings
+        result, mock_fastmcp, _ = self._invoke(["--transport", "streamable-http"])
+        self.assertEqual(result.exit_code, 0, result.output)
+        call_kwargs = mock_fastmcp.call_args.kwargs
+        ts = call_kwargs.get("transport_security")
+        self.assertIsInstance(ts, TransportSecuritySettings)
+        self.assertTrue(ts.enable_dns_rebinding_protection)
+
+    def test_dns_rebinding_allowed_hosts_includes_bind_address(self):
+        from mcp.server.transport_security import TransportSecuritySettings
+        result, mock_fastmcp, _ = self._invoke(
+            ["--transport", "streamable-http", "--host", "0.0.0.0", "--port", "9000"]
+        )
+        self.assertEqual(result.exit_code, 0, result.output)
+        ts = mock_fastmcp.call_args.kwargs.get("transport_security")
+        self.assertIsInstance(ts, TransportSecuritySettings)
+        self.assertIn("0.0.0.0:9000", ts.allowed_hosts)
 
     def test_invalid_transport_fails(self):
         result, _, _ = self._invoke(["--transport", "invalid"])
@@ -139,12 +163,24 @@ class TestServerRun(unittest.TestCase):
         result, _, _ = self._invoke(["--port", "99999"])
         self.assertEqual(result.exit_code, 0, result.output)
 
+    def test_host_with_control_characters_fails(self):
+        for bad_host in ["bad\nhost", "bad\rhost", "bad\x00host"]:
+            with self.subTest(host=bad_host):
+                result, _, _ = self._invoke(["--transport", "streamable-http", "--host", bad_host])
+                self.assertNotEqual(result.exit_code, 0, f"Expected failure for host={bad_host!r}")
+
     def test_no_warning_for_loopback_variants(self):
-        for loopback in ["127.0.0.1", "::1", "localhost", "LOCALHOST", "  127.0.0.1  "]:
+        for loopback in ["127.0.0.1", "::1", "localhost", "LOCALHOST", "  127.0.0.1  ", "127.0.0.2"]:
             with self.subTest(host=loopback):
                 result, _, _ = self._invoke(["--transport", "streamable-http", "--host", loopback])
                 self.assertEqual(result.exit_code, 0, result.output)
                 self.assertNotIn("no built-in authentication", result.output)
+
+    def test_warning_emitted_when_http_env_vars_set_in_stdio_mode(self):
+        with self.assertLogs("pagerduty_mcp.server", level="WARNING") as cm:
+            result, _, _ = self._invoke(env={"MCP_HOST": "0.0.0.0"})
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertTrue(any("no effect" in m for m in cm.output))
 
     def test_warning_emitted_for_non_loopback_http(self):
         with self.assertLogs("pagerduty_mcp.server", level="WARNING") as cm:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -145,6 +145,19 @@ class TestServerRun(unittest.TestCase):
         self.assertIn("127.0.0.1:9000", ts.allowed_hosts)
         self.assertIn("127.0.0.1", ts.allowed_hosts)  # bare form for standard-port clients
 
+    def test_dns_rebinding_localhost_hostname_includes_numeric_loopback(self):
+        from mcp.server.transport_security import TransportSecuritySettings
+        result, mock_fastmcp, _ = self._invoke(
+            ["--transport", "streamable-http", "--host", "localhost", "--port", "9000"]
+        )
+        self.assertEqual(result.exit_code, 0, result.output)
+        ts = mock_fastmcp.call_args.kwargs.get("transport_security")
+        self.assertIsInstance(ts, TransportSecuritySettings)
+        self.assertIn("127.0.0.1:9000", ts.allowed_hosts)
+        self.assertIn("127.0.0.1", ts.allowed_hosts)
+        self.assertIn("[::1]:9000", ts.allowed_hosts)
+        self.assertIn("[::1]", ts.allowed_hosts)
+
     def test_dns_rebinding_ipv6_loopback_uses_brackets(self):
         from mcp.server.transport_security import TransportSecuritySettings
         result, mock_fastmcp, _ = self._invoke(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,3 +1,4 @@
+import logging
 import unittest
 import unittest.mock
 from unittest.mock import MagicMock, patch
@@ -121,21 +122,24 @@ class TestServerRun(unittest.TestCase):
         self.assertNotEqual(result.exit_code, 0)
 
     def test_no_warning_for_loopback_variants(self):
-        for loopback in ["127.0.0.1", "::1", "localhost"]:
-            with self.subTest(host=loopback), patch("pagerduty_mcp.server.logging") as mock_logging:
-                mock_logger = MagicMock()
-                mock_logging.getLogger.return_value = mock_logger
-                result, _, _ = self._invoke(["--transport", "streamable-http", "--host", loopback])
-                self.assertEqual(result.exit_code, 0, result.output)
-                mock_logger.warning.assert_not_called()
+        for loopback in ["127.0.0.1", "::1", "localhost", "LOCALHOST", "  127.0.0.1  "]:
+            with self.subTest(host=loopback):
+                with self.assertLogs("pagerduty_mcp.server", level="WARNING") as cm:
+                    logging.getLogger("pagerduty_mcp.server").warning("_sentinel_")
+                warning_msgs = [m for m in cm.output if "_sentinel_" not in m]
+                self.assertEqual(warning_msgs, [], f"Unexpected warning for loopback host {loopback!r}")
 
     def test_warning_emitted_for_non_loopback_http(self):
-        with patch("pagerduty_mcp.server.logging") as mock_logging:
-            mock_logger = MagicMock()
-            mock_logging.getLogger.return_value = mock_logger
+        with self.assertLogs("pagerduty_mcp.server", level="WARNING") as cm:
             result, _, _ = self._invoke(["--transport", "streamable-http", "--host", "0.0.0.0"])
-            self.assertEqual(result.exit_code, 0, result.output)
-            mock_logger.warning.assert_called_once()
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertTrue(any("no built-in authentication" in m for m in cm.output))
+
+    def test_privileged_port_warning(self):
+        with self.assertLogs("pagerduty_mcp.server", level="WARNING") as cm:
+            result, _, _ = self._invoke(["--port", "80"])
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertTrue(any("privileged port" in m for m in cm.output))
 
     def test_write_tools_not_registered_by_default(self):
         result, mock_fastmcp, mock_mcp = self._invoke()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -57,8 +57,8 @@ class TestServerRun(unittest.TestCase):
         self.assertEqual(result.exit_code, 0, result.output)
         mock_mcp.run.assert_called_once_with(transport="sse")
 
-    def test_default_host_and_port(self):
-        result, mock_fastmcp, _ = self._invoke()
+    def test_default_host_and_port_for_http_transport(self):
+        result, mock_fastmcp, _ = self._invoke(["--transport", "streamable-http"])
         self.assertEqual(result.exit_code, 0, result.output)
         mock_fastmcp.assert_called_once_with(
             "PagerDuty MCP Server",
@@ -67,8 +67,18 @@ class TestServerRun(unittest.TestCase):
             port=8000,
         )
 
+    def test_stdio_does_not_pass_host_or_port_to_fastmcp(self):
+        result, mock_fastmcp, _ = self._invoke()
+        self.assertEqual(result.exit_code, 0, result.output)
+        mock_fastmcp.assert_called_once_with(
+            "PagerDuty MCP Server",
+            instructions=unittest.mock.ANY,
+        )
+
     def test_custom_host_and_port_via_cli(self):
-        result, mock_fastmcp, _ = self._invoke(["--host", "0.0.0.0", "--port", "9000"])
+        result, mock_fastmcp, _ = self._invoke(
+            ["--transport", "streamable-http", "--host", "0.0.0.0", "--port", "9000"]
+        )
         self.assertEqual(result.exit_code, 0, result.output)
         mock_fastmcp.assert_called_once_with(
             "PagerDuty MCP Server",
@@ -78,7 +88,9 @@ class TestServerRun(unittest.TestCase):
         )
 
     def test_host_from_env_var(self):
-        result, mock_fastmcp, _ = self._invoke(env={"MCP_HOST": "0.0.0.0"})
+        result, mock_fastmcp, _ = self._invoke(
+            ["--transport", "streamable-http"], env={"MCP_HOST": "0.0.0.0"}
+        )
         self.assertEqual(result.exit_code, 0, result.output)
         mock_fastmcp.assert_called_once_with(
             "PagerDuty MCP Server",
@@ -88,7 +100,9 @@ class TestServerRun(unittest.TestCase):
         )
 
     def test_port_from_env_var(self):
-        result, mock_fastmcp, _ = self._invoke(env={"MCP_PORT": "9000"})
+        result, mock_fastmcp, _ = self._invoke(
+            ["--transport", "streamable-http"], env={"MCP_PORT": "9000"}
+        )
         self.assertEqual(result.exit_code, 0, result.output)
         mock_fastmcp.assert_called_once_with(
             "PagerDuty MCP Server",
@@ -99,7 +113,8 @@ class TestServerRun(unittest.TestCase):
 
     def test_cli_flag_overrides_env_var(self):
         result, mock_fastmcp, _ = self._invoke(
-            ["--host", "192.168.1.1"], env={"MCP_HOST": "0.0.0.0"}
+            ["--transport", "streamable-http", "--host", "192.168.1.1"],
+            env={"MCP_HOST": "0.0.0.0"},
         )
         self.assertEqual(result.exit_code, 0, result.output)
         mock_fastmcp.assert_called_once_with(
@@ -113,21 +128,24 @@ class TestServerRun(unittest.TestCase):
         result, _, _ = self._invoke(["--transport", "invalid"])
         self.assertNotEqual(result.exit_code, 0)
 
-    def test_port_zero_fails(self):
-        result, _, _ = self._invoke(["--port", "0"])
+    def test_port_zero_fails_for_http_transport(self):
+        result, _, _ = self._invoke(["--transport", "streamable-http", "--port", "0"])
         self.assertNotEqual(result.exit_code, 0)
 
-    def test_port_out_of_range_fails(self):
-        result, _, _ = self._invoke(["--port", "99999"])
+    def test_port_out_of_range_fails_for_http_transport(self):
+        result, _, _ = self._invoke(["--transport", "streamable-http", "--port", "99999"])
         self.assertNotEqual(result.exit_code, 0)
+
+    def test_port_out_of_range_ignored_for_stdio(self):
+        result, _, _ = self._invoke(["--port", "99999"])
+        self.assertEqual(result.exit_code, 0, result.output)
 
     def test_no_warning_for_loopback_variants(self):
         for loopback in ["127.0.0.1", "::1", "localhost", "LOCALHOST", "  127.0.0.1  "]:
             with self.subTest(host=loopback):
-                with self.assertLogs("pagerduty_mcp.server", level="WARNING") as cm:
-                    logging.getLogger("pagerduty_mcp.server").warning("_sentinel_")
-                warning_msgs = [m for m in cm.output if "_sentinel_" not in m]
-                self.assertEqual(warning_msgs, [], f"Unexpected warning for loopback host {loopback!r}")
+                result, _, _ = self._invoke(["--transport", "streamable-http", "--host", loopback])
+                self.assertEqual(result.exit_code, 0, result.output)
+                self.assertNotIn("no built-in authentication", result.output)
 
     def test_warning_emitted_for_non_loopback_http(self):
         with self.assertLogs("pagerduty_mcp.server", level="WARNING") as cm:
@@ -137,7 +155,7 @@ class TestServerRun(unittest.TestCase):
 
     def test_privileged_port_warning(self):
         with self.assertLogs("pagerduty_mcp.server", level="WARNING") as cm:
-            result, _, _ = self._invoke(["--port", "80"])
+            result, _, _ = self._invoke(["--transport", "streamable-http", "--port", "80"])
         self.assertEqual(result.exit_code, 0, result.output)
         self.assertTrue(any("privileged port" in m for m in cm.output))
 

--- a/uv.lock
+++ b/uv.lock
@@ -94,7 +94,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [

--- a/website/docs/configuration/environment-variables.md
+++ b/website/docs/configuration/environment-variables.md
@@ -17,6 +17,8 @@ The PagerDuty MCP Server uses the following environment variables.
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `PAGERDUTY_API_HOST` | `https://api.pagerduty.com` | PagerDuty API endpoint. Set to `https://api.eu.pagerduty.com` for EU accounts. |
+| `MCP_HOST` | `127.0.0.1` | Host to bind to for HTTP-based transports (`streamable-http`, `sse`). Set to `0.0.0.0` to listen on all interfaces. |
+| `MCP_PORT` | `8000` | Port to bind to for HTTP-based transports. |
 
 ## Setting Variables
 

--- a/website/docs/configuration/environment-variables.md
+++ b/website/docs/configuration/environment-variables.md
@@ -17,7 +17,7 @@ The PagerDuty MCP Server uses the following environment variables.
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `PAGERDUTY_API_HOST` | `https://api.pagerduty.com` | PagerDuty API endpoint. Set to `https://api.eu.pagerduty.com` for EU accounts. |
-| `MCP_HOST` | `127.0.0.1` | Host to bind to for HTTP-based transports (`streamable-http`, `sse`). Set to `0.0.0.0` to listen on all interfaces. |
+| `MCP_HOST` | `127.0.0.1` | Host to bind to for HTTP-based transports (`streamable-http`, `sse`). Set to `0.0.0.0` to listen on all interfaces. ⚠️ HTTP transports have no built-in auth — only expose beyond loopback behind an authenticating proxy or on a trusted network. |
 | `MCP_PORT` | `8000` | Port to bind to for HTTP-based transports. |
 
 ## Setting Variables

--- a/website/docs/configuration/environment-variables.md
+++ b/website/docs/configuration/environment-variables.md
@@ -17,8 +17,8 @@ The PagerDuty MCP Server uses the following environment variables.
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `PAGERDUTY_API_HOST` | `https://api.pagerduty.com` | PagerDuty API endpoint. Set to `https://api.eu.pagerduty.com` for EU accounts. |
-| `MCP_HOST` | `127.0.0.1` | Host to bind to for HTTP-based transports (`streamable-http`, `sse`). Set to `0.0.0.0` to listen on all interfaces. ⚠️ HTTP transports have no built-in auth — only expose beyond loopback behind an authenticating proxy or on a trusted network. |
-| `MCP_PORT` | `8000` | Port to bind to for HTTP-based transports. |
+| `MCP_HOST` | `127.0.0.1` | Host to bind to for HTTP-based transports (`streamable-http`, `sse`). Set to `0.0.0.0` to listen on all interfaces. ⚠️ HTTP transports have no built-in auth — only expose beyond loopback behind an authenticating proxy or on a trusted network. No effect when `--transport stdio` (default). |
+| `MCP_PORT` | `8000` | Port to bind to for HTTP-based transports (`streamable-http`, `sse`). No effect when `--transport stdio` (default). |
 
 ## Setting Variables
 

--- a/website/docs/configuration/environment-variables.md
+++ b/website/docs/configuration/environment-variables.md
@@ -18,7 +18,7 @@ The PagerDuty MCP Server uses the following environment variables.
 |----------|---------|-------------|
 | `PAGERDUTY_API_HOST` | `https://api.pagerduty.com` | PagerDuty API endpoint. Set to `https://api.eu.pagerduty.com` for EU accounts. |
 | `MCP_HOST` | `127.0.0.1` | Host to bind to for HTTP-based transports (`streamable-http`, `sse`). Set to `0.0.0.0` to listen on all interfaces. ⚠️ HTTP transports have no built-in auth — only expose beyond loopback behind an authenticating proxy or on a trusted network. No effect when `--transport stdio` (default). |
-| `MCP_PORT` | `8000` | Port to bind to for HTTP-based transports (`streamable-http`, `sse`). Must be a valid integer (1–65535) — the CLI validates the type at startup even in `stdio` mode, though the value is not used. No effect at runtime when `--transport stdio` (default). |
+| `MCP_PORT` | `8000` | Port to bind to for HTTP-based transports (`streamable-http`, `sse`). Must be a valid integer — the CLI parses the type at startup even in `stdio` mode. Range validation (1–65535) only applies when using an HTTP transport. No effect at runtime when `--transport stdio` (default). |
 
 ## Setting Variables
 

--- a/website/docs/configuration/environment-variables.md
+++ b/website/docs/configuration/environment-variables.md
@@ -18,7 +18,7 @@ The PagerDuty MCP Server uses the following environment variables.
 |----------|---------|-------------|
 | `PAGERDUTY_API_HOST` | `https://api.pagerduty.com` | PagerDuty API endpoint. Set to `https://api.eu.pagerduty.com` for EU accounts. |
 | `MCP_HOST` | `127.0.0.1` | Host to bind to for HTTP-based transports (`streamable-http`, `sse`). Set to `0.0.0.0` to listen on all interfaces. ⚠️ HTTP transports have no built-in auth — only expose beyond loopback behind an authenticating proxy or on a trusted network. No effect when `--transport stdio` (default). |
-| `MCP_PORT` | `8000` | Port to bind to for HTTP-based transports (`streamable-http`, `sse`). No effect when `--transport stdio` (default). |
+| `MCP_PORT` | `8000` | Port to bind to for HTTP-based transports (`streamable-http`, `sse`). Must be a valid integer (1–65535) — the CLI validates the type at startup even in `stdio` mode, though the value is not used. No effect at runtime when `--transport stdio` (default). |
 
 ## Setting Variables
 

--- a/website/docs/configuration/environment-variables.md
+++ b/website/docs/configuration/environment-variables.md
@@ -17,7 +17,7 @@ The PagerDuty MCP Server uses the following environment variables.
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `PAGERDUTY_API_HOST` | `https://api.pagerduty.com` | PagerDuty API endpoint. Set to `https://api.eu.pagerduty.com` for EU accounts. |
-| `MCP_HOST` | `127.0.0.1` | Host to bind to for HTTP-based transports (`streamable-http`, `sse`). Set to `0.0.0.0` to listen on all interfaces. ⚠️ HTTP transports have no built-in auth — only expose beyond loopback behind an authenticating proxy or on a trusted network. No effect when `--transport stdio` (default). |
+| `MCP_HOST` | `127.0.0.1` | Host to bind to for HTTP-based transports (`streamable-http`, `sse`). Set to `0.0.0.0` to listen on all interfaces. ⚠️ HTTP transports have no built-in auth — only expose beyond loopback behind an authenticating proxy or on a trusted network. Not used for binding when `--transport stdio` (default), but a warning is emitted if set to a non-default value. |
 | `MCP_PORT` | `8000` | Port to bind to for HTTP-based transports (`streamable-http`, `sse`). Must be a valid integer — the CLI parses the type at startup even in `stdio` mode. Range validation (1–65535) only applies when using an HTTP transport. No effect at runtime when `--transport stdio` (default). |
 
 ## Setting Variables


### PR DESCRIPTION
## Summary

- Adds `--transport` CLI flag supporting `stdio` (default), `sse`, and `streamable-http`
- Adds `--host` and `--port` CLI flags for HTTP-based transports
- `MCP_HOST` and `MCP_PORT` environment variables supported via `typer.Option(envvar=...)` for Docker/Kubernetes deployments
- Updates README with transport modes documentation and env var examples
- Updates `website/docs/configuration/environment-variables.md` with `MCP_HOST` and `MCP_PORT`

Closes #25

> This PR incorporates the work from #146 (by @pipo02mix / Giant Swarm) with an additional fix to make `host` and `port` configurable via environment variables. Closing #146 in favor of this one.

## Test plan

- [ ] `uv run pagerduty-mcp --help` — verify `--host`, `--port` show `[env var: MCP_HOST]` / `[env var: MCP_PORT]`
- [ ] `uv run pagerduty-mcp --transport streamable-http` — server binds to `127.0.0.1:8000` by default
- [ ] `MCP_HOST=0.0.0.0 MCP_PORT=9000 uv run pagerduty-mcp --transport streamable-http` — uses env vars
- [ ] `uv run pagerduty-mcp` — stdio mode unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)