### PR TITLE
chore: bump version to 1.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pagerduty-mcp"
-version = "1.0.0"
+version = "1.1.0"
 description = "PagerDuty's official local MCP (Model Context Protocol) server which provides tools to interact with your PagerDuty account directly from your MCP-enabled client."
 readme = "README.md"
 requires-python = "~=3.12.0"

--- a/uv.lock
+++ b/uv.lock
@@ -94,7 +94,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+    { name = "pycparser" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -596,7 +596,7 @@ wheels = [
 
 [[package]]
 name = "pagerduty-mcp"
-version = "1.0.0"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },


### PR DESCRIPTION
## Summary

Bumps the package version from `1.0.0` → `1.1.0` (minor bump).

This release includes the v3 schedules tools and the `schedule_v3_reference` escalation policy fix from #124 (FDE-359):
- `list_schedules_v3`, `get_schedule_v3`, `create_schedule_v3`, `update_schedule_v3`
- Fix Pydantic validation error in `get_escalation_policy` for rules referencing a v3 schedule

Since #124 introduced new backward-compatible functionality (`feat`), this is a minor version bump per semver.

## Changes
- `pyproject.toml`: `version = "1.1.0"`
- `uv.lock`: regenerated to match

🤖 Generated with [Claude Code](https://claude.com/claude-code)