### PR TITLE
feat: add service_ids filter to list_incidents

### DIFF
--- a/pagerduty_mcp/tools/incidents.py
+++ b/pagerduty_mcp/tools/incidents.py
@@ -31,6 +31,7 @@ def list_incidents(
     until: datetime | None = None,
     urgencies: list[str] | None = None,
     priorities: list[str] | None = None,
+    service_ids: list[str] | None = None,
     limit: int | None = None,
 ) -> ListResponseModel[Incident]:
     """List incidents with optional filtering.
@@ -42,6 +43,7 @@ def list_incidents(
         until: Filter incidents created before this datetime
         urgencies: Filter by urgency (high, low)
         priorities: Filter by priority IDs (use list_priorities to resolve names to IDs)
+        service_ids: Filter to incidents on these service IDs
         limit: Max results to return (default 1000)
 
     Returns:
@@ -60,6 +62,8 @@ def list_incidents(
         # The List Incidents endpoint filters on priority via priority_ids[]; priorities[] is
         # silently ignored by the API, so the filter must use priority_ids[] to take effect.
         params["priority_ids[]"] = priorities
+    if service_ids:
+        params["service_ids[]"] = service_ids
 
     if request_scope in ["assigned", "teams"]:
         user_data = ContextResolver.get_user()

--- a/tests/test_incidents.py
+++ b/tests/test_incidents.py
@@ -280,6 +280,17 @@ class TestIncidentTools(unittest.TestCase):
         self.assertNotIn("priorities[]", params)
 
     @patch("pagerduty_mcp.tools.incidents.paginate")
+    def test_list_incidents_service_ids_filter(self, mock_paginate):
+        """Service filter must be sent as service_ids[]."""
+        mock_paginate.return_value = [self.sample_incident_data]
+
+        _ = list_incidents(service_ids=["PSERVICE1", "PSERVICE2"])
+
+        params = mock_paginate.call_args[1]["params"]
+        self.assertIn("service_ids[]", params)
+        self.assertEqual(params["service_ids[]"], ["PSERVICE1", "PSERVICE2"])
+
+    @patch("pagerduty_mcp.tools.incidents.paginate")
     def test_list_incidents_with_date_range(self, mock_paginate):
         """Test listing incidents with since/until date range."""
         mock_paginate.return_value = [self.sample_incident_data]


### PR DESCRIPTION
### Description

Adds an optional `service_ids` parameter to `list_incidents`, passed through to the REST endpoint as `service_ids[]`. The List Incidents API already supports this filter but MCP doesn't expose it.

Motivation: a common agent triage pattern is "has this service seen similar incidents recently?" (recurrence/flap analysis). Without a service filter, the model must pull incidents across the entire account (default limit 1000) and filter in-context.

Implementation mirrors the existing `priorities` filter passthrough. New unit test follows the pattern of `test_list_incidents_priorities_filter`.

### Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only

### Checklist

- [x] I have performed a self-review of this change
- [x] Changes have been tested (`pytest tests/` — 473 passed)
- [x] Changes are documented (docstring)
- [x] Changes generate *no new warnings*
- [x] PR title follows conventional commit semantics

