### PR TITLE
chore: bump version to 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.2.0] - 2026-07-13
+
+### Added
+
+- `create_escalation_policy` and `update_escalation_policy` tools for managing escalation policies (#155)
+- HTTP, SSE, and streamable-http transport support via `MCP_TRANSPORT`, `MCP_HOST`, and `MCP_PORT` environment variables (#159)
+
 ## [1.0.0]
 
 ### Changed — ⚠️ Breaking Change

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pagerduty-mcp"
-version = "1.1.0"
+version = "1.2.0"
 description = "PagerDuty's official local MCP (Model Context Protocol) server which provides tools to interact with your PagerDuty account directly from your MCP-enabled client."
 readme = "README.md"
 requires-python = "~=3.12.0"

--- a/uv.lock
+++ b/uv.lock
@@ -596,7 +596,7 @@ wheels = [
 
 [[package]]
 name = "pagerduty-mcp"
-version = "1.1.0"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },


### PR DESCRIPTION
## Summary

- Bumps package version from `1.1.0` to `1.2.0`
- Adds CHANGELOG entry for 1.2.0 covering escalation policy tools (#155) and HTTP/SSE/streamable-http transport (#159)

## Test plan

- [x] All 472 unit tests pass (`uv run pytest tests/`)
- [ ] After merge: trigger `python-publish.yml` (Production) via GitHub Actions
- [ ] After merge: trigger `publish-mcp-registry.yml` via GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)